### PR TITLE
Add testing block to clowdapp spec

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -18,6 +18,8 @@ objects:
         service: provisioning
     spec:
       envName: ${ENV_NAME}
+      testing: 
+        iqePlugin: hms-provisioning
       deployments:
         - name: service
           minReplicas: ${{MIN_REPLICAS}}


### PR DESCRIPTION
This is used by the bonfire iqe-cji smoke testing process.

Context: 
https://consoledot.pages.redhat.com/docs/dev/getting-started/ephemeral/smoke.html#_clowdapp_settings