### PR TITLE
Pass errors by value copy

### DIFF
--- a/internal/dao/dao_errors.go
+++ b/internal/dao/dao_errors.go
@@ -25,22 +25,22 @@ type MismatchAffectedError struct {
 	Context context.Context
 }
 
-func (e *Error) Error() string {
+func (e Error) Error() string {
 	return fmt.Sprintf("DAO error: %s: %s", e.Message, e.Err.Error())
 }
 
-func (e *Error) Unwrap() error {
+func (e Error) Unwrap() error {
 	return e.Err
 }
 
-func (e *NoRowsError) Error() string {
+func (e NoRowsError) Error() string {
 	return fmt.Sprintf("DAO no rows returned: %s", e.Message)
 }
 
-func (e *NoRowsError) Unwrap() error {
+func (e NoRowsError) Unwrap() error {
 	return e.Err
 }
 
-func (e *MismatchAffectedError) Error() string {
+func (e MismatchAffectedError) Error() string {
 	return fmt.Sprintf("DAO mismatch affected rows: %s", e.Message)
 }

--- a/internal/dao/sqlx/sqlx_errors.go
+++ b/internal/dao/sqlx/sqlx_errors.go
@@ -13,79 +13,79 @@ type NamedForError interface {
 	NameForError() string
 }
 
-func newError(ctx context.Context, msg string, err error) *dao.Error {
+func newError(ctx context.Context, msg string, err error) dao.Error {
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}
-	return &dao.Error{
+	return dao.Error{
 		Message: msg,
 		Context: ctx,
 		Err:     err,
 	}
 }
 
-func newMismatchAffectedError(ctx context.Context, msg string) *dao.MismatchAffectedError {
+func newMismatchAffectedError(ctx context.Context, msg string) dao.MismatchAffectedError {
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Warn().Msg(msg)
 	}
-	return &dao.MismatchAffectedError{
+	return dao.MismatchAffectedError{
 		Message: msg,
 		Context: ctx,
 	}
 }
 
-func newNoRowsError(ctx context.Context, msg string, noRowsErr error) *dao.NoRowsError {
+func newNoRowsError(ctx context.Context, msg string, noRowsErr error) dao.NoRowsError {
 	if logger := ctxval.GetLogger(ctx); logger != nil {
 		logger.Debug().Err(noRowsErr).Msg(msg)
 	}
-	return &dao.NoRowsError{
+	return dao.NoRowsError{
 		Err:     noRowsErr,
 		Message: msg,
 		Context: ctx,
 	}
 }
 
-func NewPrepareStatementError(context context.Context, daoName NamedForError, sql string, err error) *dao.Error {
+func NewPrepareStatementError(context context.Context, daoName NamedForError, sql string, err error) dao.Error {
 	msg := fmt.Sprintf("sqlx %s prepare statement error: %s: %v", daoName.NameForError(), sql, err)
 	return newError(context, msg, err)
 }
 
-func NewTransactionError(context context.Context, err error) *dao.Error {
+func NewTransactionError(context context.Context, err error) dao.Error {
 	msg := fmt.Sprintf("transaction: %v", err)
 	return newError(context, msg, err)
 }
 
-func NewGetError(context context.Context, daoName NamedForError, sql string, err error) *dao.Error {
+func NewGetError(context context.Context, daoName NamedForError, sql string, err error) dao.Error {
 	msg := fmt.Sprintf("sqlx %s get error: %s: %v", daoName.NameForError(), sql, err)
 	return newError(context, msg, err)
 }
 
-func NewSelectError(context context.Context, daoName NamedForError, sql string, err error) *dao.Error {
+func NewSelectError(context context.Context, daoName NamedForError, sql string, err error) dao.Error {
 	msg := fmt.Sprintf("sqlx %s select error: %s: %v", daoName.NameForError(), sql, err)
 	return newError(context, msg, err)
 }
 
-func NewExecUpdateError(context context.Context, daoName NamedForError, sql string, err error) *dao.Error {
+func NewExecUpdateError(context context.Context, daoName NamedForError, sql string, err error) dao.Error {
 	msg := fmt.Sprintf("sqlx %s exec update error: %s: %v", daoName.NameForError(), sql, err)
 	return newError(context, msg, err)
 }
 
-func NewExecDeleteError(context context.Context, daoName NamedForError, sql string, err error) *dao.Error {
+func NewExecDeleteError(context context.Context, daoName NamedForError, sql string, err error) dao.Error {
 	msg := fmt.Sprintf("sqlx %s exec delete error: %s: %v", daoName.NameForError(), sql, err)
 	return newError(context, msg, err)
 }
 
-func NewDeleteMismatchAffectedError(context context.Context, daoName NamedForError, expected, was int64) *dao.MismatchAffectedError {
+func NewDeleteMismatchAffectedError(context context.Context, daoName NamedForError, expected, was int64) dao.MismatchAffectedError {
 	msg := fmt.Sprintf("sqlx %s delete expected: %d rows, was: %d rows", daoName.NameForError(), expected, was)
 	return newMismatchAffectedError(context, msg)
 }
 
-func NewUpdateMismatchAffectedError(context context.Context, daoName NamedForError, expected, was int64) *dao.MismatchAffectedError {
+func NewUpdateMismatchAffectedError(context context.Context, daoName NamedForError, expected, was int64) dao.MismatchAffectedError {
 	msg := fmt.Sprintf("sqlx %s update expected: %d rows, was: %d rows", daoName.NameForError(), expected, was)
 	return newMismatchAffectedError(context, msg)
 }
 
-func NewNoRowsError(context context.Context, daoName NamedForError, sql string, noRowsErr error) *dao.NoRowsError {
+func NewNoRowsError(context context.Context, daoName NamedForError, sql string, noRowsErr error) dao.NoRowsError {
 	msg := fmt.Sprintf("sqlx %s no rows returned from: %s", daoName.NameForError(), sql)
 	return newNoRowsError(context, msg, noRowsErr)
 }


### PR DESCRIPTION
THIS IS A PROPOSAL. I do not feel this is necessary, but IMHO it reads better :)

We are passing errors as pointers, but errors shall be static structures.
No changes should be made to it post creation.

Given performance impact is very small, we can do this to assure correct use of error structures.
