### PR TITLE
Use JSONB for reservation details and improve error handling

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -76,6 +76,12 @@
           "instance_type": {
             "type": "string"
           },
+          "name": {
+            "type": "string"
+          },
+          "poweroff": {
+            "type": "boolean"
+          },
           "pubkey_id": {
             "format": "int64",
             "type": "integer"
@@ -171,6 +177,9 @@
             "format": "date-time",
             "type": "string"
           },
+          "error": {
+            "type": "string"
+          },
           "finished_at": {
             "format": "date-time",
             "type": "string"
@@ -184,6 +193,14 @@
           },
           "status": {
             "type": "string"
+          },
+          "step": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "steps": {
+            "format": "int32",
+            "type": "integer"
           },
           "success": {
             "type": "boolean"

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -242,6 +242,10 @@ components:
           type: string
         instance_type:
           type: string
+        name:
+          type: string
+        poweroff:
+          type: boolean
         pubkey_id:
           format: int64
           type: integer
@@ -307,6 +311,8 @@ components:
         created_at:
           format: date-time
           type: string
+        error:
+          type: string
         finished_at:
           format: date-time
           type: string
@@ -317,6 +323,12 @@ components:
           type: integer
         status:
           type: string
+        step:
+          format: int32
+          type: integer
+        steps:
+          format: int32
+          type: integer
         success:
           type: boolean
       type: object

--- a/internal/clients/ec2/ec2_client.go
+++ b/internal/clients/ec2/ec2_client.go
@@ -118,7 +118,7 @@ func (c *Client) ListInstanceTypesWithPaginator() ([]types.InstanceTypeInfo, err
 	return res, nil
 }
 
-func (c *Client) RunInstances(ctx context.Context, name string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error) {
+func (c *Client) RunInstances(ctx context.Context, name *string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error) {
 	log.Trace().Msg("Run AWS EC2 instance")
 	encodedUserData := base64.StdEncoding.EncodeToString(userData)
 	input := &ec2.RunInstancesInput{
@@ -129,16 +129,18 @@ func (c *Client) RunInstances(ctx context.Context, name string, amount int32, in
 		KeyName:      &keyName,
 		UserData:     &encodedUserData,
 	}
-	input.TagSpecifications = []types.TagSpecification{
-		{
-			ResourceType: types.ResourceTypeInstance,
-			Tags: []types.Tag{
-				{
-					Key:   aws.String("Name"),
-					Value: aws.String(name),
+	if name != nil {
+		input.TagSpecifications = []types.TagSpecification{
+			{
+				ResourceType: types.ResourceTypeInstance,
+				Tags: []types.Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String(*name),
+					},
 				},
 			},
-		},
+		}
 	}
 	resp, err := c.ec2.RunInstances(ctx, input)
 	if err != nil {

--- a/internal/ctxval/context_values.go
+++ b/internal/ctxval/context_values.go
@@ -2,6 +2,7 @@ package ctxval
 
 import (
 	"context"
+	"errors"
 
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/rs/zerolog"
@@ -16,6 +17,8 @@ const (
 	requestNumCtxKey commonKeyId = iota
 	accountIdCtxKey  commonKeyId = iota
 )
+
+var MissingAccountInContextError = errors.New("operation requires account_id in context")
 
 // Identity returns identity header struct or nil when not set.
 func Identity(ctx context.Context) identity.XRHID {
@@ -56,9 +59,13 @@ func WithRequestNumber(ctx context.Context, num uint64) context.Context {
 	return context.WithValue(ctx, requestNumCtxKey, num)
 }
 
-// Account returns current account model or nil when not set.
+// Account returns current account model or panics when not set
 func AccountId(ctx context.Context) int64 {
-	return ctx.Value(accountIdCtxKey).(int64)
+	value := ctx.Value(accountIdCtxKey)
+	if value == nil {
+		panic(MissingAccountInContextError)
+	}
+	return value.(int64)
 }
 
 func WithAccountId(ctx context.Context, accountId int64) context.Context {

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -1,3 +1,14 @@
+// Package dao provides a Database Access Object interface to stored data.
+//
+// All functions require the following variables to be set in the context:
+//
+// * Logger: for all context-aware logging.
+// * Account ID: for multi-tenancy, unless marked with UNSCOPED word.
+//
+// Functions marked as UNSCOPED can be safely used from contexts where there is
+// exactly zero function arguments coming from an user (e.g. ID was retrieved via
+// another DAO call that was scoped).
+//
 package dao
 
 import (
@@ -8,6 +19,7 @@ import (
 
 var GetAccountDao func(ctx context.Context) (AccountDao, error)
 
+// AccountDao TODO
 type AccountDao interface {
 	Create(ctx context.Context, pk *models.Account) error
 	GetById(ctx context.Context, id int64) (*models.Account, error)
@@ -19,6 +31,7 @@ type AccountDao interface {
 
 var GetPubkeyDao func(ctx context.Context) (PubkeyDao, error)
 
+// PubkeyDao TODO
 type PubkeyDao interface {
 	Create(ctx context.Context, pk *models.Pubkey) error
 	Update(ctx context.Context, pk *models.Pubkey) error
@@ -29,6 +42,7 @@ type PubkeyDao interface {
 
 var GetPubkeyResourceDao func(ctx context.Context) (PubkeyResourceDao, error)
 
+// PubkeyResourceDao TODO
 type PubkeyResourceDao interface {
 	GetResourceByProviderType(ctx context.Context, pubkeyId int64, provider models.ProviderType) (*models.PubkeyResource, error)
 	ListByPubkeyId(ctx context.Context, pkId int64) ([]*models.PubkeyResource, error)
@@ -38,14 +52,40 @@ type PubkeyResourceDao interface {
 
 var GetReservationDao func(ctx context.Context) (ReservationDao, error)
 
+// ReservationDao represents a reservation, an abstraction of one or more background jobs with
+// associated detail information different for different cloud providers (like number of vCPUs,
+// instance IDs created etc).
 type ReservationDao interface {
+	// CreateNoop creates no operation reservation with details in a single transaction.
 	CreateNoop(ctx context.Context, reservation *models.NoopReservation) error
+
+	// CreateAWS creates AWS reservation with details in a single transaction.
 	CreateAWS(ctx context.Context, reservation *models.AWSReservation) error
+
+	// CreateInstance inserts instance associated to a reservation.
 	CreateInstance(ctx context.Context, reservation *models.ReservationInstance) error
+
+	// GetById returns reservation for a particular account.
+	GetById(ctx context.Context, id int64) (*models.Reservation, error)
+
+	// List returns reservation for a particular account.
 	List(ctx context.Context, limit, offset int64) ([]*models.Reservation, error)
+
+	// ListInstances returns instances associated to a reservation. UNSCOPED.
 	ListInstances(ctx context.Context, limit, offset int64) ([]*models.ReservationInstance, error)
-	UpdateStatus(ctx context.Context, id int64, status string) error
+
+	// UpdateStatus sets status field and increment step counter by addSteps. UNSCOPED.
+	UpdateStatus(ctx context.Context, id int64, status string, addSteps int32) error
+
+	// UpdateReservationIDForAWS updates AWS reservation id field. UNSCOPED.
 	UpdateReservationIDForAWS(ctx context.Context, id int64, awsReservationId string) error
-	Finish(ctx context.Context, id int64, success bool, status string) error
+
+	// FinishWithSuccess sets Success flag. UNSCOPED.
+	FinishWithSuccess(ctx context.Context, id int64) error
+
+	// FinishWithError sets Success flag and Error flag. UNSCOPED.
+	FinishWithError(ctx context.Context, id int64, errorString string) error
+
+	// Delete deletes a reservation. Only used in tests and background cleanup job. UNSCOPED.
 	Delete(ctx context.Context, id int64) error
 }

--- a/internal/dao/stubs/reservation_dao.go
+++ b/internal/dao/stubs/reservation_dao.go
@@ -47,6 +47,10 @@ func (stub *reservationDaoStub) CreateInstance(ctx context.Context, reservation 
 	return nil
 }
 
+func (stub *reservationDaoStub) GetById(ctx context.Context, id int64) (*models.Reservation, error) {
+	return nil, nil
+}
+
 func (stub *reservationDaoStub) List(ctx context.Context, limit, offset int64) ([]*models.Reservation, error) {
 	return nil, nil
 }
@@ -55,7 +59,7 @@ func (stub *reservationDaoStub) ListInstances(ctx context.Context, limit, offset
 	return nil, nil
 }
 
-func (stub *reservationDaoStub) UpdateStatus(ctx context.Context, id int64, status string) error {
+func (stub *reservationDaoStub) UpdateStatus(ctx context.Context, id int64, status string, addSteps int32) error {
 	return nil
 }
 
@@ -63,7 +67,11 @@ func (stub *reservationDaoStub) UpdateReservationIDForAWS(ctx context.Context, i
 	return nil
 }
 
-func (stub *reservationDaoStub) Finish(ctx context.Context, id int64, success bool, status string) error {
+func (stub *reservationDaoStub) FinishWithSuccess(ctx context.Context, id int64) error {
+	return nil
+}
+
+func (stub *reservationDaoStub) FinishWithError(ctx context.Context, id int64, errorString string) error {
 	return nil
 }
 

--- a/internal/db/migrations/005_reservations.sql
+++ b/internal/db/migrations/005_reservations.sql
@@ -4,7 +4,10 @@ CREATE TABLE reservations
   provider INTEGER NOT NULL CHECK (valid_provider(provider)),
   account_id BIGINT NOT NULL REFERENCES accounts(id),
   created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  steps SMALLINT NOT NULL,
+  step SMALLINT NOT NULL DEFAULT 0,
   status TEXT NOT NULL CHECK (NOT empty(status)),
+  error TEXT NOT NULL DEFAULT '',
   finished_at TIMESTAMP,
   success BOOLEAN,
 
@@ -23,12 +26,9 @@ CREATE TABLE aws_reservation_details
   provider INTEGER NOT NULL DEFAULT provider_type_aws(),
   pubkey_id BIGINT NOT NULL REFERENCES pubkeys(id),
   source_id TEXT NOT NULL,
-  name TEXT NOT NULL DEFAULT '',
-  instance_type TEXT NOT NULL,
-  amount INTEGER NOT NULL,
   image_id TEXT NOT NULL,
-  poweroff BOOLEAN NOT NULL DEFAULT false,
   aws_reservation_id TEXT,
+  detail JSONB,
 
   FOREIGN KEY (reservation_id, provider) REFERENCES reservations(id, provider) ON DELETE CASCADE,
   CHECK (provider = provider_type_aws())

--- a/internal/jobs/common.go
+++ b/internal/jobs/common.go
@@ -1,0 +1,102 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/lzap/dejq"
+)
+
+func decodeJob(ctx context.Context, job dejq.Job, argInterface interface{}) error {
+	err := job.Decode(&argInterface)
+	if err != nil {
+		ctxval.Logger(ctx).Error().Err(err).Msgf("Unable to decode arguments for job '%s'", job.Type())
+		return fmt.Errorf("decode error: %w", err)
+		// TODO: increase counter of failed jobs in Prometheus
+	}
+	return nil
+}
+
+func contextLogger(ctx context.Context, jobName string, args interface{}, accountId, reservationId int64) context.Context {
+	newContext := ctxval.WithAccountId(ctx, accountId)
+	logger := ctxval.Logger(newContext).With().Int64("reservation_id", reservationId).Logger()
+	logger.Info().Interface("args", args).Msgf("Processing job: '%s'", jobName)
+	newContext = ctxval.WithLogger(newContext, &logger)
+	return newContext
+}
+
+func finishJob(ctx context.Context, reservationId int64, jobErr error) {
+	if jobErr != nil {
+		// TODO: increase counter of failed jobs in Prometheus
+		finishWithError(ctx, reservationId, jobErr)
+	} else {
+		// TODO: increase counter of successful jobs in Prometheus
+		finishWithSuccess(ctx, reservationId)
+	}
+}
+
+func finishWithSuccess(ctx context.Context, reservationId int64) {
+	ctxLogger := ctxval.Logger(ctx).With().Int64("reservation_id", reservationId).Logger()
+
+	rDao, err := dao.GetReservationDao(ctx)
+	if err != nil {
+		ctxLogger.Warn().Err(err).Msg("unable to update job status: dao")
+		return
+	}
+
+	reservation, err := rDao.GetById(ctx, reservationId)
+	if err != nil {
+		ctxLogger.Warn().Err(err).Msg("unable to update job status: get by id")
+		return
+	}
+	ctxLogger.Debug().Msgf("Job step: %d/%d", reservation.Step, reservation.Steps)
+
+	// if this was the last step, set the success flag
+	if reservation.Step >= reservation.Steps {
+		ctxLogger.Info().Msgf("All jobs executed, marking job as success")
+		err = rDao.FinishWithSuccess(ctx, reservationId)
+		if err != nil {
+			ctxLogger.Warn().Err(err).Msg("unable to update job status: finish")
+		}
+	}
+}
+
+func finishWithError(ctx context.Context, reservationId int64, jobError error) {
+	ctxLogger := ctxval.Logger(ctx).With().Int64("reservation_id", reservationId).Logger()
+	ctxLogger.Warn().Err(jobError).Msgf("Job returned an error: %s", jobError.Error())
+
+	rDao, err := dao.GetReservationDao(ctx)
+	if err != nil {
+		ctxLogger.Warn().Err(err).Msg("unable to update job status: dao")
+		return
+	}
+	err = rDao.FinishWithError(ctx, reservationId, jobError.Error())
+	if err != nil {
+		ctxLogger.Warn().Err(err).Msg("unable to update job status: finish")
+	}
+}
+
+func updateStatusBefore(ctx context.Context, id int64, status string) {
+	updateStatusAfter(ctx, id, status, 0)
+}
+
+func updateStatusAfter(ctx context.Context, id int64, status string, addSteps int) {
+	ctxLogger := ctxval.Logger(ctx).With().Int64("reservation_id", id).Logger()
+	ctxLogger.Debug().Bool("step", true).Msgf("Reservation status change: '%s'", status)
+	if addSteps != 0 {
+		ctxLogger.Trace().Bool("step", true).Msgf("Increased step number by: %d", addSteps)
+	}
+
+	rDao, err := dao.GetReservationDao(ctx)
+	if err != nil {
+		ctxLogger.Warn().Err(err).Msg("unable to update step number: dao")
+		return
+	}
+
+	err = rDao.UpdateStatus(ctx, id, status, int32(addSteps))
+	if err != nil {
+		ctxLogger.Warn().Err(err).Msg("unable to update step number: update")
+	}
+}

--- a/internal/jobs/queue/queue_types.go
+++ b/internal/jobs/queue/queue_types.go
@@ -3,5 +3,5 @@ package queue
 const (
 	TypeNoop              = "no_operation"
 	TypePubkeyUploadAws   = "pubkey_upload_aws"
-	TypeLaunchInstanceAws = "launch_instance_aws"
+	TypeLaunchInstanceAws = "launch_instances_aws"
 )

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -21,8 +21,18 @@ type Reservation struct {
 	// Time when reservation was made.
 	CreatedAt time.Time `db:"created_at" json:"created_at"`
 
-	// Textual status of the reservation or error when there was a failure
+	// Total number of job steps for this reservation.
+	Steps int32 `db:"steps" json:"steps"`
+
+	// Active job step for this reservation. See Status for more details.
+	Step int32 `db:"step" json:"step"`
+
+	// Textual status of the reservation or error when there was a failure. This is user-facing message,
+	// it should not contain error details. See Error field for more details.
 	Status string `db:"status" json:"status"`
+
+	// Error message when reservation was not successful. Only set when Success if false.
+	Error string `db:"error" json:"error,omitempty"`
 
 	// Time when reservation was finished or nil when it's still processing.
 	FinishedAt sql.NullTime `db:"finished_at" json:"finished_at"`
@@ -35,6 +45,20 @@ type NoopReservation struct {
 	Reservation
 }
 
+type AWSDetail struct {
+	// Optional instance name
+	Name *string `json:"name"`
+
+	// AWS Instance type.
+	InstanceType string `json:"instance_type"`
+
+	// Amount of instances to provision of type: Instance type.
+	Amount int32 `json:"amount"`
+
+	// Immediately power off the system after initialization
+	PowerOff bool `json:"poweroff"`
+}
+
 type AWSReservation struct {
 	Reservation
 
@@ -44,23 +68,14 @@ type AWSReservation struct {
 	// Source ID.
 	SourceID string `db:"source_id" json:"source_id"`
 
-	// Optional instance name
-	Name string `db:"name" json:"name"`
-
-	// AWS Instance type.
-	InstanceType string `db:"instance_type" json:"instance_type"`
-
-	// Amount of instances to provision of type: Instance type.
-	Amount int32 `db:"amount" json:"amount"`
-
-	// The ID of the image from which the instance is created.
-	ImageID string `db:"image_id" json:"image_id"`
-
-	// Immediately power off the system after initialization
-	PowerOff bool `db:"poweroff" json:"poweroff"`
-
 	// The ID of the aws reservation which was created.
 	AWSReservationID string `db:"aws_reservation_id" json:"aws_reservation_id"`
+
+	// The ID of the image from which the instance is created. AMI's must be prefixed with 'ami-'.
+	ImageID string `json:"image_id"`
+
+	// Detail information is stored as JSON in DB
+	Detail *AWSDetail `db:"detail" json:"detail"`
 }
 
 type ReservationInstance struct {

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -20,8 +20,17 @@ type GenericReservationResponsePayload struct {
 	// Time when reservation was made.
 	CreatedAt time.Time `json:"created_at"`
 
+	// Total number of job steps for this reservation.
+	Steps int32 `db:"steps" json:"steps"`
+
+	// Active job step for this reservation. See Status for more details.
+	Step int32 `db:"step" json:"step"`
+
 	// Textual status of the reservation or error when there was a failure
 	Status string `json:"status"`
+
+	// Error message when reservation was not successful. Only set when Success if false.
+	Error string `db:"error" json:"error,omitempty"`
 
 	// Time when reservation was finished or nil when it's still processing.
 	FinishedAt *time.Time `json:"finished_at"`
@@ -50,6 +59,12 @@ type AWSReservationResponsePayload struct {
 
 	// The ID of the aws reservation which was created.
 	AWSReservationID string `json:"aws_reservation_id"`
+
+	// Optional name of the instance(s).
+	Name *string `json:"name"`
+
+	// Immediately power off the system after initialization
+	PowerOff bool `json:"poweroff"`
 }
 
 type NoopReservationResponsePayload struct {
@@ -64,7 +79,7 @@ type AWSReservationRequestPayload struct {
 	SourceID string `json:"source_id"`
 
 	// Optional name of the instance(s).
-	Name string `json:"name"`
+	Name *string `json:"name"`
 
 	// AWS Instance type.
 	InstanceType string `json:"instance_type"`
@@ -72,7 +87,7 @@ type AWSReservationRequestPayload struct {
 	// Amount of instances to provision of type: Instance type.
 	Amount int32 ` json:"amount"`
 
-	// Image Builder UUID of the image that should be launched. AMI is also supported.
+	// Image Builder UUID of the image that should be launched. AMI's must be prefixed with 'ami-'.
 	ImageID string `json:"image_id"`
 
 	// Immediately power off the system after initialization
@@ -99,10 +114,12 @@ func NewAWSReservationResponse(reservation *models.AWSReservation) render.Render
 	response := AWSReservationResponsePayload{
 		ImageID:          reservation.ImageID,
 		SourceID:         reservation.SourceID,
-		Amount:           reservation.Amount,
-		InstanceType:     reservation.InstanceType,
+		Amount:           reservation.Detail.Amount,
+		InstanceType:     reservation.Detail.InstanceType,
 		AWSReservationID: reservation.AWSReservationID,
 		ID:               reservation.ID,
+		Name:             reservation.Detail.Name,
+		PowerOff:         reservation.Detail.PowerOff,
 	}
 	return &response
 }
@@ -116,13 +133,24 @@ func NewNoopReservationResponse(reservation *models.NoopReservation) render.Rend
 func NewReservationListResponse(reservations []*models.Reservation) []render.Renderer {
 	list := make([]render.Renderer, 0, len(reservations))
 	for _, reservation := range reservations {
+		var finishedAt *time.Time
+		if reservation.FinishedAt.Valid {
+			finishedAt = &reservation.FinishedAt.Time
+		}
+		var success *bool
+		if reservation.Success.Valid {
+			success = &reservation.Success.Bool
+		}
 		list = append(list, &GenericReservationResponsePayload{
 			ID:         reservation.ID,
 			Provider:   int(reservation.Provider),
 			CreatedAt:  reservation.CreatedAt,
-			FinishedAt: &reservation.FinishedAt.Time,
+			FinishedAt: finishedAt,
 			Status:     reservation.Status,
-			Success:    &reservation.Success.Bool,
+			Success:    success,
+			Steps:      reservation.Steps,
+			Step:       reservation.Step,
+			Error:      reservation.Error,
 		})
 	}
 	return list

--- a/internal/services/noop_reservation_service.go
+++ b/internal/services/noop_reservation_service.go
@@ -29,6 +29,7 @@ func CreateNoopReservation(w http.ResponseWriter, r *http.Request) {
 			Provider:  models.ProviderTypeNoop,
 			AccountID: accountId,
 			Status:    "Created",
+			Steps:     1,
 		},
 	}
 


### PR DESCRIPTION
The list of fields in aws details table was only growing. Most of the fields, however, are informative and they are only passed into jobs as inputs. They are saved only when user wants to fetch existing reservation for more details.

It makes sense to store these fields as a native JSON (JSONB) because we will need to unlikely search or order these fields. This patch does exactly that.

On top of that change, instance name can be now an array so instances can be named separately. There is, however, one big problem with that - AWS API does not allow naming instances in batches, all get the same name.

The patch improves error handling of jobs, we simply ignored errors so far. Now we properly fail reservation with "Error: xxx" status and Success bool is set to false as it was meant.

Therefore, this initial version of the change only recognizes one case - when there is exactly one name. In that case, it will be passed in when launching instance.

The solution is to create a new job that will be only responsible for renaming all existing instances separately, after they are launched. We have the list in the reservation, so that is doable.

This creates a problem tho: launch operation now will contain 2 or 3 jobs depending on if names were provided or not. The launch job currently sets the status to "Finished" and UI expects that. I think we need to change the way we report status.

There is currently the Success flag that is either null (not finished yet) or true/false. We should only use this.

On top of that, I propose to add two new ints, one is total number of steps and the other is actual step that is currently in progress. This way, the UI can actually show a relevant progress bar depending on how many steps the launch is actually doing. Also a new field `Error` would be helpful with detailed error message.

Then the UI would have the following logic: @amirfefer @adiabramovitch @ezr-ondrej 

* Check reservation `Success`:
 * `null` means it is still in progress
 * `true` means it is finished
 * `false` means there was a failure, error message should be found in `Error`
* Use `Status` string field to display some meaningful information (e.g. "Uploading public key")
* Use `Step` and `Steps` fields will contain integers, e.g. `2/3` meaning currently executing job 2 out of three 3.
* Use `Status` and `Error` field when a job was not successful to retrieve detailed error. While `Status` would contain user-facing error like `Uploading of public key failed`, the `Error` field would contain full error message (go error).

Let me know if you like this and I will incorporate this into the patch, or create a new one.