### PR TITLE
Generalize testing factories

### DIFF
--- a/internal/dao/stubs/model_factories.go
+++ b/internal/dao/stubs/model_factories.go
@@ -2,45 +2,14 @@ package stubs
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"fmt"
 
 	"github.com/RHEnVision/provisioning-backend/internal/models"
-	"golang.org/x/crypto/ssh"
 )
 
-// GeneratePubkey generates a pubkey and stores it in the context stub
-func GeneratePubkey(ctx context.Context, pubkey models.Pubkey) error {
+func AddPubkey(ctx context.Context, pubkey *models.Pubkey) error {
 	pubkeyDao, err := getPubkeyDaoStub(ctx)
 	if err != nil {
 		return err
 	}
-	if pubkey.AccountID == 0 {
-		pubkey.AccountID = 1
-	}
-	if pubkey.Name == "" {
-		pubkey.Name = fmt.Sprintf("pubkey %d", pubkeyDao.lastId+1)
-	}
-	if pubkey.Body == "" {
-		if pubkey.Body, err = generateRandomRSAPubKey(ctx); err != nil {
-			return err
-		}
-	}
-	if err = pubkeyDao.Create(ctx, &pubkey); err != nil {
-		return err
-	}
-	return nil
-}
-
-func generateRandomRSAPubKey(_ context.Context) (string, error) {
-	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return "", RSAGenerationError
-	}
-	pubkey, err := ssh.NewPublicKey(&rsaKey.PublicKey)
-	if err != nil {
-		return "", RSAGenerationError
-	}
-	return string(ssh.MarshalAuthorizedKey(pubkey)), nil
+	return pubkeyDao.Create(ctx, pubkey)
 }

--- a/internal/dao/stubs/stub_errors.go
+++ b/internal/dao/stubs/stub_errors.go
@@ -10,7 +10,6 @@ import (
 
 var ContextReadError = errors.New("missing variable in context")
 var ContextSecondInitializationError = errors.New("trying to initialize context twice, please avoid that")
-var RSAGenerationError = errors.New("rsa key generation failed")
 
 func NewRecordNotFoundError(ctx context.Context, stubName dao.NamedForError) dao.NoRowsError {
 	return dao.NoRowsError{

--- a/internal/services/pubkey_service_test.go
+++ b/internal/services/pubkey_service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/dao/stubs"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/testing/factories"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,12 +20,25 @@ func TestListPubkeysHandler(t *testing.T) {
 	ctx := stubs.WithAccountDaoOne(context.Background())
 	ctx = identity.WithTenant(t, ctx)
 	ctx = stubs.WithPubkeyDao(ctx)
-	err := stubs.GeneratePubkey(ctx, models.Pubkey{})
-	assert.Nil(t, err, fmt.Sprintf("Error while generating a pubkey: %v", err))
-	err = stubs.GeneratePubkey(ctx, models.Pubkey{})
-	assert.Nil(t, err, fmt.Sprintf("Error while generating a pubkey: %v", err))
+	err := stubs.AddPubkey(ctx, &models.Pubkey{
+		Name: factories.GetSequenceName("pubkey"),
+		Body: factories.GenerateRSAPubKey(t),
+	})
+	if err != nil {
+		t.Fatalf("failed to add stubbed key: %v", err)
+	}
+	err = stubs.AddPubkey(ctx, &models.Pubkey{
+		Name: factories.GetSequenceName("pubkey"),
+		Body: factories.GenerateRSAPubKey(t),
+	})
+	if err != nil {
+		t.Fatalf("failed to add stubbed key: %v", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "GET", "/api/provisioning/pubkeys", nil)
+	if err != nil {
+		t.Fatalf("Error creating a new request: %v", err)
+	}
 	assert.Nil(t, err, fmt.Sprintf("Error creating a new request: %v", err))
 
 	rr := httptest.NewRecorder()

--- a/internal/testing/factories/factories.go
+++ b/internal/testing/factories/factories.go
@@ -1,0 +1,31 @@
+package factories
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var nameSequence uint64 = 1
+
+func GetSequenceName(prefix string) string {
+	return fmt.Sprintf("%s %d", prefix, atomic.AddUint64(&nameSequence, 1))
+}
+
+// GenerateRSAPubKey generates pubkey for use in tests
+func GenerateRSAPubKey(t *testing.T) string {
+	t.Helper()
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate pubky: %v", err)
+	}
+	pubkey, err := ssh.NewPublicKey(&rsaKey.PublicKey)
+	if err != nil {
+		t.Fatalf("Failed to generate pubky: %v", err)
+	}
+	return string(ssh.MarshalAuthorizedKey(pubkey))
+}


### PR DESCRIPTION
Factories should be usable in unit and DAO tests alike.

Adding `testing/factories` package, that should host model generation methods for tests.
