### PR TITLE
Use message instead of field for panic messages

### DIFF
--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -47,8 +47,7 @@ func LoggerMiddleware(rootLogger *zerolog.Logger) func(next http.Handler) http.H
 							Bool("panic", true).
 							Int("status", panicStatus).
 							Interface("recover_info", rec).
-							Bytes("debug_stack", debug.Stack()).
-							Msg("Unhandled panic")
+							Msgf("Unhandled panic: %s", debug.Stack())
 						http.Error(ww, http.StatusText(panicStatus), panicStatus)
 					}
 				}


### PR DESCRIPTION
They can be quite long and in development we do cut the messages.

Thanks for the contribution, take a moment to read our contributing and security guidelines:

**Checklist**
- [ ] https://github.com/RHEnVision/provisioning-backend#contributing
- [ ] https://github.com/RedHatInsights/secure-coding-checklist
