### PR TITLE
NoRowsError wrap the original error

### DIFF
--- a/internal/dao/dao_errors.go
+++ b/internal/dao/dao_errors.go
@@ -16,6 +16,7 @@ type Error struct {
 type NoRowsError struct {
 	Message string
 	Context context.Context
+	Err     error
 }
 
 // MismatchAffectedError is returned when affected rows do not match expectation (e.g. create/delete).
@@ -34,6 +35,10 @@ func (e *Error) Unwrap() error {
 
 func (e *NoRowsError) Error() string {
 	return fmt.Sprintf("DAO no rows returned: %s", e.Message)
+}
+
+func (e *NoRowsError) Unwrap() error {
+	return e.Err
 }
 
 func (e *MismatchAffectedError) Error() string {

--- a/internal/dao/sqlx/pubkey_dao.go
+++ b/internal/dao/sqlx/pubkey_dao.go
@@ -104,7 +104,7 @@ func (di *pubkeyDaoSqlx) GetById(ctx context.Context, id int64) (*models.Pubkey,
 	err := stmt.GetContext(ctx, result, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, NewNoRowsError(ctx, di, query)
+			return nil, NewNoRowsError(ctx, di, query, err)
 		} else {
 			return nil, NewGetError(ctx, di, query, err)
 		}

--- a/internal/dao/sqlx/pubkey_resource_dao.go
+++ b/internal/dao/sqlx/pubkey_resource_dao.go
@@ -73,7 +73,7 @@ func (di *pubkeyResourceDaoSqlx) GetResourceByProviderType(ctx context.Context, 
 	err := stmt.GetContext(ctx, result, pubkeyId, provider)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, NewNoRowsError(ctx, di, query)
+			return nil, NewNoRowsError(ctx, di, query, err)
 		} else {
 			return nil, NewGetError(ctx, di, query, err)
 		}

--- a/internal/dao/sqlx/sqlx_errors.go
+++ b/internal/dao/sqlx/sqlx_errors.go
@@ -34,11 +34,12 @@ func newMismatchAffectedError(ctx context.Context, msg string) *dao.MismatchAffe
 	}
 }
 
-func newNoRowsError(ctx context.Context, msg string) *dao.NoRowsError {
+func newNoRowsError(ctx context.Context, msg string, noRowsErr error) *dao.NoRowsError {
 	if logger := ctxval.GetLogger(ctx); logger != nil {
-		logger.Warn().Msg(msg)
+		logger.Debug().Err(noRowsErr).Msg(msg)
 	}
 	return &dao.NoRowsError{
+		Err:     noRowsErr,
 		Message: msg,
 		Context: ctx,
 	}
@@ -84,7 +85,7 @@ func NewUpdateMismatchAffectedError(context context.Context, daoName NamedForErr
 	return newMismatchAffectedError(context, msg)
 }
 
-func NewNoRowsError(context context.Context, daoName NamedForError, sql string) *dao.NoRowsError {
+func NewNoRowsError(context context.Context, daoName NamedForError, sql string, noRowsErr error) *dao.NoRowsError {
 	msg := fmt.Sprintf("sqlx %s no rows returned from: %s", daoName.NameForError(), sql)
-	return newNoRowsError(context, msg)
+	return newNoRowsError(context, msg, noRowsErr)
 }


### PR DESCRIPTION
NoRowsError shall wrap the sql.NoRowsErr so we can test for it in inheritance.

This also levels down the error level of logging this error,
it might be expected by the  user.
