### PR TITLE
Make log field truncating configurable

### DIFF
--- a/configs/local_example.yaml
+++ b/configs/local_example.yaml
@@ -19,6 +19,10 @@ logging:
   level: 1
   # Write logs to standard output in human-readable form
   stdout: false
+  # Truncate log fields to specific size, only useful for development to keep
+  # the standard output clean and human-readable. Set to zero or comment out
+  # to disable.
+  maxField: 0
 
 # AWS provisioning account (EC2, STS...)
 aws:

--- a/internal/config/main_config.go
+++ b/internal/config/main_config.go
@@ -34,8 +34,9 @@ var config struct {
 		LogLevel    int
 	}
 	Logging struct {
-		Level  int
-		Stdout bool
+		Level    int
+		Stdout   bool
+		MaxField int
 	}
 	Cloudwatch struct {
 		Enabled bool

--- a/internal/logging/zerolog.go
+++ b/internal/logging/zerolog.go
@@ -27,14 +27,20 @@ func init() {
 
 func truncateText(str string, length int) string {
 	if length <= 0 {
-		return ""
+		return str
 	}
 
 	if utf8.RuneCountInString(str) <= length {
 		return str
 	}
 
-	return string([]rune(str)[:length]) + "...\""
+	trimmed := []rune(str)[:length]
+
+	if trimmed[0] == '"' {
+		return string(trimmed) + "...\""
+	} else {
+		return string(trimmed) + "..."
+	}
 }
 
 func decorate(l zerolog.Logger) zerolog.Logger {
@@ -56,7 +62,7 @@ func InitializeStdout() zerolog.Logger {
 		Out:        os.Stdout,
 		TimeFormat: time.Kitchen,
 		FormatFieldValue: func(i interface{}) string {
-			return truncateText(fmt.Sprintf("%s", i), 40)
+			return truncateText(fmt.Sprintf("%s", i), config.Logging.MaxField)
 		},
 	}))
 }

--- a/internal/logging/zerolog_test.go
+++ b/internal/logging/zerolog_test.go
@@ -21,7 +21,17 @@ func TestTruncateExactly(t *testing.T) {
 	assert.Equal(t, "test", result)
 }
 
+func TestTruncateExactlyQuoted(t *testing.T) {
+	result := truncateText("\"test\"", 6)
+	assert.Equal(t, "\"test\"", result)
+}
+
 func TestTruncateOne(t *testing.T) {
 	result := truncateText("test", 3)
-	assert.Equal(t, "tes...\"", result)
+	assert.Equal(t, "tes...", result)
+}
+
+func TestTruncateOneQuoted(t *testing.T) {
+	result := truncateText("\"test\"", 3)
+	assert.Equal(t, "\"te...\"", result)
 }

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -46,8 +46,7 @@ func LoggerMiddleware(rootLogger *zerolog.Logger) func(next http.Handler) http.H
 						log.Error().
 							Bool("panic", true).
 							Int("status", panicStatus).
-							Interface("recover_info", rec).
-							Msgf("Unhandled panic: %s", debug.Stack())
+							Msgf("Unhandled panic: %s\n%s", rec, debug.Stack())
 						http.Error(ww, http.StatusText(panicStatus), panicStatus)
 					}
 				}


### PR DESCRIPTION
Also puts the panic contents (the error string) into the message as it was not presented. Finally, fixes the truncating quoting - when it's quoted close the quote, otherwise do not close it.

Thanks for the contribution, take a moment to read our contributing and security guidelines:

**Checklist**
- [x] https://github.com/RHEnVision/provisioning-backend#contributing
- [x] https://github.com/RedHatInsights/secure-coding-checklist
