### PR TITLE
Add podman push for short SHA

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -33,4 +33,5 @@ make build-podman \
 
 # push to logged in registries and tag for SHA
 podman tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SMOKE_TEST_TAG}"
+podman push "${IMAGE}:${IMAGE_TAG}"
 podman push "${IMAGE}:${SMOKE_TEST_TAG}"


### PR DESCRIPTION
Builds are only pushing latest tag, missed this as the make rule for container build doesn't include a push. 
