### PR TITLE
Use Request/Response suffixes in OpenAPI schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ TAGS
 /scripts/sources-*/
 /scripts/sources.local.conf
 /scripts/rest_examples/*.local.http
+/scripts/rest_examples/*.private.env.json
 /dao_tests.test

--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -86,7 +86,7 @@
         },
         "type": "object"
       },
-      "v1.Account": {
+      "v1.AccountRequest": {
         "properties": {
           "account_number": {
             "type": "string"
@@ -101,7 +101,22 @@
         },
         "type": "object"
       },
-      "v1.InstanceType": {
+      "v1.AccountResponse": {
+        "properties": {
+          "account_number": {
+            "type": "string"
+          },
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "org_id": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.InstanceTypeResponse": {
         "properties": {
           "id": {
             "type": "string"
@@ -118,7 +133,25 @@
         },
         "type": "object"
       },
-      "v1.Pubkey": {
+      "v1.PubkeyRequest": {
+        "properties": {
+          "body": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.PubkeyResponse": {
         "properties": {
           "body": {
             "type": "string"
@@ -173,7 +206,7 @@
         },
         "type": "object"
       },
-      "v1.Source": {
+      "v1.SourceResponse": {
         "properties": {
           "id": {
             "type": "string"
@@ -223,7 +256,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/v1.InstanceType"
+                  "$ref": "#/components/schemas/v1.InstanceTypeResponse"
                 }
               }
             },
@@ -247,7 +280,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/v1.Pubkey"
+                  "$ref": "#/components/schemas/v1.PubkeyResponse"
                 }
               }
             },
@@ -265,11 +298,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/v1.Pubkey"
+                "$ref": "#/components/schemas/v1.PubkeyRequest"
               }
             }
           },
-          "description": "Name and body are required, fingerprint must not be set, in fact any value is ignored.\n",
+          "description": "request body",
           "required": true
         },
         "responses": {
@@ -277,7 +310,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/v1.Pubkey"
+                  "$ref": "#/components/schemas/v1.PubkeyResponse"
                 }
               }
             },
@@ -310,7 +343,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/v1.Pubkey"
+                  "$ref": "#/components/schemas/v1.PubkeyResponse"
                 }
               }
             },
@@ -325,7 +358,7 @@
         }
       },
       "get": {
-        "description": "A pubkey represents an SSH public portion of a key pair with name and body. The fingerprint field is read-only and any value will be ignored during creation. Pubkeys must have unique name and body (fingerprint) per each account. To find if a pubkey was uploaded to particular cloud, check PubkeyResource resource.\n",
+        "description": "A pubkey represents an SSH public portion of a key pair with name and body. Pubkeys must have unique name and body (SSH public key fingerprint) per each account. To find if a pubkey was uploaded to particular cloud, check PubkeyResource resource.\n",
         "operationId": "getPubkeyById",
         "parameters": [
           {
@@ -344,7 +377,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/v1.Pubkey"
+                  "$ref": "#/components/schemas/v1.PubkeyResponse"
                 }
               }
             },
@@ -444,7 +477,7 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/v1.Source"
+                    "$ref": "#/components/schemas/v1.SourceResponse"
                   },
                   "type": "array"
                 }

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -12,9 +12,8 @@ paths:
     get:
       operationId: getPubkeyById
       description: >
-        A pubkey represents an SSH public portion of a key pair with name and body. The
-        fingerprint field is read-only and any value will be ignored during creation.
-        Pubkeys must have unique name and body (fingerprint) per each account.
+        A pubkey represents an SSH public portion of a key pair with name and body.
+        Pubkeys must have unique name and body (SSH public key fingerprint) per each account.
         To find if a pubkey was uploaded to particular cloud, check PubkeyResource resource.
       parameters:
         - name: ID
@@ -30,7 +29,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.Pubkey'
+                $ref: '#/components/schemas/v1.PubkeyResponse'
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -58,7 +57,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.Pubkey'
+                $ref: '#/components/schemas/v1.PubkeyResponse'
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -74,9 +73,8 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/v1.Pubkey"
-        description: >
-          Name and body are required, fingerprint must not be set, in fact any value is ignored.
+              "$ref": "#/components/schemas/v1.PubkeyRequest"
+        description: request body
         required: true
       responses:
         '200':
@@ -84,7 +82,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.Pubkey'
+                $ref: '#/components/schemas/v1.PubkeyResponse'
         "500":
           $ref: '#/components/responses/InternalError'
     get:
@@ -98,7 +96,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.Pubkey'
+                $ref: '#/components/schemas/v1.PubkeyResponse'
         "500":
           $ref: '#/components/responses/InternalError'
   /sources:
@@ -113,7 +111,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/v1.Source'
+                  $ref: '#/components/schemas/v1.SourceResponse'
         '500':
           $ref: "#/components/responses/InternalError"
   /instance_types/{source_id}:
@@ -134,7 +132,7 @@ paths:
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/v1.InstanceType'
+                  $ref: '#/components/schemas/v1.InstanceTypeResponse'
           '404':
             $ref: "#/components/responses/NotFound"
           '500':
@@ -162,7 +160,7 @@ paths:
       description: >
         A reservation is a way to activate a job, keeps all data needed for a job to start.
         An AWS reservation is a reservation created for an AWS job.
-      requestBody: 
+      requestBody:
         content:
           application/json:
             schema:
@@ -173,7 +171,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/v1.AWSReservationResponse'
+                $ref: '#/components/schemas/v1.AWSReservationResponse'
         "500":
           $ref: '#/components/responses/InternalError'
   /reservations/noop:
@@ -189,7 +187,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/v1.NoopReservationResponse'
+                $ref: '#/components/schemas/v1.NoopReservationResponse'
         "500":
           $ref: '#/components/responses/InternalError'
 components:
@@ -250,7 +248,7 @@ components:
           format: int64
           type: integer
       type: object
-    v1.Account:
+    v1.AccountRequest:
       properties:
         account_number:
           type: string
@@ -260,7 +258,17 @@ components:
         org_id:
           type: string
       type: object
-    v1.InstanceType:
+    v1.AccountResponse:
+      properties:
+        account_number:
+          type: string
+        id:
+          format: int64
+          type: integer
+        org_id:
+          type: string
+      type: object
+    v1.InstanceTypeResponse:
       properties:
         id:
           type: string
@@ -271,7 +279,19 @@ components:
           format: int64
           type: integer
       type: object
-    v1.Pubkey:
+    v1.PubkeyRequest:
+      properties:
+        body:
+          type: string
+        fingerprint:
+          type: string
+        id:
+          format: int64
+          type: integer
+        name:
+          type: string
+      type: object
+    v1.PubkeyResponse:
       properties:
         body:
           type: string
@@ -308,7 +328,7 @@ components:
         request_id:
           type: string
       type: object
-    v1.Source:
+    v1.SourceResponse:
       properties:
         id:
           type: string

--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -48,15 +48,19 @@ func main() {
 	gen := APISchemaGen{}
 	gen.init()
 	// payloads
-	gen.addSchema("v1.Account", &payloads.AccountPayload{})
-	gen.addSchema("v1.Pubkey", &payloads.PubkeyPayload{})
-	gen.addSchema("v1.ResponseError", &payloads.ResponseError{})
-	gen.addSchema("v1.Source", &payloads.SourceResponse{})
-	gen.addSchema("v1.InstanceType", &payloads.InstanceTypeResponse{})
+	gen.addSchema("v1.AccountRequest", &payloads.AccountRequest{})
+	gen.addSchema("v1.AccountResponse", &payloads.AccountResponse{})
+	gen.addSchema("v1.PubkeyRequest", &payloads.PubkeyRequest{})
+	gen.addSchema("v1.PubkeyResponse", &payloads.PubkeyResponse{})
+	gen.addSchema("v1.SourceResponse", &payloads.SourceResponse{})
+	gen.addSchema("v1.InstanceTypeResponse", &payloads.InstanceTypeResponse{})
 	gen.addSchema("v1.ReservationResponse", &payloads.GenericReservationResponsePayload{})
 	gen.addSchema("v1.NoopReservationResponse", &payloads.NoopReservationResponsePayload{})
-	gen.addSchema("v1.AWSReservationResponse", &payloads.AWSReservationResponsePayload{})
 	gen.addSchema("v1.AWSReservationRequest", &payloads.AWSReservationRequestPayload{})
+	gen.addSchema("v1.AWSReservationResponse", &payloads.AWSReservationResponsePayload{})
+
+	// error payloads
+	gen.addSchema("v1.ResponseError", &payloads.ResponseError{})
 
 	// errors
 	gen.addResponse("NotFound", "The specified resource was not found", "#/components/schemas/v1.ResponseError")

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -12,9 +12,8 @@ paths:
     get:
       operationId: getPubkeyById
       description: >
-        A pubkey represents an SSH public portion of a key pair with name and body. The
-        fingerprint field is read-only and any value will be ignored during creation.
-        Pubkeys must have unique name and body (fingerprint) per each account.
+        A pubkey represents an SSH public portion of a key pair with name and body.
+        Pubkeys must have unique name and body (SSH public key fingerprint) per each account.
         To find if a pubkey was uploaded to particular cloud, check PubkeyResource resource.
       parameters:
         - name: ID
@@ -30,7 +29,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.Pubkey'
+                $ref: '#/components/schemas/v1.PubkeyResponse'
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -58,7 +57,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.Pubkey'
+                $ref: '#/components/schemas/v1.PubkeyResponse'
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -74,9 +73,8 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/v1.Pubkey"
-        description: >
-          Name and body are required, fingerprint must not be set, in fact any value is ignored.
+              "$ref": "#/components/schemas/v1.PubkeyRequest"
+        description: request body
         required: true
       responses:
         '200':
@@ -84,7 +82,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.Pubkey'
+                $ref: '#/components/schemas/v1.PubkeyResponse'
         "500":
           $ref: '#/components/responses/InternalError'
     get:
@@ -98,7 +96,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/v1.Pubkey'
+                $ref: '#/components/schemas/v1.PubkeyResponse'
         "500":
           $ref: '#/components/responses/InternalError'
   /sources:
@@ -113,7 +111,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/v1.Source'
+                  $ref: '#/components/schemas/v1.SourceResponse'
         '500':
           $ref: "#/components/responses/InternalError"
   /instance_types/{source_id}:
@@ -134,7 +132,7 @@ paths:
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/v1.InstanceType'
+                  $ref: '#/components/schemas/v1.InstanceTypeResponse'
           '404':
             $ref: "#/components/responses/NotFound"
           '500':
@@ -162,7 +160,7 @@ paths:
       description: >
         A reservation is a way to activate a job, keeps all data needed for a job to start.
         An AWS reservation is a reservation created for an AWS job.
-      requestBody: 
+      requestBody:
         content:
           application/json:
             schema:
@@ -173,7 +171,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/v1.AWSReservationResponse'
+                $ref: '#/components/schemas/v1.AWSReservationResponse'
         "500":
           $ref: '#/components/responses/InternalError'
   /reservations/noop:
@@ -189,6 +187,6 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/v1.NoopReservationResponse'
+                $ref: '#/components/schemas/v1.NoopReservationResponse'
         "500":
           $ref: '#/components/responses/InternalError'

--- a/scripts/rest_examples/http-client.env.json
+++ b/scripts/rest_examples/http-client.env.json
@@ -4,11 +4,5 @@
     "port": "8000",
     "prefix": "api/provisioning/v1",
     "identity": "eyJpZGVudGl0eSI6IHsidHlwZSI6ICJVc2VyIiwgImFjY291bnRfbnVtYmVyIjoiMTMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDEzIn19fQo="
-  },
-  "stage-id": {
-    "hostname": "localhost",
-    "port": "8000",
-    "prefix": "api/provisioning/v1",
-    "identity": "eyJpZGVudGl0eSI6IHsidHlwZSI6ICJVc2VyIiwgImFjY291bnRfbnVtYmVyIjoiNjM5NTM0MyIsICJpbnRlcm5hbCI6eyJvcmdfaWQiOiIxMzQ0NjY1OSJ9fX0K"
   }
 }


### PR DESCRIPTION
We need to start differentiating between the two because for some endpoints (likely /reservations) these are going to look different.

QA: Nothing is changing effectively, these identifiers are for internal use. Generated clients might change internal structure names tho.