### PR TITLE
Configurable HTTP client body logging

### DIFF
--- a/configs/local_example.yaml
+++ b/configs/local_example.yaml
@@ -38,6 +38,8 @@ cloudwatch:
   stream: stream
 
 restEndpoints:
+  # complete request and response logging (do not use in production)
+  traceData: false
   imageBuilder:
     url: https://xxx.stage.redhat.com/api/image-builder/v1
     # basic auth and proxy is only useful for development against stage

--- a/internal/clients/image_builder/image_client.go
+++ b/internal/clients/image_builder/image_client.go
@@ -22,12 +22,16 @@ func init() {
 func newImageBuilderClient(ctx context.Context) (clients.ImageBuilder, error) {
 	c, err := NewClientWithResponses(config.ImageBuilder.URL, func(c *Client) error {
 		if config.ImageBuilder.Proxy.URL != "" {
+			var client HttpRequestDoer
 			if config.Features.Environment != "development" {
 				return clients.ClientProxyProductionUseErr
 			}
 			client, err := clients.NewProxyDoer(ctx, config.ImageBuilder.Proxy.URL)
 			if err != nil {
 				return fmt.Errorf("cannot create proxy doer: %w", err)
+			}
+			if config.RestEndpoints.TraceData {
+				client = clients.NewLoggingDoer(ctx, client)
 			}
 			c.Client = client
 		}

--- a/internal/clients/interface_doer.go
+++ b/internal/clients/interface_doer.go
@@ -1,0 +1,7 @@
+package clients
+
+import "net/http"
+
+type HttpRequestDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}

--- a/internal/clients/logging_doer.go
+++ b/internal/clients/logging_doer.go
@@ -1,0 +1,73 @@
+package clients
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/rs/zerolog"
+)
+
+type LoggingDoer struct {
+	ctx  context.Context
+	log  *zerolog.Logger
+	doer HttpRequestDoer
+}
+
+func NewLoggingDoer(ctx context.Context, doer HttpRequestDoer) *LoggingDoer {
+	client := LoggingDoer{
+		ctx:  ctx,
+		log:  ctxval.Logger(ctx),
+		doer: doer,
+	}
+	return &client
+}
+
+func (c *LoggingDoer) Do(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		// read request data into a byte slice
+		requestData, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read request data: %w", err)
+		}
+
+		// rewind the original request reader
+		req.Body = ioutil.NopCloser(bytes.NewReader(requestData))
+
+		// perform logging
+		c.log.Trace().Str("method", req.Method).
+			Str("url", req.URL.RequestURI()).
+			Int64("content_length", req.ContentLength).
+			Bool("request_trace", true).
+			Msg(bytes.NewBuffer(requestData).String())
+	}
+
+	// delegate the request
+	resp, err := c.doer.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request error: %w", err)
+	}
+
+	if resp.Body != nil {
+		// read response data into a byte slice
+		responseData, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read response data: %w", err)
+		}
+
+		// rewind the original response reader
+		resp.Body = ioutil.NopCloser(bytes.NewReader(responseData))
+
+		// perform logging
+		c.log.Trace().Str("status", resp.Status).
+			Int("status_code", resp.StatusCode).
+			Int64("content_length", resp.ContentLength).
+			Bool("response_trace", true).
+			Msg(bytes.NewBuffer(responseData).String())
+	}
+
+	return resp, nil
+}

--- a/internal/clients/sources/sources_client.go
+++ b/internal/clients/sources/sources_client.go
@@ -27,9 +27,13 @@ func newSourcesClient(ctx context.Context) (clients.Sources, error) {
 			if config.Features.Environment != "development" {
 				return clients.ClientProxyProductionUseErr
 			}
+			var client HttpRequestDoer
 			client, err := clients.NewProxyDoer(ctx, config.Sources.Proxy.URL)
 			if err != nil {
 				return fmt.Errorf("cannot create proxy doer: %w", err)
+			}
+			if config.RestEndpoints.TraceData {
+				client = clients.NewLoggingDoer(ctx, client)
 			}
 			c.Client = client
 		}

--- a/internal/config/main_config.go
+++ b/internal/config/main_config.go
@@ -73,6 +73,7 @@ var config struct {
 			Password string
 			Proxy    proxy
 		}
+		TraceData bool
 	}
 	Worker struct {
 		Queue        string
@@ -89,6 +90,7 @@ var Logging = &config.Logging
 var Cloudwatch = &config.Cloudwatch
 var AWS = &config.AWS
 var Features = &config.FeatureFlags
+var RestEndpoints = &config.RestEndpoints
 var ImageBuilder = &config.RestEndpoints.ImageBuilder
 var Sources = &config.RestEndpoints.Sources
 var Worker = &config.Worker
@@ -148,5 +150,7 @@ func DumpConfig(logger zerolog.Logger) {
 	configCopy.AWS.Key = replacement
 	configCopy.AWS.Secret = replacement
 	configCopy.AWS.Session = replacement
+	configCopy.RestEndpoints.Sources.Password = replacement
+	configCopy.RestEndpoints.ImageBuilder.Password = replacement
 	logger.Info().Msgf("Configuration: %+v", configCopy)
 }


### PR DESCRIPTION
Adds optional (opt-in) logging for all requests and responses done via our HTTP clients (not AWS, can be added later). When turned on, full request and response body is logged as a logging message. Additional fields like URL or status code are added too with a flag that allows searching for such logs which could be helpful in stage environment.

This flag must be not set in production as whole bodies are loaded into byte slices into memory without any limitation.

An example:

```
12:09PM TRC Proxy request to https://console.xxxx.redhat.com/api/image-builder/v1/ready via http://xxxxx.redhat.com:3128 account_number=13 bytes_in=0 hostname=mone.home.lan method=GET org_id=000013 remote_ip=127.0.0.1:50105 rid=cc2aernm1tugokqq9100 rn=2 url=/api/provisioning/v1/ready/ib
12:09PM TRC {"readiness":"ready"}
 account_number=13 bytes_in=0 content_length=22 hostname=mone.home.lan method=GET org_id=000013 remote_ip=127.0.0.1:50105 response_trace=true rid=cc2aernm1tugokqq9100 rn=2 status="200 OK" status_code=200 url=/api/provisioning/v1/ready/ib
12:09PM INF Completed GET request /api/provisioning/v1/ready/ib in 510ms ms with 0 bytes_in=0 bytes_out=0 hostname=mone.home.lan latency_ms=510.426958 method=GET remote_ip=127.0.0.1:50105 rid=cc2aernm1tugokqq9100 rn=2 status=0 url=/api/provisioning/v1/ready/ib
```