### PR TITLE
Add error responses to the spec file

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -1,5 +1,37 @@
 {
   "components": {
+    "responses": {
+      "BadRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/v1.ResponseError"
+            }
+          }
+        },
+        "description": "The request's parameters are not sufficient"
+      },
+      "InternalError": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/v1.ResponseError"
+            }
+          }
+        },
+        "description": "The server encountered with an internal error"
+      },
+      "NotFound": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/v1.ResponseError"
+            }
+          }
+        },
+        "description": "The specified resource was not found"
+      }
+    },
     "schemas": {
       "v1.Account": {
         "properties": {
@@ -74,6 +106,9 @@
               }
             },
             "description": "Returned on success."
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
           }
         }
       }
@@ -106,24 +141,10 @@
             "description": "Returned on success."
           },
           "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/v1.ResponseError"
-                }
-              }
-            },
-            "description": "Returned when resource cannot be found."
+            "$ref": "#/components/responses/NotFound"
           },
           "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/v1.ResponseError"
-                }
-              }
-            },
-            "description": "Returned when an internal error occurs."
+            "$ref": "#/components/responses/InternalError"
           }
         }
       }

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -27,17 +27,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/v1.Pubkey'
         "404":
-          description: 'Returned when resource cannot be found.'
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/v1.ResponseError"
+            $ref: "#/components/responses/NotFound"
         "500":
-          description: 'Returned when an internal error occurs.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/v1.ResponseError'
+            $ref: '#/components/responses/InternalError'
   /pubkeys:
     get:
       operationId: getPubkeyList
@@ -51,7 +43,28 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.Pubkey'
+        "500":
+            $ref: '#/components/responses/InternalError'
 components:
+  responses:
+    BadRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/v1.ResponseError'
+      description: The request's parameters are not sufficient
+    InternalError:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/v1.ResponseError'
+      description: The server encountered with an internal error
+    NotFound:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/v1.ResponseError'
+      description: The specified resource was not found
   schemas:
     v1.Account:
       properties:

--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -30,6 +30,7 @@ func (s *APISchemaGen) init() {
 	}
 	s.Components = openapi3.NewComponents()
 	s.Components.Schemas = make(map[string]*openapi3.SchemaRef)
+	s.Components.Responses = make(map[string]*openapi3.ResponseRef)
 }
 
 func (s *APISchemaGen) addSchema(name string, model interface{}) {
@@ -38,15 +39,24 @@ func (s *APISchemaGen) addSchema(name string, model interface{}) {
 	s.Components.Schemas[name] = schema
 }
 
+func (s *APISchemaGen) addResponse(name string, description string, ref string) {
+	response := openapi3.NewResponse().WithDescription(description).WithJSONSchemaRef(&openapi3.SchemaRef{Ref: ref})
+	s.Components.Responses[name] = &openapi3.ResponseRef{Value: response}
+}
+
 func main() {
 	gen := APISchemaGen{}
 	gen.init()
-	// models
+	// payloads
 	gen.addSchema("v1.Account", &payloads.AccountPayload{})
 	gen.addSchema("v1.Pubkey", &payloads.PubkeyPayload{})
+	gen.addSchema("v1.ResponseError", &payloads.ResponseError{})
 
 	// errors
-	gen.addSchema("v1.ResponseError", &payloads.ResponseError{})
+	gen.addResponse("NotFound", "The specified resource was not found", "#/components/schemas/v1.ResponseError")
+	gen.addResponse("InternalError", "The server encountered with an internal error", "#/components/schemas/v1.ResponseError")
+	gen.addResponse("BadRequest", "The request's parameters are not sufficient", "#/components/schemas/v1.ResponseError")
+
 	type Swagger struct {
 		Components openapi3.Components `json:"components,omitempty" yaml:"components,omitempty"`
 		Servers    openapi3.Servers    `json:"servers,omitempty" yaml:"servers,omitempty"`

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -27,17 +27,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/v1.Pubkey'
         "404":
-          description: 'Returned when resource cannot be found.'
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/v1.ResponseError"
+            $ref: "#/components/responses/NotFound"
         "500":
-          description: 'Returned when an internal error occurs.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/v1.ResponseError'
+            $ref: '#/components/responses/InternalError'
   /pubkeys:
     get:
       operationId: getPubkeyList
@@ -51,3 +43,5 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.Pubkey'
+        "500":
+            $ref: '#/components/responses/InternalError'


### PR DESCRIPTION
This adds errors `responses` to the spec file under `components` for easy referencing from a route.
For motivation see [Reusing responses](https://swagger.io/docs/specification/describing-responses/)


