### PR TITLE
add error types to spec 

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -16,6 +16,39 @@
         },
         "type": "object"
       },
+      "v1.BadRequestError": {
+        "properties": {
+          "msg": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.InternalRequestError": {
+        "properties": {
+          "msg": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.NotFoundError": {
+        "properties": {
+          "msg": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "v1.Pubkey": {
         "properties": {
           "account_id": {
@@ -30,17 +63,6 @@
             "type": "integer"
           },
           "name": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "v1.ResponseError": {
-        "properties": {
-          "msg": {
-            "type": "string"
-          },
-          "request_id": {
             "type": "string"
           }
         },
@@ -74,6 +96,16 @@
               }
             },
             "description": "Returned on success."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InternalRequestError"
+                }
+              }
+            },
+            "description": "Returned when an internal error occurs."
           }
         }
       }
@@ -109,7 +141,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/v1.ResponseError"
+                  "$ref": "#/components/schemas/v1.NotFoundError"
                 }
               }
             },
@@ -119,7 +151,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/v1.ResponseError"
+                  "$ref": "#/components/schemas/v1.InternalRequestError"
                 }
               }
             },

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -31,13 +31,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/v1.ResponseError"
+                $ref: "#/components/schemas/v1.NotFoundError"
         "500":
           description: 'Returned when an internal error occurs.'
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.ResponseError'
+                $ref: '#/components/schemas/v1.InternalRequestError'
   /pubkeys:
     get:
       operationId: getPubkeyList
@@ -51,6 +51,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.Pubkey'
+        "500":
+          description: 'Returned when an internal error occurs.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v1.InternalRequestError'
 components:
   schemas:
     v1.Account:
@@ -61,6 +67,27 @@ components:
           format: int64
           type: integer
         org_id:
+          type: string
+      type: object
+    v1.BadRequestError:
+      properties:
+        msg:
+          type: string
+        request_id:
+          type: string
+      type: object
+    v1.InternalRequestError:
+      properties:
+        msg:
+          type: string
+        request_id:
+          type: string
+      type: object
+    v1.NotFoundError:
+      properties:
+        msg:
+          type: string
+        request_id:
           type: string
       type: object
     v1.Pubkey:
@@ -74,13 +101,6 @@ components:
           format: int64
           type: integer
         name:
-          type: string
-      type: object
-    v1.ResponseError:
-      properties:
-        msg:
-          type: string
-        request_id:
           type: string
       type: object
 servers:

