### PR TITLE
Add version information to header and logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 TEST_TAGS?=test
 CONTAINER_BUILD_OPTS ?= --build-arg=quay_expiration=2d
 CONTAINER_IMAGE ?= provisioning-backend
+PACKAGE_BASE = github.com/RHEnVision/provisioning-backend/internal
+LDFLAGS = "-X $(PACKAGE_BASE)/version.BuildCommit=$(shell git rev-parse --short HEAD) -X $(PACKAGE_BASE)/version.BuildTime=$(shell date +'%Y-%m-%d_%T')"
 
 .PHONY: build
 build: build-pbapi build-pbmigrate
 
 .PHONY: build-pbapi
 build-pbapi:
-	CGO_ENABLED=0 go build -o pbapi ./cmd/pbapi
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o pbapi ./cmd/pbapi
 
 .PHONY: build-pbmigrate
 build-pbmigrate:

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,15 @@ PACKAGE_BASE = github.com/RHEnVision/provisioning-backend/internal
 LDFLAGS = "-X $(PACKAGE_BASE)/version.BuildCommit=$(shell git rev-parse --short HEAD) -X $(PACKAGE_BASE)/version.BuildTime=$(shell date +'%Y-%m-%d_%T')"
 
 .PHONY: build
-build: build-pbapi build-pbmigrate
+build: build-pbapi build-pbmigrate build-pbworker
 
 .PHONY: build-pbapi
 build-pbapi:
 	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o pbapi ./cmd/pbapi
+
+.PHONY: build-pbworker
+build-pbworker:
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o pbworker ./cmd/pbworker
 
 .PHONY: build-pbmigrate
 build-pbmigrate:

--- a/cmd/pbapi/main.go
+++ b/cmd/pbapi/main.go
@@ -1,6 +1,12 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
 	"syscall"
 
 	// HTTP client implementations
@@ -9,13 +15,6 @@ import (
 
 	// Job queue implementation
 	"github.com/RHEnVision/provisioning-backend/internal/jobs/queue/dejq"
-
-	"context"
-	"errors"
-	"fmt"
-	"net/http"
-	"os"
-	"os/signal"
 
 	// DAO implementation, must be initialized before any database packages.
 	_ "github.com/RHEnVision/provisioning-backend/internal/dao/sqlx"
@@ -72,6 +71,7 @@ func main() {
 
 	// Routes for the main service
 	r := chi.NewRouter()
+	r.Use(m.VersionMiddleware)
 	r.Use(m.RequestID)
 	r.Use(m.RequestNum)
 	r.Use(m.MetricsMiddleware)

--- a/internal/logging/zerolog.go
+++ b/internal/logging/zerolog.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients/cloudwatchlogs"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/version"
 
 	cww "github.com/lzap/cloudwatchwriter2"
 	"github.com/rs/zerolog"
@@ -37,7 +38,14 @@ func truncateText(str string, length int) string {
 }
 
 func decorate(l zerolog.Logger) zerolog.Logger {
-	return l.With().Timestamp().Str("hostname", hostname).Logger()
+	logger := l.With().Timestamp().
+		Str("hostname", hostname)
+
+	if version.BuildCommit != "" {
+		logger = logger.Str("version", version.BuildCommit)
+	}
+
+	return logger.Logger()
 }
 
 // InitializeStdout initializes logging to standard output with human-friendly output.

--- a/internal/middleware/version.go
+++ b/internal/middleware/version.go
@@ -1,0 +1,18 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/version"
+)
+
+func VersionMiddleware(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		if version.BuildCommit != "" && version.BuildTime != "" {
+			w.Header().Set("X-RH-Version", fmt.Sprintf("%s (%s)", version.BuildCommit, version.BuildTime))
+		}
+		next.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,9 @@
+package version
+
+var (
+	// Git SHA commit set via -ldflags
+	BuildCommit string
+
+	// Build date and time in UTC set via -ldflags
+	BuildTime string
+)


### PR DESCRIPTION
I just experienced what I believe was a testing of an incorrect build artifact. It is worth adding version information (sha commit, build date and time) into HTTP header as well as logs. It should be safe to show this for every request, but I will confirm on Slack.

This patch adds exactly that, all log lines contain "version" string which holds the commit sha. All responses contain new X-Rh-Version header which contains the same plug date and time (in UTC) of comiplation.

When compiling this via IDE (e.g. not via Makefile) no version information will be provided, thus the header will not be present. The same for log field.