### PR TITLE
Enforce goimports to prevent import ordering conflicts

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -5,8 +5,8 @@ on:
       - main
   pull_request:
 jobs:
-  gofmt:
-    name: go fmt
+  formatting:
+    name: go fmt and goimports
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -14,26 +14,19 @@ jobs:
         with:
           go-version: "1.16"
       - uses: Jerome1337/gofmt-action@v1.0.4
+      - uses: Jerome1337/goimports-action@v1.0.2
 
-  govet:
-    name: go vet
+  linting:
+    name: go vet and golangci-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: "1.16"
-      - run: |
+      - name: vet
+        run: |
           go vet ./...
-
-  golangci:
-    name: golangci-lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.16"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -41,12 +34,12 @@ jobs:
           only-new-issues: true
           skip-go-installation: true
 
-  gotest:
+  testing:
     name: go test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.16"
       - run: |

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,17 @@ run:
 
 .PHONY: install-tools
 install-tools:
+	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
 
+.PHONY: fmt
+fmt:
+	go fmt ./...
+	goimports -w .
+
 .PHONY: lint
 lint:
-	go fmt ./...
 	go vet ./...
 	golangci-lint run
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ dnf install postgresql-server postgresql-contrib
 make run
 ```
 
-## Code lint
+## Code style
 
-We run `go fmt`, `go vet` and `golangci-lint` lint suite via GitHub Actions. To run them locally do:
+We run `go fmt`, `goimports`, `go vet` and `golangci-lint` lint suite via GitHub Actions. To run them locally do:
 
 ```
 make install-tools
-make lint
+make fmt lint
 ```
+
+Make sure to set your editor to use [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) formatting style of code.
 
 ## Migrations
 

--- a/internal/clients/ec2/ec2_client.go
+++ b/internal/clients/ec2/ec2_client.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"context"
 	"fmt"
+
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/models"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,10 +3,11 @@ package config
 import (
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/spf13/viper"

--- a/internal/ctxval/ctx_getters.go
+++ b/internal/ctxval/ctx_getters.go
@@ -2,6 +2,7 @@ package ctxval
 
 import (
 	"context"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"context"
 	"database/sql"
+
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/jmoiron/sqlx"
 )

--- a/internal/dao/dao_transaction.go
+++ b/internal/dao/dao_transaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/jmoiron/sqlx"
 )

--- a/internal/dao/sqlx/account_dao.go
+++ b/internal/dao/sqlx/account_dao.go
@@ -2,6 +2,7 @@ package sqlx
 
 import (
 	"context"
+
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/jmoiron/sqlx"

--- a/internal/dao/sqlx/pubkey_dao.go
+++ b/internal/dao/sqlx/pubkey_dao.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/jmoiron/sqlx"

--- a/internal/dao/sqlx/pubkey_resource_dao.go
+++ b/internal/dao/sqlx/pubkey_resource_dao.go
@@ -2,6 +2,7 @@ package sqlx
 
 import (
 	"context"
+
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/jmoiron/sqlx"

--- a/internal/dao/sqlx/sqlx_errors.go
+++ b/internal/dao/sqlx/sqlx_errors.go
@@ -3,6 +3,7 @@ package sqlx
 import (
 	"context"
 	"fmt"
+
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 )

--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"fmt"
+	"net/url"
+
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/log/zerologadapter"
@@ -9,7 +11,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"net/url"
 )
 
 var (

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -3,15 +3,16 @@ package db
 import (
 	"embed"
 	"fmt"
-	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"io/ioutil"
 	stdlog "log"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/pgx"

--- a/internal/logging/zerolog.go
+++ b/internal/logging/zerolog.go
@@ -2,10 +2,11 @@ package logging
 
 import (
 	"fmt"
-	"github.com/RHEnVision/provisioning-backend/internal/clients/cloudwatchlogs"
-	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"os"
 	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients/cloudwatchlogs"
+	"github.com/RHEnVision/provisioning-backend/internal/config"
 
 	cww "github.com/lzap/cloudwatchwriter2"
 	"github.com/rs/zerolog"

--- a/internal/middleware/duration_metric.go
+++ b/internal/middleware/duration_metric.go
@@ -1,10 +1,11 @@
 package middleware
 
 import (
-	"github.com/RHEnVision/provisioning-backend/internal/metrics"
-	"github.com/prometheus/client_golang/prometheus"
 	"net/http"
 	"strconv"
+
+	"github.com/RHEnVision/provisioning-backend/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type responseWriter struct {

--- a/internal/middleware/find_resource.go
+++ b/internal/middleware/find_resource.go
@@ -2,8 +2,9 @@ package middleware
 
 import (
 	"context"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 )
 
 func FindResourceCtx(next http.Handler) http.Handler {

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -3,12 +3,13 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"net/http"
 	"runtime/debug"
 	"strconv"
 	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 
 	"github.com/go-chi/chi/middleware"
 	"github.com/rs/zerolog"

--- a/internal/middleware/request_id.go
+++ b/internal/middleware/request_id.go
@@ -2,8 +2,9 @@ package middleware
 
 import (
 	"context"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 
 	"github.com/rs/xid"
 )

--- a/internal/middleware/request_num.go
+++ b/internal/middleware/request_num.go
@@ -2,9 +2,10 @@ package middleware
 
 import (
 	"context"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"net/http"
 	"sync/atomic"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 )
 
 var reqNum uint64

--- a/internal/payloads/account_payload.go
+++ b/internal/payloads/account_payload.go
@@ -1,8 +1,9 @@
 package payloads
 
 import (
-	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/models"
 
 	"github.com/go-chi/render"
 )

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -3,8 +3,9 @@ package payloads
 import (
 	"context"
 	"fmt"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 
 	"github.com/go-chi/render"
 )

--- a/internal/payloads/pubkey_payload.go
+++ b/internal/payloads/pubkey_payload.go
@@ -1,8 +1,9 @@
 package payloads
 
 import (
-	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/models"
 
 	"github.com/go-chi/render"
 )

--- a/internal/services/account_service.go
+++ b/internal/services/account_service.go
@@ -1,11 +1,12 @@
 package services
 
 import (
+	"net/http"
+
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/db"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/render"
-	"net/http"
 )
 
 func ListAccounts(w http.ResponseWriter, r *http.Request) {

--- a/internal/services/context_logger.go
+++ b/internal/services/context_logger.go
@@ -1,8 +1,9 @@
 package services
 
 import (
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 
 	"github.com/rs/zerolog"
 )

--- a/internal/services/error_renderer.go
+++ b/internal/services/error_renderer.go
@@ -2,9 +2,10 @@ package services
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/go-chi/render"
-	"net/http"
 )
 
 // writeBasicError is used when rendering of the error fails so at least something is written

--- a/internal/services/parameters.go
+++ b/internal/services/parameters.go
@@ -2,9 +2,10 @@ package services
 
 import (
 	"fmt"
-	"github.com/go-chi/chi/v5"
 	"net/http"
 	"strconv"
+
+	"github.com/go-chi/chi/v5"
 )
 
 func ParseUint64(r *http.Request, param string) (uint64, error) {

--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"net/http"
+
 	"github.com/RHEnVision/provisioning-backend/internal/clients/ec2"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/db"
@@ -9,7 +11,6 @@ import (
 	"github.com/go-chi/render"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"net/http"
 )
 
 func CreatePubkey(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
We are already hitting problems with import ordering, this enforces it via GHA.

I am also mergine jobs into three items: formatting, linting, testing. There is no point in running each in its own container.