### PR TITLE
Keep only account id in the context

### DIFF
--- a/internal/ctxval/context_values.go
+++ b/internal/ctxval/context_values.go
@@ -3,7 +3,6 @@ package ctxval
 import (
 	"context"
 
-	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -15,7 +14,7 @@ const (
 	loggerCtxKey     commonKeyId = iota
 	requestIdCtxKey  commonKeyId = iota
 	requestNumCtxKey commonKeyId = iota
-	accountCtxKey    commonKeyId = iota
+	accountIdCtxKey  commonKeyId = iota
 )
 
 // Identity returns identity header struct or nil when not set.
@@ -58,10 +57,10 @@ func WithRequestNumber(ctx context.Context, num uint64) context.Context {
 }
 
 // Account returns current account model or nil when not set.
-func Account(ctx context.Context) *models.Account {
-	return ctx.Value(accountCtxKey).(*models.Account)
+func AccountId(ctx context.Context) int64 {
+	return ctx.Value(accountIdCtxKey).(int64)
 }
 
-func WithAccount(ctx context.Context, account *models.Account) context.Context {
-	return context.WithValue(ctx, accountCtxKey, account)
+func WithAccountId(ctx context.Context, accountId int64) context.Context {
+	return context.WithValue(ctx, accountIdCtxKey, accountId)
 }

--- a/internal/dao/sqlx/account_dao.go
+++ b/internal/dao/sqlx/account_dao.go
@@ -23,7 +23,7 @@ const (
 )
 
 func ctxAccountId(ctx context.Context) int64 {
-	return ctxval.Account(ctx).ID
+	return ctxval.AccountId(ctx)
 }
 
 type accountDaoSqlx struct {

--- a/internal/dao/stubs/context_getters.go
+++ b/internal/dao/stubs/context_getters.go
@@ -15,7 +15,7 @@ const (
 )
 
 func ctxAccountId(ctx context.Context) int64 {
-	return ctxval.Account(ctx).ID
+	return ctxval.AccountId(ctx)
 }
 
 func WithPubkeyDao(parent context.Context) context.Context {

--- a/internal/middleware/account.go
+++ b/internal/middleware/account.go
@@ -25,7 +25,7 @@ func AccountMiddleware(next http.Handler) http.Handler {
 		}
 
 		newLogger := logger.With().Str("org_id", acc.OrgID).Str("account_number", *acc.AccountNumber).Logger()
-		ctx := ctxval.WithAccount(r.Context(), acc)
+		ctx := ctxval.WithAccountId(r.Context(), acc.ID)
 		ctx = ctxval.WithLogger(ctx, &newLogger)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}

--- a/internal/middleware/account_test.go
+++ b/internal/middleware/account_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/dao/stubs"
 	"github.com/RHEnVision/provisioning-backend/internal/middleware"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
@@ -28,8 +29,8 @@ func TestAccountMiddleware(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		isAccInNext := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var acc = ctxval.Account(r.Context())
-			assert.NotNil(t, acc, "account was not set")
+			var acc = ctxval.AccountId(r.Context())
+			assert.NotNil(t, acc, "account id was not set")
 		})
 
 		handler := middleware.AccountMiddleware(isAccInNext)
@@ -45,8 +46,16 @@ func TestAccountMiddleware(t *testing.T) {
 		rr := httptest.NewRecorder()
 
 		isAccInNext := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var acc = ctxval.Account(r.Context())
-			assert.NotNil(t, acc, "account was not set")
+			var accId = ctxval.AccountId(r.Context())
+			assert.NotNil(t, accId, "account id was not set")
+			accDao, innerErr := dao.GetAccountDao(r.Context())
+			if innerErr != nil {
+				t.Errorf("failed to initialize account: %v", err)
+			}
+			acc, innerErr := accDao.GetById(r.Context(), accId)
+			if innerErr != nil {
+				t.Errorf("could not fetch account by id: %v", err)
+			}
 			assert.Equal(t, "124", acc.OrgID)
 		})
 

--- a/internal/models/validator.go
+++ b/internal/models/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/go-playground/validator/v10"
 	"golang.org/x/crypto/ssh"
 )
@@ -23,8 +24,7 @@ func Validate(ctx context.Context, model interface{}) validator.ValidationErrors
 	err := validate.StructCtx(ctx, model)
 	var validationError validator.ValidationErrors
 	if err != nil && !errors.As(err, &validationError) {
-		// dependency cycle
-		//ctxval.Logger(ctx).Fatal().Msgf("Invalid model passed for validation: %v", model)
+		ctxval.Logger(ctx).Fatal().Msgf("Invalid model passed for validation: %v", model)
 		panic(err)
 	}
 	return validationError

--- a/internal/testing/identity/dummy_identity.go
+++ b/internal/testing/identity/dummy_identity.go
@@ -45,7 +45,7 @@ func WithTenant(t *testing.T, ctx context.Context) context.Context {
 	if err != nil {
 		t.Errorf("failed to fetch account for default identity %v", err)
 	}
-	return ctxval.WithAccount(ctx, acc)
+	return ctxval.WithAccountId(ctx, acc.ID)
 }
 
 func newIdentity(orgId string, accountNumber *string) rhidentity.XRHID {


### PR DESCRIPTION
Keeping the whole account in the context is bit troublesome.