### PR TITLE
HMSPROV-164: Change sources client implementation

### DIFF
--- a/internal/clients/sources/sources_interface.go
+++ b/internal/clients/sources/sources_interface.go
@@ -12,4 +12,6 @@ type SourcesIntegration interface {
 	ListApplicationTypeSourcesWithResponse(ctx context.Context, appTypeId ID, params *ListApplicationTypeSourcesParams, reqEditors ...RequestEditorFn) (*ListApplicationTypeSourcesResponse, error)
 	ListSourceAuthenticationsWithResponse(ctx context.Context, id ID, params *ListSourceAuthenticationsParams, reqEditors ...RequestEditorFn) (*ListSourceAuthenticationsResponse, error)
 	ShowApplicationWithResponse(ctx context.Context, id ID, reqEditors ...RequestEditorFn) (*ShowApplicationResponse, error)
+	FetchARN(ctx context.Context, sourceId string) (string, error)
+	FilterSourceAuthentications(authentications *[]AuthenticationRead) (AuthenticationRead, error)
 }

--- a/internal/headers/headers.go
+++ b/internal/headers/headers.go
@@ -1,4 +1,4 @@
-package services
+package headers
 
 import (
 	"context"

--- a/internal/services/instance_types_service.go
+++ b/internal/services/instance_types_service.go
@@ -22,7 +22,7 @@ func ListInstanceTypes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	arn, err := fetchARN(r.Context(), sourcesClient, sourceId)
+	arn, err := sourcesClient.FetchARN(r.Context(), sourceId)
 	if err != nil {
 		if errors.Is(err, sources.ApplicationNotFoundErr) {
 			renderError(w, r, payloads.SourcesClientError(r.Context(), "can't fetch arn from sources: application not found", err, 404))

--- a/internal/services/sources_service.go
+++ b/internal/services/sources_service.go
@@ -1,11 +1,10 @@
 package services
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 
 	sources "github.com/RHEnVision/provisioning-backend/internal/clients/sources"
+	"github.com/RHEnVision/provisioning-backend/internal/headers"
 	"github.com/RHEnVision/provisioning-backend/internal/parsing"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/chi/v5"
@@ -18,12 +17,12 @@ func ListSources(w http.ResponseWriter, r *http.Request) {
 		renderError(w, r, payloads.NewClientInitializationError(r.Context(), "sources client", err))
 		return
 	}
-	appTypeId, err := client.GetProvisioningTypeId(r.Context(), AddIdentityHeader)
+	appTypeId, err := client.GetProvisioningTypeId(r.Context(), headers.AddIdentityHeader)
 	if err != nil {
 		renderError(w, r, payloads.SourcesClientError(r.Context(), "get provisioning app type", err, 500))
 		return
 	}
-	resp, err := client.ListApplicationTypeSourcesWithResponse(r.Context(), appTypeId, &sources.ListApplicationTypeSourcesParams{}, AddIdentityHeader)
+	resp, err := client.ListApplicationTypeSourcesWithResponse(r.Context(), appTypeId, &sources.ListApplicationTypeSourcesParams{}, headers.AddIdentityHeader)
 	statusCode := resp.StatusCode()
 	if err != nil {
 		renderError(w, r, payloads.SourcesClientError(r.Context(), "list sources", err, statusCode))
@@ -53,7 +52,7 @@ func GetSource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := client.ShowSourceWithResponse(r.Context(), sources.ID(id), AddIdentityHeader)
+	resp, err := client.ShowSourceWithResponse(r.Context(), sources.ID(id), headers.AddIdentityHeader)
 	statusCode := resp.StatusCode()
 	if err != nil {
 		renderError(w, r, payloads.SourcesClientError(r.Context(), "show source", err, statusCode))
@@ -70,63 +69,4 @@ func GetSource(w http.ResponseWriter, r *http.Request) {
 	if err := render.Render(w, r, payloads.NewShowSourcesResponse(resp.JSON200)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "show source", err))
 	}
-}
-
-func fetchARN(ctx context.Context, client sources.SourcesIntegration, sourceId string) (string, error) {
-	// Get all the authentications linked to a specific source
-	resp, err := client.ListSourceAuthenticationsWithResponse(ctx, sourceId, &sources.ListSourceAuthenticationsParams{}, AddIdentityHeader)
-	if err != nil {
-		return "", fmt.Errorf("cannot list source authentication: %w", err)
-	}
-	statusCode := resp.StatusCode()
-	if parsing.IsHTTPNotFound(statusCode) {
-		return "", sources.AuthenticationForSourcesNotFoundErr
-	}
-	if !parsing.IsHTTPStatus2xx(statusCode) {
-		return "", sources.SourcesClientErr
-	}
-	// Filter authentications to include only auth where resource_type == "Application"
-	auth, err := filterSourceAuthentications(resp.JSON200.Data)
-	if err != nil {
-		return "", err
-	}
-	// Get the resource_id which equals to application_id
-	// and check that application_type_id in /applications/<app_id> equals to provisioning id
-	res, err := client.ShowApplicationWithResponse(ctx, *auth.ResourceId, AddIdentityHeader)
-	if err != nil {
-		return "", fmt.Errorf("cannot list source authentication: %w", err)
-	}
-	statusCode = res.StatusCode()
-	if parsing.IsHTTPNotFound(statusCode) {
-		return "", sources.ApplicationNotFoundErr
-	}
-	if !parsing.IsHTTPStatus2xx(statusCode) {
-		return "", sources.SourcesClientErr
-	}
-
-	appTypeId, err := client.GetProvisioningTypeId(ctx, AddIdentityHeader)
-	if err != nil {
-		return "", fmt.Errorf("cannot get provisioning app type: %w", err)
-	}
-
-	if *res.JSON200.ApplicationTypeId == appTypeId {
-		return *auth.Username, nil
-
-	}
-	return "", fmt.Errorf("cannot find authentication linked to source id %s and to the provisioning app: %w", sourceId, err)
-}
-
-func filterSourceAuthentications(authentications *[]sources.AuthenticationRead) (sources.AuthenticationRead, error) {
-	auths := *authentications
-	list := make([]sources.AuthenticationRead, 0, len(auths))
-	for _, auth := range auths {
-		if *auth.ResourceType == "Application" {
-			list = append(list, auth)
-		}
-	}
-	// Assumption: each source has one authentication linked to it
-	if len(list) > 1 {
-		return sources.AuthenticationRead{}, sources.MoreThenOneAuthenticationForSourceErr
-	}
-	return list[0], nil
 }


### PR DESCRIPTION
The changes here:

- Changed the location of FetchARN and FilterSourceAuthentications to be as part of sources_impl and not sources_service 
- Added FetchARN and FilterSourceAuthentications to be a part of sources_interface
- Changed the naming of init_store to sources 
- Added authentication stub 
- Added test for FetchARN
- Extract AddIdentityHeader function from the services packages so it will be reachable in sources packages (cycle importing)
