### PR TITLE
HMSPROV-147: Add errors from sources client

### DIFF
--- a/internal/clients/sources/sources_errors.go
+++ b/internal/clients/sources/sources_errors.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"encoding/json"
 	"errors"
 )
 
@@ -8,6 +9,23 @@ var MoreThenOneAuthenticationForSourceErr = errors.New("more then one authentica
 var AuthenticationForSourcesNotFoundErr = errors.New("authentications for source weren't found in sources app")
 var SourcesClientErr = errors.New("sources client error")
 var ApplicationNotFoundErr = errors.New("application not found is sources app")
-var ApplicationTypesFetchUnsuccessful = errors.New("failed to fetch ApplicationTypes")
-var ApplicationTypeNotFound = errors.New("application type 'provisioning' has not been found in types supported by sources")
-var ApplicationTypeCacheFailed = errors.New("application type id failed to write to cache")
+var ApplicationTypesFetchUnsuccessfulErr = errors.New("failed to fetch ApplicationTypes")
+var ApplicationTypeNotFoundErr = errors.New("application type 'provisioning' has not been found in types supported by sources")
+var ApplicationTypeCacheFailedErr = errors.New("application type id failed to write to cache")
+var CantMarshalErr = errors.New("cant marshal array to json")
+
+func ParseErrorNotFoundToJSON(sourcesErrors ErrorNotFound) ([]byte, error) {
+	j, err := json.Marshal(sourcesErrors)
+	if err != nil {
+		return nil, CantMarshalErr
+	}
+	return j, nil
+}
+
+func ParseErrorBadRequestToJSON(sourcesErrors ErrorBadRequest) ([]byte, error) {
+	j, err := json.Marshal(sourcesErrors)
+	if err != nil {
+		return nil, CantMarshalErr
+	}
+	return j, nil
+}

--- a/internal/clients/sources/sources_impl.go
+++ b/internal/clients/sources/sources_impl.go
@@ -50,7 +50,7 @@ func loadAppId(ctx context.Context, client *ClientWithResponses) (string, error)
 	}
 	if !parsing.IsHTTPStatus2xx(resp.StatusCode) {
 		ctxval.Logger(ctx).Warn().Msgf("Sources replied with unexpected status while fetching ApplicationTypes: %s", resp.Status)
-		return "", fmt.Errorf("%w, status: '%s'", ApplicationTypesFetchUnsuccessful, resp.Status)
+		return "", fmt.Errorf("%w, status: '%s'", ApplicationTypesFetchUnsuccessfulErr, resp.Status)
 	}
 	defer resp.Body.Close()
 	var appTypesData dataElement
@@ -63,5 +63,5 @@ func loadAppId(ctx context.Context, client *ClientWithResponses) (string, error)
 			return t.Id, nil
 		}
 	}
-	return "", ApplicationTypeNotFound
+	return "", ApplicationTypeNotFoundErr
 }

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -28,6 +28,15 @@ type ResponseError struct {
 	Context context.Context `json:"-"`
 }
 
+type ClientError struct {
+	Message string `json:"msg"`
+	Body    string `json:"body"`
+}
+
+func (e ClientError) Error() string {
+	return e.Message
+}
+
 func (e *ResponseError) Render(_ http.ResponseWriter, r *http.Request) error {
 	render.Status(r, e.HTTPStatusCode)
 	return nil

--- a/internal/services/sources_service.go
+++ b/internal/services/sources_service.go
@@ -20,28 +20,42 @@ func ListSources(w http.ResponseWriter, r *http.Request) {
 	}
 	appTypeId, err := client.GetProvisioningTypeId(r.Context(), AddIdentityHeader)
 	if err != nil {
-		renderError(w, r, payloads.SourcesClientError(r.Context(), "get provisioning app type", err, 500))
+		renderError(w, r, payloads.SourcesClientError(r.Context(), "get provisioning type id", err, 500))
 		return
 	}
 	resp, err := client.ListApplicationTypeSourcesWithResponse(r.Context(), appTypeId, &sources.ListApplicationTypeSourcesParams{}, AddIdentityHeader)
 	statusCode := resp.StatusCode()
 	if err != nil {
-		renderError(w, r, payloads.SourcesClientError(r.Context(), "list sources", err, statusCode))
+		renderError(w, r, payloads.SourcesClientError(r.Context(), "list application types", err, statusCode))
 		return
 	}
+
 	if parsing.IsHTTPNotFound(statusCode) {
-		renderError(w, r, payloads.SourcesClientError(r.Context(), "sources not found", err, statusCode))
+		errors, err := sources.ParseErrorNotFoundToJSON(*resp.JSON404)
+		if err != nil {
+			renderError(w, r, payloads.NewRenderError(r.Context(), "list sources", err))
+			return
+		}
+		sourcesErr := payloads.ClientError{Message: fmt.Sprintf("source not found %s", errors)}
+		renderError(w, r, payloads.NewNotFoundError(r.Context(), sourcesErr))
 		return
 	}
+
 	if !parsing.IsHTTPStatus2xx(statusCode) {
-		renderError(w, r, payloads.SourcesClientError(r.Context(), "sources client error", err, statusCode))
+		errors, err := sources.ParseErrorBadRequestToJSON(*resp.JSON400)
+		if err != nil {
+			renderError(w, r, payloads.NewRenderError(r.Context(), "list sources", err))
+			return
+		}
+		sourcesErr := payloads.ClientError{Message: fmt.Sprintf("sources client error %s", errors)}
+		renderError(w, r, payloads.SourcesClientError(r.Context(), "list sources", sourcesErr, statusCode))
 		return
 	}
+
 	if err := render.RenderList(w, r, payloads.NewListSourcesResponse(resp.JSON200.Data)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "list sources", err))
 		return
 	}
