### PR TITLE
HMSPROV-115: Update makefile, add pr_checks and build_deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 TEST_TAGS?=test
+CONTAINER_BUILD_OPTS ?= --build-arg=quay_expiration=2d
+CONTAINER_IMAGE ?= provisioning-backend
 
 .PHONY: build
 build: build-pbapi build-pbmigrate
@@ -23,7 +25,7 @@ clean:
 build-podman:
 	# remote podman build has problem with -f option, so we link the file as workaround
 	ln -f build/Dockerfile Containerfile
-	podman build --build-arg quay_expiration=2d -t provisioning-backend .
+	podman build $(CONTAINER_BUILD_OPTS) -t $(CONTAINER_IMAGE) .
 
 .PHONY: prep
 prep:

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+IMAGE="${IMAGE:-quay.io/cloudservices/provisioning-backend}"
+IMAGE_TAG="$(git rev-parse --short=7 HEAD)"
+SMOKE_TEST_TAG="latest"
+
+if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
+    echo "QUAY_USER and QUAY_TOKEN must be set"
+    exit 1
+fi
+
+if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
+    echo "RH_REGISTRY_USER and RH_REGISTRY_TOKEN  must be set"
+    exit 1
+fi
+
+# Login to quay
+podman login \
+    -u ${QUAY_USER} \
+    -p ${QUAY_TOKEN} \
+    quay.io
+
+# Login to registry.redhat
+podman login \
+    -u ${RH_REGISTRY_USER} \
+    -p ${RH_REGISTRY_TOKEN} \
+    registry.redhat.io
+
+# build and push
+make build-podman \
+    CONTAINER_IMAGE="${IMAGE}:${IMAGE_TAG}"
+
+# push to logged in registries and tag for SHA
+podman tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SMOKE_TEST_TAG}"
+podman push "${IMAGE}:${SMOKE_TEST_TAG}"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -92,7 +92,7 @@ parameters:
     required: true
   - description: Image name
     name: IMAGE
-    value: quay.io/envision/provisioning-backend
+    value: quay.io/cloudservices/provisioning-backend
   - description: Determines Clowder deployment
     name: CLOWDER_ENABLED
     value: "true"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -5,7 +5,7 @@ labels:
   app: provisioning
   template: provisioning
 metadata:
-  name: provisioning
+  name: provisioning-backend
   annotations:
     description: API backend for provisioning in console.redhat.com
 
@@ -13,7 +13,7 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
-      name: provisioning
+      name: provisioning-backend
       labels:
         service: provisioning
     spec:

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Options that must be configured by app owner
+# --------------------------------------------
+APP_NAME="provisioning"  # name of app-sre "application" folder this component lives in
+COMPONENT_NAME="provisioning-backend"  # name of resourceTemplate component for deploy
+IMAGE="quay.io/cloudservices/provisioning-backend"  # image location on quay
+DOCKERFILE="build/Dockerfile"
+
+IQE_PLUGINS="hms-provisioning"  # name of the IQE plugin for this app.
+IQE_MARKER_EXPRESSION=""  # This is the value passed to pytest -m
+IQE_FILTER_EXPRESSION=""  # This is the value passed to pytest -k
+IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
+
+
+# Install bonfire repo/initialize
+# https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/bootstrap.sh
+# This script automates the install / config of bonfire
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+
+# This script is used to build the image that is used in the PR Check
+source $CICD_ROOT/build.sh
+
+# This script is used to deploy the ephemeral environment for smoke tests.
+# The manual steps for this can be found in:
+# https://internal.cloud.redhat.com/docs/devprod/ephemeral/02-deploying/
+source $CICD_ROOT/deploy_ephemeral_env.sh
+
+# Run smoke tests using a ClowdJobInvocation and iqe-tests
+COMPONENT_NAME="provisioning"  # name of app used in deploy-iqe-cji
+source $CICD_ROOT/cji_smoke_test.sh
+
+# Post a comment with test run IDs to the PR
+# source $CICD_ROOT/post_test_results.sh


### PR DESCRIPTION
These will be used by appsre CI for building the main branch image and
pushing to quay.io/cloudservices, and for executing PR checks against
all PRs opened in this repo.

pr_checks will call CI scripts from a shared repo to build an image with
the PR content and run iqe tests against it

build_deploy will execute against the main branch after PR merges.

### Testing

Executed build_deploy locally, producing and pushing this image:
https://quay.io/repository/mshriver/provisioning-backend?tab=tags