### PR TITLE
Client proxy support with basic auth for stage

### DIFF
--- a/cmd/pbapi/main.go
+++ b/cmd/pbapi/main.go
@@ -3,7 +3,11 @@ package main
 import (
 	"syscall"
 
-	// Performs initialization of DAO implementation, must be initialized before any database packages.
+	// HTTP client implementations
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/image_builder"
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/sources"
+
+	// DAO implementation, must be initialized before any database packages.
 	_ "github.com/RHEnVision/provisioning-backend/internal/dao/sqlx"
 	"github.com/RHEnVision/provisioning-backend/internal/jobs"
 

--- a/configs/local_example.yaml
+++ b/configs/local_example.yaml
@@ -39,9 +39,19 @@ cloudwatch:
 
 restEndpoints:
   imageBuilder:
-    url:
+    url: https://xxx.stage.redhat.com/api/image-builder/v1
+    # basic auth and proxy is only useful for development against stage
+    username: stage-account
+    password: only_for_development
+    proxy:
+      url: http://squid.xxx.redhat.com:3128
   sources:
-    url:
+    url: https://xxx.stage.redhat.com/api/sources/v3.1
+    # basic auth and proxy is only useful for development against stage
+    username: stage-account
+    password: only_for_development
+    proxy:
+      url: http://squid.xxx.redhat.com:3128
 
 featureFlags:
   # development or production

--- a/internal/clients/clients_interfaces.go
+++ b/internal/clients/clients_interfaces.go
@@ -13,6 +13,8 @@ type Sources interface {
 	GetArn(ctx context.Context, sourceId ID) (string, error)
 	// GetProvisioningTypeId might not need exposing
 	GetProvisioningTypeId(ctx context.Context) (string, error)
+	// Ready returns readiness information
+	Ready(ctx context.Context) error
 }
 
 var GetImageBuilderClient func(ctx context.Context) (ImageBuilder, error)
@@ -20,4 +22,6 @@ var GetImageBuilderClient func(ctx context.Context) (ImageBuilder, error)
 type ImageBuilder interface {
 	// GetAWSAmi returns related AWS image AMI identifer
 	GetAWSAmi(ctx context.Context, composeID string) (string, error)
+	// Ready returns readiness information
+	Ready(ctx context.Context) error
 }

--- a/internal/clients/image_builder/image_client.go
+++ b/internal/clients/image_builder/image_client.go
@@ -20,11 +20,37 @@ func init() {
 }
 
 func newImageBuilderClient(ctx context.Context) (clients.ImageBuilder, error) {
-	c, err := NewClientWithResponses(config.ImageBuilder.URL)
+	c, err := NewClientWithResponses(config.ImageBuilder.URL, func(c *Client) error {
+		if config.ImageBuilder.Proxy.URL != "" {
+			if config.Features.Environment != "development" {
+				return clients.ClientProxyProductionUseErr
+			}
+			client, err := clients.NewProxyDoer(ctx, config.ImageBuilder.Proxy.URL)
+			if err != nil {
+				return fmt.Errorf("cannot create proxy doer: %w", err)
+			}
+			c.Client = client
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 	return &ImageBuilderClient{client: c}, nil
+}
+
+func (c *ImageBuilderClient) Ready(ctx context.Context) error {
+	resp, err := c.client.GetReadiness(ctx, headers.AddImageBuilderIdentityHeader)
+	if err != nil {
+		ctxval.Logger(ctx).Error().Err(err).Msgf("Readiness request failed for image builder: %s", err.Error())
+		return err
+	}
+	defer resp.Body.Close()
+	if !parsing.IsHTTPStatus2xx(resp.StatusCode) {
+		ctxval.Logger(ctx).Warn().Msgf("Readiness response from image builder: %d", resp.StatusCode)
+		return ClientErr
+	}
+	return nil
 }
 
 func (c *ImageBuilderClient) GetAWSAmi(ctx context.Context, composeID string) (string, error) {
@@ -47,7 +73,7 @@ func (c *ImageBuilderClient) GetAWSAmi(ctx context.Context, composeID string) (s
 
 func (c *ImageBuilderClient) fetchImageStatus(ctx context.Context, composeID string) (*UploadStatus, error) {
 	ctxval.Logger(ctx).Info().Msgf("Fetching image status %v", composeID)
-	resp, err := c.client.GetComposeStatusWithResponse(ctx, composeID, headers.AddIdentityHeader)
+	resp, err := c.client.GetComposeStatusWithResponse(ctx, composeID, headers.AddImageBuilderIdentityHeader)
 	if err != nil {
 		ctxval.Logger(ctx).Warn().Err(err).Msg("Failed to fetch image status from image builder")
 		return nil, fmt.Errorf("cannot get compose status: %w", err)

--- a/internal/clients/image_builder/stubs/image_builder_stub.go
+++ b/internal/clients/image_builder/stubs/image_builder_stub.go
@@ -34,6 +34,10 @@ func getImageBuilderClientStub(ctx context.Context) (si clients.ImageBuilder, er
 	}
 	return si, err
 }
+func (_ *ImageBuilderClientStub) Ready(ctx context.Context) error {
+	return nil
+}
+
 func (mock *ImageBuilderClientStub) GetAWSAmi(ctx context.Context, composeID string) (string, error) {
 	return "ami-0c830793775595d4b-test", nil
 }

--- a/internal/clients/proxy_doer.go
+++ b/internal/clients/proxy_doer.go
@@ -1,0 +1,44 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+)
+
+var ClientProxyProductionUseErr = errors.New("client proxy cannot be used in production mode")
+
+type ProxyClient struct {
+	ctx    context.Context
+	url    *url.URL
+	client *http.Client
+}
+
+func NewProxyDoer(ctx context.Context, URL string) (*ProxyClient, error) {
+	proxyURL, err := url.Parse(URL)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create proxy doer: %w", err)
+	}
+	transport := &http.Transport{
+		Proxy: http.ProxyURL(proxyURL),
+	}
+	client := ProxyClient{
+		ctx:    ctx,
+		url:    proxyURL,
+		client: &http.Client{Transport: transport},
+	}
+	return &client, nil
+}
+
+func (c *ProxyClient) Do(req *http.Request) (*http.Response, error) {
+	ctxval.Logger(c.ctx).Trace().Msgf("Proxy request to %s via %s", req.URL, c.url.String())
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot proxy request: %w", err)
+	}
+	return resp, nil
+}

--- a/internal/clients/sources/stubs/sources_stub.go
+++ b/internal/clients/sources/stubs/sources_stub.go
@@ -43,6 +43,11 @@ func getSourcesClientStub(ctx context.Context) (si clients.Sources, err error) {
 	}
 	return si, err
 }
+
+func (_ *SourcesClientStub) Ready(ctx context.Context) error {
+	return nil
+}
+
 func (mock *SourcesClientStub) GetArn(ctx context.Context, sourceId sources.ID) (string, error) {
 	return "arn:aws:iam::230214684733:role/Test", nil
 }

--- a/internal/config/main_config.go
+++ b/internal/config/main_config.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+type proxy struct {
+	URL string
+}
+
 var config struct {
 	App struct {
 		Name    string
@@ -58,10 +62,16 @@ var config struct {
 	}
 	RestEndpoints struct {
 		ImageBuilder struct {
-			URL string
+			URL      string
+			Username string
+			Password string
+			Proxy    proxy
 		}
 		Sources struct {
-			URL string
+			URL      string
+			Username string
+			Password string
+			Proxy    proxy
 		}
 	}
 	Worker struct {

--- a/internal/headers/headers.go
+++ b/internal/headers/headers.go
@@ -2,12 +2,37 @@ package headers
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-func AddIdentityHeader(ctx context.Context, req *http.Request) error {
-	req.Header.Set("x-rh-identity", identity.GetIdentityHeader(ctx))
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+func addIdentityHeader(ctx context.Context, req *http.Request, username, password string) error {
+	if username != "" && password != "" {
+		ctxval.Logger(ctx).Warn().Msgf("Username/password authentication: %s", username)
+		req.Header.Add("Authorization", "Basic "+basicAuth(username, password))
+	} else {
+		req.Header.Set("X-RH-Identity", identity.GetIdentityHeader(ctx))
+	}
 	return nil
+}
+
+func AddSourcesIdentityHeader(ctx context.Context, req *http.Request) error {
+	username := config.Sources.Username
+	password := config.Sources.Password
+	return addIdentityHeader(ctx, req, username, password)
+}
+
+func AddImageBuilderIdentityHeader(ctx context.Context, req *http.Request) error {
+	username := config.ImageBuilder.Username
+	password := config.ImageBuilder.Password
+	return addIdentityHeader(ctx, req, username, password)
 }

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -35,6 +35,14 @@ func apiRouter() http.Handler {
 	r.Group(func(r chi.Router) {
 		r.Use(identity.EnforceIdentity)
 		r.Use(middleware.AccountMiddleware)
+
+		r.Route("/ready", func(r chi.Router) {
+			r.Get("/", s.ReadyService)
+			r.Route("/{SRV}", func(r chi.Router) {
+				r.Get("/", s.ReadyBackendService)
+			})
+		})
+
 		r.Route("/sources", func(r chi.Router) {
 			r.Get("/", s.ListSources)
 		})

--- a/scripts/rest_examples/http-client.env.json
+++ b/scripts/rest_examples/http-client.env.json
@@ -4,5 +4,11 @@
     "port": "8000",
     "prefix": "api/provisioning/v1",
     "identity": "eyJpZGVudGl0eSI6IHsidHlwZSI6ICJVc2VyIiwgImFjY291bnRfbnVtYmVyIjoiMTMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDEzIn19fQo="
+  },
+  "stage-id": {
+    "hostname": "localhost",
+    "port": "8000",
+    "prefix": "api/provisioning/v1",
+    "identity": "eyJpZGVudGl0eSI6IHsidHlwZSI6ICJVc2VyIiwgImFjY291bnRfbnVtYmVyIjoiNjM5NTM0MyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMzQ0NjY1OSJ9fX0K"
   }
 }

--- a/scripts/rest_examples/status-ready-ib.http
+++ b/scripts/rest_examples/status-ready-ib.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/ready/ib HTTP/1.1
+Content-Type: application/json
+X-RH-Identity: {{identity}}

--- a/scripts/rest_examples/status-ready-sources.http
+++ b/scripts/rest_examples/status-ready-sources.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/ready/sources HTTP/1.1
+Content-Type: application/json
+X-RH-Identity: {{identity}}

--- a/scripts/rest_examples/status-ready.http
+++ b/scripts/rest_examples/status-ready.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/ready HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}


### PR DESCRIPTION
This patch is continuation of https://github.com/RHEnVision/provisioning-backend/pull/150

The idea is to introduce HTTP client configurable proxy per individual service (sources, ib). This is meant for development use against stage. Unfortunately, RHID header cannot be used in this scenario, therefore optional basic auth was added. This is only meant for development, in test/stage/prod environments the basic auth will be blank therefore RHID will be passed instead.