--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -46,7 +46,10 @@ func main() {
 	gen.addSchema("v1.Pubkey", &payloads.PubkeyPayload{})
 
 	// errors
-	gen.addSchema("v1.ResponseError", &payloads.ResponseError{})
+	gen.addSchema("v1.NotFoundError", &payloads.NotFoundError{})
+	gen.addSchema("v1.BadRequestError", &payloads.BadRequestError{})
+	gen.addSchema("v1.InternalRequestError", &payloads.InternalServerError{})
+
 	type Swagger struct {
 		Components openapi3.Components `json:"components,omitempty" yaml:"components,omitempty"`
 		Servers    openapi3.Servers    `json:"servers,omitempty" yaml:"servers,omitempty"`

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -31,13 +31,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/v1.ResponseError"
+                $ref: "#/components/schemas/v1.NotFoundError"
         "500":
           description: 'Returned when an internal error occurs.'
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.ResponseError'
+                $ref: '#/components/schemas/v1.InternalRequestError'
   /pubkeys:
     get:
       operationId: getPubkeyList
@@ -51,3 +51,9 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.Pubkey'
+        "500":
+          description: 'Returned when an internal error occurs.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v1.InternalRequestError'

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -10,6 +10,23 @@ import (
 	"github.com/go-chi/render"
 )
 
+type APIError interface {
+	Error() string
+	GetStatus() int
+	SetMessage(string)
+	Unwrap() error
+	Render(_ http.ResponseWriter, r *http.Request) error
+}
+
+func (e *ResponseError) Error() string       { return fmt.Sprintf("%s: %s", e.Message, e.Err.Error()) }
+func (e *ResponseError) GetStatus() int      { return e.HTTPStatusCode }
+func (e *ResponseError) SetMessage(m string) { e.Message = m }
+func (e *ResponseError) Unwrap() error       { return e.Err }
+func (e *ResponseError) Render(_ http.ResponseWriter, r *http.Request) error {
+	render.Status(r, e.HTTPStatusCode)
+	return nil
+}
+
 // ResponseError implements Go standard error interface as well as Wrapper and Renderer
 type ResponseError struct {
 	// HTTP status code
@@ -28,155 +45,177 @@ type ResponseError struct {
 	Context context.Context `json:"-"`
 }
 
-func (e *ResponseError) Render(_ http.ResponseWriter, r *http.Request) error {
-	render.Status(r, e.HTTPStatusCode)
-	return nil
+type InternalServerError struct {
+	ResponseError
 }
 
-func (e *ResponseError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Message, e.Err.Error())
-}
-
-func (e *ResponseError) Unwrap() error {
-	return e.Err
-}
-
-func NewInvalidRequestError(ctx context.Context, err error) *ResponseError {
+func NewInvalidRequestError(ctx context.Context, err error) APIError {
 	msg := fmt.Sprintf("invalid request: %v", err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 500,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+
+	return &InternalServerError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 500,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }
 
-func New3rdPartyClientError(ctx context.Context, message string, err error) *ResponseError {
+func New3rdPartyClientError(ctx context.Context, message string, err error) APIError {
 	msg := fmt.Sprintf("3rd Party Client error: %s: %v", message, err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 500,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+
+	return &InternalServerError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 500,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }
 
-func NewClientInitializationError(ctx context.Context, message string, err error) *ResponseError {
+func NewClientInitializationError(ctx context.Context, message string, err error) APIError {
 	msg := fmt.Sprintf("HTTP client initialization error: %s: %v", message, err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 500,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+
+	return &InternalServerError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 500,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }
 
-func NewNotFoundError(ctx context.Context, err error) *ResponseError {
+type NotFoundError struct {
+	ResponseError
+}
+
+func NewNotFoundError(ctx context.Context, err error) APIError {
 	msg := fmt.Sprintf("not found: %v", err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Warn().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 404,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+	return &NotFoundError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 404,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }
 
-func NewInitializeDAOError(ctx context.Context, message string, err error) *ResponseError {
+func NewInitializeDAOError(ctx context.Context, message string, err error) APIError {
 	msg := fmt.Sprintf("DAO initialization error: %s: %v", message, err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 500,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+	return &InternalServerError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 500,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }
 
-func NewDAOError(ctx context.Context, message string, err error) *ResponseError {
+func NewDAOError(ctx context.Context, message string, err error) APIError {
 	msg := fmt.Sprintf("DAO error: %s: %v", message, err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 500,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+	return &InternalServerError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 500,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }
 
-func NewRenderError(ctx context.Context, message string, err error) *ResponseError {
+func NewRenderError(ctx context.Context, message string, err error) APIError {
 	msg := fmt.Sprintf("render error: %s: %v", message, err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 500,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+	return &InternalServerError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 500,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }
 
-func NewURLParsingError(ctx context.Context, paramName string, err error) *ResponseError {
+type BadRequestError struct {
+	ResponseError
+}
+
+func NewURLParsingError(ctx context.Context, paramName string, err error) APIError {
 	msg := fmt.Sprintf("URL parsing error for param '%s': %v", paramName, err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 400,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+	return &BadRequestError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 400,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }
 
-func NewAWSError(ctx context.Context, message string, err error) *ResponseError {
+func NewAWSError(ctx context.Context, message string, err error) APIError {
 	msg := fmt.Sprintf("AWS error: %s: %v", message, err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 500,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+	return &InternalServerError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 500,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }
 
-func NewUnknownError(ctx context.Context, err error) *ResponseError {
+func NewUnknownError(ctx context.Context, err error) APIError {
 	msg := fmt.Sprintf("unknown error: %v", err)
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &ResponseError{
-		HTTPStatusCode: 500,
-		Message:        msg,
-		RequestId:      ctxval.GetRequestId(ctx),
-		Err:            err,
-		Context:        ctx,
+	return &InternalServerError{
+		ResponseError: ResponseError{
+			HTTPStatusCode: 500,
+			Message:        msg,
+			RequestId:      ctxval.GetRequestId(ctx),
+			Err:            err,
+			Context:        ctx,
+		},
 	}
 }


### PR DESCRIPTION
This PR refactors the errors payload and transforms it into an interface for a simpler consuming and extending,
this also allows adding different error types into openapi spec.

We can leverage this interface instead of creating a new error payload for every new service, and keep our code dry