### PR TITLE
Fix variable naming

### DIFF
--- a/internal/payloads/pubkey_payload.go
+++ b/internal/payloads/pubkey_payload.go
@@ -22,14 +22,14 @@ func (p *PubkeyResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
 
-func NewPubkeyResponse(account *models.Pubkey) render.Renderer {
-	return &PubkeyResponse{Pubkey: account}
+func NewPubkeyResponse(pubkey *models.Pubkey) render.Renderer {
+	return &PubkeyResponse{Pubkey: pubkey}
 }
 
-func NewPubkeyListResponse(accounts []*models.Pubkey) []render.Renderer {
-	list := make([]render.Renderer, 0, len(accounts))
-	for _, a := range accounts {
-		list = append(list, &PubkeyResponse{Pubkey: a})
+func NewPubkeyListResponse(pubkeys []*models.Pubkey) []render.Renderer {
+	list := make([]render.Renderer, 0, len(pubkeys))
+	for _, pubkey := range pubkeys {
+		list = append(list, &PubkeyResponse{Pubkey: pubkey})
 	}
 	return list
 }


### PR DESCRIPTION
Copied name of variables did not match what the variable actually holds.

I've noticed this during @lzap's presentation and my OCD did not handle it well xD