### PR TITLE
Validate spec and clients via Makefile

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -44,7 +44,7 @@ jobs:
           make test
 
   openapi:
-    name: validate and compare spec
+    name: validate and compare spec and client code
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -56,6 +56,4 @@ jobs:
           generator: python
           openapi-file: api/openapi.gen.yaml
       - run: |
-          make generate-spec
-      - run: |
-          git diff --exit-code api/openapi.gen.yaml
+          make validate

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ internal/clients/sources/client.gen.go: configs/sources_config.yml configs/sourc
 internal/clients/image_builder/client.gen.go: configs/ib_config.yaml configs/ib_api.yaml
 	oapi-codegen -config ./configs/ib_config.yaml ./configs/ib_api.yaml
 
+.PHONY: validate-clients
+validate-clients: generate-clients
+	git diff --exit-code internal/clients/*/client.gen.go
+
 .PHONY: install-tools
 install-tools:
 	go install golang.org/x/tools/cmd/goimports@latest
@@ -83,3 +87,10 @@ generate-migration:
 .PHONY: generate-spec
 generate-spec:
 	go run ./cmd/spec
+
+.PHONY: validate-spec
+validate-spec: generate-spec
+	git diff --exit-code api/openapi.gen.yaml
+
+.PHONY: validate
+validate: validate-spec validate-clients


### PR DESCRIPTION
I wanted to test https://github.com/RHEnVision/provisioning-backend/pull/51 locally but I have realized we don't do it in the Makefile. So I moved it there.

On top of that, I implemented the same validation for OpenAPI clients so they are never out of date from the spec we have in the repo.