### PR TITLE
ETag middleware with implementation for OpenAPI

### DIFF
--- a/api/embed.go
+++ b/api/embed.go
@@ -4,13 +4,31 @@ import (
 	_ "embed"
 	"fmt"
 	"net/http"
+	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/middleware"
 )
 
 //go:embed openapi.gen.json
 var embeddedJSONSpec []byte
 
-func ServeOpenAPISpec(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+var etag *middleware.ETag
+
+func init() {
+	var err error
+	etag, err = middleware.GenerateETagFromBuffer("json-spec", 30*time.Minute, embeddedJSONSpec)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// ETagValue returns etag generated from the input file content with 30 minute expiration.
+func ETagValue() *middleware.ETag {
+	return etag
+}
+
+func ServeOpenAPISpec(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write(embeddedJSONSpec)
 	if err != nil {

--- a/internal/config/parser/known.go
+++ b/internal/config/parser/known.go
@@ -10,7 +10,6 @@ package parser
 //
 // APP_NAME (implicit from APP.NAME)
 // AWS_INSTANCE_PREFIX (explicitly set)
-//
 var known = [][]string{
 	{"APP", ""},
 	{"APP.NAME", ""},

--- a/internal/config/parser/viper.go
+++ b/internal/config/parser/viper.go
@@ -5,7 +5,6 @@
 // viper is initialized with custom StringReplacer.
 //
 // https://github.com/spf13/viper/pull/870
-//
 package parser
 
 import "github.com/spf13/viper"

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -8,7 +8,6 @@
 // Functions marked as UNSCOPED can be safely used from contexts where there is
 // exactly zero function arguments coming from an user (e.g. ID was retrieved via
 // another DAO call that was scoped).
-//
 package dao
 
 import (

--- a/internal/middleware/etag_middleware.go
+++ b/internal/middleware/etag_middleware.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"errors"
+	"fmt"
+	"hash/crc64"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+)
+
+var InvalidETagErr = errors.New("empty etag provided")
+
+type ETag struct {
+	Name       string
+	Expiration time.Duration
+	Value      string
+	HashTime   time.Duration
+}
+
+type ETagValueFunc func() *ETag
+
+var etags = make([]*ETag, 0)
+
+func (etag *ETag) Header() string {
+	return fmt.Sprintf("\"pb-%s-%s\"", etag.Name, etag.Value)
+}
+
+func (etag *ETag) CacheControlHeader() string {
+	return fmt.Sprintf("max-age=%d", int(etag.Expiration.Seconds()))
+}
+
+func ETagMiddleware(etagFunc ETagValueFunc) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			etag := etagFunc()
+			if etag.Value == "" {
+				panic(InvalidETagErr)
+			}
+			cc := etag.CacheControlHeader()
+			w.Header().Set("ETag", etag.Header())
+			w.Header().Set("Cache-Control", cc)
+			logger := ctxval.Logger(r.Context()).With().Str("etag", etag.Value).Str("etag_name", etag.Name).Logger()
+			logger.Trace().Msgf("Returned etag with Cache-Control '%s'", cc)
+
+			if match := r.Header.Get("If-None-Match"); match != "" {
+				if strings.Contains(match, etag.Value) {
+					logger.Trace().Msgf("ETag cache hit")
+					w.WriteHeader(http.StatusNotModified)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+}
+
+func GenerateETagFromBuffer(name string, expiration time.Duration, buffers ...[]byte) (*ETag, error) {
+	start := time.Now()
+	hash := crc64.New(crc64.MakeTable(crc64.ECMA))
+	for _, buffer := range buffers {
+		_, err := hash.Write(buffer)
+		if err != nil {
+			return nil, fmt.Errorf("unable to generate etag from buffer: %w", err)
+		}
+	}
+	etag := &ETag{
+		Name:       name,
+		Expiration: expiration,
+		Value:      fmt.Sprintf("%x", hash.Sum64()),
+		HashTime:   time.Since(start),
+	}
+	etags = append(etags, etag)
+	return etag, nil
+}
+
+// AllETags returns all etags for diagnostic purposes
+func AllETags() []*ETag {
+	return etags
+}

--- a/internal/middleware/etag_middleware_test.go
+++ b/internal/middleware/etag_middleware_test.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateETagFromBuffer(t *testing.T) {
+	b := []byte("test")
+	etag, _ := GenerateETagFromBuffer("test", time.Minute*1, b)
+	assert.Equal(t, "test", etag.Name)
+	assert.Equal(t, time.Minute*1, etag.Expiration)
+	assert.Equal(t, "fa15fda7c10c75a5", etag.Value)
+}
+
+func TestGenerateETagHeader(t *testing.T) {
+	b := []byte("test")
+	etag, _ := GenerateETagFromBuffer("test", time.Minute*1, b)
+	assert.Equal(t, "\"pb-test-fa15fda7c10c75a5\"", etag.Header())
+}
+
+func TestGenerateETagCacheControl(t *testing.T) {
+	b := []byte("test")
+	etag, _ := GenerateETagFromBuffer("test", time.Minute*1, b)
+	assert.Equal(t, "max-age=60", etag.CacheControlHeader())
+}
+
+func TestGenerateETagFromThreeBuffers(t *testing.T) {
+	b1 := []byte("a")
+	b2 := []byte("b")
+	b3 := []byte("c")
+	etag, _ := GenerateETagFromBuffer("test", time.Minute*1, b1, b2, b3)
+	assert.Equal(t, "2cd8094a1a277627", etag.Value)
+}
+
+func TestGenerateETagFromTwoBuffers(t *testing.T) {
+	b1 := []byte("ab")
+	b2 := []byte("c")
+	etag, _ := GenerateETagFromBuffer("test", time.Minute*1, b1, b2)
+	assert.Equal(t, "2cd8094a1a277627", etag.Value)
+}


### PR DESCRIPTION
This new middleware can be used to cache any static or nearly static content. Everything works transparently, as long as a valid etag (string, hash, datetime, timestamp, anything unique) is provided and expiration time is set.

Caching works transparently in browsers, it will not work when API is hit from a curl utility of course.

The OpenAPI caching is just an example, this will be useful for instance types endpoint once we start embedding them into the application instead of dynamically loading them every time.

It can be also useful for any content that was cached in the future.

Thanks for the contribution, take a moment to read our contributing and security guidelines:

I tested it works fine with JSON spec, however, I am trying to open up redoc documentation and it simply renders JSON instead of giving me any HTML. What is the URL again?

http://localhost:8000/docs/openapi.json
