### PR TITLE
Use versioned endpoint for sources

### DIFF
--- a/internal/config/5_real_config.go
+++ b/internal/config/5_real_config.go
@@ -22,7 +22,7 @@ func init() {
 		viper.Set("prometheus.port", cfg.MetricsPort)
 		viper.Set("prometheus.path", cfg.MetricsPath)
 		if endpoint, ok := clowder.DependencyEndpoints["sources-api"]["svc"]; ok {
-			viper.Set("restEndpoints.sources.url", fmt.Sprintf("http://%s:%d/api/sources", endpoint.Hostname, endpoint.Port))
+			viper.Set("restEndpoints.sources.url", fmt.Sprintf("http://%s:%d/api/sources/v3", endpoint.Hostname, endpoint.Port))
 		}
 	} else {
 		viper.SetDefault("featureFlags.environment", "development")


### PR DESCRIPTION
We have forgotten a version in the config from clowder.
