### PR TITLE
HMSPROV-108: Return correct status on not found

### DIFF
--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -83,7 +83,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 		logger.Debug().Msgf("Validating existing pubkey %d", *payload.Pubkey.ExistingID)
 		pk, err = pkDao.GetById(r.Context(), *payload.Pubkey.ExistingID)
 		if err != nil {
-			var e *dao.NoRowsError
+			var e dao.NoRowsError
 			if errors.As(err, &e) {
 				renderError(w, r, payloads.NewNotFoundError(r.Context(), err))
 			} else {
@@ -109,7 +109,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	uploadNeeded := false
 	pkr, errDao := pkrDao.GetResourceByProviderType(r.Context(), pk.ID, models.ProviderTypeAWS)
 	if errDao != nil {
-		var e *dao.NoRowsError
+		var e dao.NoRowsError
 		if errors.As(errDao, &e) {
 			uploadNeeded = true
 		} else {

--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -67,7 +67,7 @@ func GetPubkey(w http.ResponseWriter, r *http.Request) {
 
 	pubkey, err := pubkeyDao.GetById(r.Context(), id)
 	if err != nil {
-		var e *dao.NoRowsError
+		var e dao.NoRowsError
 		if errors.As(err, &e) {
 			renderError(w, r, payloads.NewNotFoundError(r.Context(), err))
 		} else {


### PR DESCRIPTION
After 276e9949346268ab01bc0cbeba1e20be84a5187d the error evaluation stopped working.
We need to test with values, not pointers to values.