### PR TITLE
Add image builder as clowder dependency

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -163,6 +163,8 @@ objects:
       inMemoryDb: true
       dependencies:
         - sources-api
+      optionalDependencies:
+        - image-builder
 
 # possible application ENV variables are in config/api.env.example
 parameters:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,6 +215,9 @@ func Initialize(configFiles ...string) {
 		if endpoint, ok := clowder.DependencyEndpoints["sources-api"]["svc"]; ok {
 			config.RestEndpoints.Sources.URL = fmt.Sprintf("http://%s:%d/api/sources/v3.1", endpoint.Hostname, endpoint.Port)
 		}
+		if endpoint, ok := clowder.DependencyEndpoints["image-builder"]["svc"]; ok {
+			config.RestEndpoints.Sources.URL = fmt.Sprintf("http://%s:%d/api/image-builder/v1", endpoint.Hostname, endpoint.Port)
+		}
 	}
 
 	// validate configuration


### PR DESCRIPTION
We now have IB in ephemeral, so adding the `image-builder` as optional dependency, not to break stage (where image-builder is still not deployed with clowder).

This will find IB config through clowder if there is one, but will not force it's presence.