-
 }
 
 func GetSource(w http.ResponseWriter, r *http.Request) {
@@ -59,61 +73,100 @@ func GetSource(w http.ResponseWriter, r *http.Request) {
 		renderError(w, r, payloads.SourcesClientError(r.Context(), "show source", err, statusCode))
 		return
 	}
+
 	if parsing.IsHTTPNotFound(statusCode) {
-		renderError(w, r, payloads.SourcesClientError(r.Context(), "source not found", err, statusCode))
+		errors, err := sources.ParseErrorNotFoundToJSON(*resp.JSON404)
+		if err != nil {
+			renderError(w, r, payloads.NewRenderError(r.Context(), "show sources", err))
+			return
+		}
+		sourcesErr := payloads.ClientError{Message: fmt.Sprintf("source not found %s", errors)}
+		renderError(w, r, payloads.NewNotFoundError(r.Context(), sourcesErr))
 		return
 	}
+
 	if !parsing.IsHTTPStatus2xx(statusCode) {
-		renderError(w, r, payloads.SourcesClientError(r.Context(), "sources client error", err, statusCode))
+		errors, err := sources.ParseErrorBadRequestToJSON(*resp.JSON400)
+		if err != nil {
+			renderError(w, r, payloads.NewRenderError(r.Context(), "list sources", err))
+			return
+		}
+		sourcesErr := payloads.ClientError{Message: fmt.Sprintf("sources client error %s", errors)}
+		renderError(w, r, payloads.SourcesClientError(r.Context(), "show source", sourcesErr, statusCode))
 		return
 	}
+
 	if err := render.Render(w, r, payloads.NewShowSourcesResponse(resp.JSON200)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "show source", err))
 	}
 }
 
-func fetchARN(ctx context.Context, client sources.SourcesIntegration, sourceId string) (string, error) {
+func fetchARN(ctx context.Context, client sources.SourcesIntegration, sourceId string) (string, []byte, error) {
 	// Get all the authentications linked to a specific source
+	var errors []byte
 	resp, err := client.ListSourceAuthenticationsWithResponse(ctx, sourceId, &sources.ListSourceAuthenticationsParams{}, AddIdentityHeader)
 	if err != nil {
-		return "", fmt.Errorf("cannot list source authentication: %w", err)
+		return "", nil, fmt.Errorf("cannot list source authentication: %w", err)
 	}
+
 	statusCode := resp.StatusCode()
 	if parsing.IsHTTPNotFound(statusCode) {
-		return "", sources.AuthenticationForSourcesNotFoundErr
+		errors, err = sources.ParseErrorNotFoundToJSON(*resp.JSON404)
+		if err != nil {
+			return "", errors, sources.AuthenticationForSourcesNotFoundErr
+		}
+		return "", errors, sources.AuthenticationForSourcesNotFoundErr
 	}
+
 	if !parsing.IsHTTPStatus2xx(statusCode) {
-		return "", sources.SourcesClientErr
+		errors, err = sources.ParseErrorBadRequestToJSON(*resp.JSON400)
+		if err != nil {
+			return "", errors, sources.SourcesClientErr
+		}
+		return "", nil, sources.SourcesClientErr
 	}
+
 	// Filter authentications to include only auth where resource_type == "Application"
 	auth, err := filterSourceAuthentications(resp.JSON200.Data)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
+
 	// Get the resource_id which equals to application_id
 	// and check that application_type_id in /applications/<app_id> equals to provisioning id
 	res, err := client.ShowApplicationWithResponse(ctx, *auth.ResourceId, AddIdentityHeader)
 	if err != nil {
-		return "", fmt.Errorf("cannot list source authentication: %w", err)
+		return "", nil, fmt.Errorf("cannot list source authentication: %w", err)
 	}
+
 	statusCode = res.StatusCode()
 	if parsing.IsHTTPNotFound(statusCode) {
-		return "", sources.ApplicationNotFoundErr
+		errors, err = sources.ParseErrorNotFoundToJSON(*resp.JSON404)
+		if err != nil {
+			return "", errors, sources.ApplicationNotFoundErr
+		}
+		return "", nil, sources.ApplicationNotFoundErr
 	}
+
 	if !parsing.IsHTTPStatus2xx(statusCode) {
-		return "", sources.SourcesClientErr
+		errors, err = sources.ParseErrorBadRequestToJSON(*resp.JSON400)
+		if err != nil {
+			return "", errors, sources.SourcesClientErr
+		}
+		return "", nil, sources.SourcesClientErr
 	}
 
 	appTypeId, err := client.GetProvisioningTypeId(ctx, AddIdentityHeader)
 	if err != nil {
-		return "", fmt.Errorf("cannot get provisioning app type: %w", err)
+		return "", nil, fmt.Errorf("cannot get provisioning app type: %w", err)
 	}
 
 	if *res.JSON200.ApplicationTypeId == appTypeId {
-		return *auth.Username, nil
+		return *auth.Username, nil, nil
 
 	}
-	return "", fmt.Errorf("cannot find authentication linked to source id %s and to the provisioning app: %w", sourceId, err)
+
+	return "", nil, fmt.Errorf("cannot find authentication linked to source id %s and to the provisioning app: %w", sourceId, err)
 }
 
 func filterSourceAuthentications(authentications *[]sources.AuthenticationRead) (sources.AuthenticationRead, error) {


### PR DESCRIPTION
Sources client have JSON404 and JSON400 errors linked to their response. 
In this PR I wanted to include those errors in our error handling process to provide more information about errors that weren't caused on our side. 

It is a draft to pass the general idea, I am open to suggestions :) 