### PR TITLE
Use setup/teardown for DAO tests, truncate tables instead of seeding

### DIFF
--- a/cmd/dao_tests/main_test.go
+++ b/cmd/dao_tests/main_test.go
@@ -17,8 +17,6 @@ import (
 )
 
 func setup() {
-	dbDrop()
-	dbMigrate()
 	dbSeed()
 }
 
@@ -59,6 +57,8 @@ func dbSeed() {
 
 func TestMain(t *testing.M) {
 	initEnvironment()
+	dbDrop()
+	dbMigrate()
 	exitVal := t.Run()
 	dbDrop()
 	os.Exit(exitVal)

--- a/cmd/dao_tests/main_test.go
+++ b/cmd/dao_tests/main_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+// +build integration
+
+// To override application configuration for integration tests, copy local.yaml into this directory.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/db"
+	"github.com/RHEnVision/provisioning-backend/internal/logging"
+	"github.com/rs/zerolog/log"
+)
+
+func setup() {
+	dbDrop()
+	dbMigrate()
+	dbSeed()
+}
+
+func teardown() {
+	// nothing
+}
+
+func initEnvironment() {
+	config.Initialize()
+	log.Logger = logging.InitializeStdout()
+
+	err := db.Initialize("integration")
+	if err != nil {
+		panic(fmt.Errorf("cannot connect to database, create cmd/dao_tests/local.yaml: %v", err))
+	}
+}
+
+func dbDrop() {
+	err := db.Seed("drop_integration")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func dbMigrate() {
+	err := db.Migrate("integration")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func dbSeed() {
+	err := db.Seed("dao_test")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestMain(t *testing.M) {
+	initEnvironment()
+	exitVal := t.Run()
+	dbDrop()
+	os.Exit(exitVal)
+}

--- a/cmd/dao_tests/pubkey_test.go
+++ b/cmd/dao_tests/pubkey_test.go
@@ -78,18 +78,18 @@ func TestUpdatePubkey(t *testing.T) {
 	defer teardownPubkey(t)
 	err := pkDao.Create(ctx, createPk())
 	if err != nil {
-		t.Errorf("Create pubkey test had failed. %s", err)
+		t.Errorf("Create pubkey test failed. %s", err)
 		return
 	}
 	err = pkDao.Update(ctx, updatePk)
 	if err != nil {
-		t.Errorf("Update pubkey test had failed. %s", err)
+		t.Errorf("Update pubkey test failed. %s", err)
 		return
 	}
 
 	pubkeys, err := pkDao.List(ctx, 10, 0)
 	if err != nil {
-		t.Errorf("Update pubkey test had failed. %s", err)
+		t.Errorf("Update pubkey test failed. %s", err)
 		return
 	}
 	assert.Equal(t, updatePk.Name, pubkeys[0].Name, "Update pubkey test had failed.")

--- a/cmd/dao_tests/reservation_test.go
+++ b/cmd/dao_tests/reservation_test.go
@@ -44,29 +44,24 @@ func createAWSReservation() *models.AWSReservation {
 	}
 }
 
-func SetupReservation(t *testing.T, s string) (dao.ReservationDao, context.Context, error) {
-	err := db.Seed("dao_test")
-	if err != nil {
-		t.Errorf("Error purging the database: %v", err)
-		return nil, nil, err
-	}
+func setupReservation(t *testing.T) (dao.ReservationDao, context.Context) {
+	setup()
 	ctx := identity.WithTenant(t, context.Background())
 	reservationDao, err := dao.GetReservationDao(ctx)
 	if err != nil {
-		t.Errorf("%s test failed: %v", s, err)
-		return nil, nil, err
+		panic(err)
 	}
-	return reservationDao, ctx, nil
+	return reservationDao, ctx
+}
+
+func teardownReservation(_ *testing.T) {
+	teardown()
 }
 
 func TestCreateNoop(t *testing.T) {
-	CleanUpDatabase(t)
-	reservationDao, ctx, err := SetupReservation(t, "Create noop reservation")
-	if err != nil {
-		t.Errorf("Database setup failed: %v", err)
-		return
-	}
-	err = reservationDao.CreateNoop(ctx, createNoopReservation())
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
+	err := reservationDao.CreateNoop(ctx, createNoopReservation())
 	if err != nil {
 		t.Errorf("createNoop failed: %v", err)
 		return
@@ -82,13 +77,9 @@ func TestCreateNoop(t *testing.T) {
 }
 
 func TestCreateAWS(t *testing.T) {
-	CleanUpDatabase(t)
-	reservationDao, ctx, err := SetupReservation(t, "Create AWS reservation")
-	if err != nil {
-		t.Errorf("Database setup failed: %v", err)
-		return
-	}
-	err = reservationDao.CreateAWS(ctx, createAWSReservation())
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
+	err := reservationDao.CreateAWS(ctx, createAWSReservation())
 	if err != nil {
 		t.Errorf("createAWS failed: %v", err)
 		return
@@ -104,15 +95,11 @@ func TestCreateAWS(t *testing.T) {
 }
 
 func TestCreateInstance(t *testing.T) {
-	CleanUpDatabase(t)
-	reservationDao, ctx, err := SetupReservation(t, "Create Instance reservation")
-	if err != nil {
-		t.Errorf("Database setup failed: %v", err)
-		return
-	}
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
 
 	reservation := createAWSReservation()
-	err = reservationDao.CreateAWS(ctx, reservation)
+	err := reservationDao.CreateAWS(ctx, reservation)
 	if err != nil {
 		t.Errorf("createAWS failed: %v", err)
 		return
@@ -134,13 +121,9 @@ func TestCreateInstance(t *testing.T) {
 }
 
 func TestListReservation(t *testing.T) {
-	CleanUpDatabase(t)
-	reservationDao, ctx, err := SetupReservation(t, "List reservation")
-	if err != nil {
-		t.Errorf("Database setup failed: %v", err)
-		return
-	}
-	err = reservationDao.CreateAWS(ctx, createAWSReservation())
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
+	err := reservationDao.CreateAWS(ctx, createAWSReservation())
 	if err != nil {
 		t.Errorf("createAWS failed: %v", err)
 		return
@@ -160,16 +143,11 @@ func TestListReservation(t *testing.T) {
 }
 
 func TestUpdateReservationIDForAWS(t *testing.T) {
-	CleanUpDatabase(t)
-	reservationDao, ctx, err := SetupReservation(t, "Update status reservation")
-	if err != nil {
-		t.Errorf("Database setup failed. %s", err)
-		return
-	}
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
 
 	reservation := createAWSReservation()
-
-	err = reservationDao.CreateAWS(ctx, reservation)
+	err := reservationDao.CreateAWS(ctx, reservation)
 	if err != nil {
 		t.Errorf("createAWS failed: %v", err)
 		return
@@ -200,13 +178,9 @@ func TestUpdateReservationIDForAWS(t *testing.T) {
 }
 
 func TestUpdateStatusReservation(t *testing.T) {
-	CleanUpDatabase(t)
-	reservationDao, ctx, err := SetupReservation(t, "Update status reservation")
-	if err != nil {
-		t.Errorf("Database setup failed. %s", err)
-		return
-	}
-	err = reservationDao.CreateNoop(ctx, createNoopReservation())
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
+	err := reservationDao.CreateNoop(ctx, createNoopReservation())
 	if err != nil {
 		t.Errorf("createNoop failed. %s", err)
 		return
@@ -233,13 +207,9 @@ func TestUpdateStatusReservation(t *testing.T) {
 }
 
 func TestDeleteReservation(t *testing.T) {
-	CleanUpDatabase(t)
-	reservationDao, ctx, err := SetupReservation(t, "Delete reservation")
-	if err != nil {
-		t.Errorf("Database setup failed: %v", err)
-		return
-	}
-	err = reservationDao.CreateNoop(ctx, createNoopReservation())
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
+	err := reservationDao.CreateNoop(ctx, createNoopReservation())
 	if err != nil {
 		t.Errorf("createNoop failed: %v", err)
 		return
@@ -265,13 +235,9 @@ func TestDeleteReservation(t *testing.T) {
 }
 
 func TestFinishReservation(t *testing.T) {
-	CleanUpDatabase(t)
-	reservationDao, ctx, err := SetupReservation(t, "Delete reservation")
-	if err != nil {
-		t.Errorf("Database setup failed: %v", err)
-		return
-	}
-	err = reservationDao.CreateNoop(ctx, createNoopReservation())
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
+	err := reservationDao.CreateNoop(ctx, createNoopReservation())
 	if err != nil {
 		t.Errorf("createNoop failed: %v", err)
 		return

--- a/internal/db/seeds/dao_test.sql
+++ b/internal/db/seeds/dao_test.sql
@@ -1,11 +1,24 @@
 --
--- Testing seed data, to execute this file during migration set DB_SEED variable to "dao_test".
+-- Truncate and seed test data. Only use for testing!
 --
 BEGIN;
 
+-- Truncate all tables in the integration schema
+DO
+$do$
+  BEGIN
+    EXECUTE
+      (SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' CASCADE'
+       FROM pg_class
+       WHERE relkind = 'r'
+         AND relnamespace = 'integration'::regnamespace);
+  END
+$do$;
+
+-- Seed the data
 INSERT INTO accounts(id, account_number, org_id)
 VALUES (1, '1', '1')
-  ON CONFLICT DO NOTHING;
+ON CONFLICT DO NOTHING;
 
 INSERT INTO pubkeys(id, account_id, name, body)
 VALUES (1, 1, 'lzap-ed25519-2021',


### PR DESCRIPTION
There are two commits in this PR.

The first one improves the DAO tests in general:

* Generic functions were moved into main_test.go and are not exported.
* There are now global `setup` and `teardown` functions and `setupPubkey` etc functions in each file for more specific setup code.
* All setup functions were renamed and broken down into `dbDrop`, `dbMigrate` and `dbSeed` to better reflect what they do.
* Error handling was vastly simplified - for fatal error states (cannot connect to DB, cannot migrate or seed) using `panic` is completely fine because this is a fatal state anyway. Setup functions themselves no longer return errors which makes the code longer due to use of panic keyword.
* Teardown functions are called via `defer`.

The second commit then switches from migrating the database for each test to more straightforward approach - the database is seeded just once and then every test all tables are truncated. This makes DAO tests faster, for me it dropped from 6 seconds down to 4.3 seconds. It's not much, but this feels cleaner.