### PR TITLE
Update dependency clowdapp

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -73,7 +73,7 @@ objects:
         name: provisioning-backend
         version: 13
       dependencies:
-        - sources-api
+        - sources
 
 parameters:
   - description: ClowdEnv Name


### PR DESCRIPTION
`sources-api` was the older version of the service. It has been replaced by `sources-api-go`. 
`sources-api-go` is the active repo right now.
https://github.com/RedHatInsights/sources-api-go