### PR TITLE
Region aware reservation endpoint 

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -55,6 +55,9 @@
             "format": "int64",
             "type": "integer"
           },
+          "region": {
+            "type": "string"
+          },
           "source_id": {
             "type": "string"
           }
@@ -85,6 +88,9 @@
           "pubkey_id": {
             "format": "int64",
             "type": "integer"
+          },
+          "region": {
+            "type": "string"
           },
           "reservation_id": {
             "format": "int64",

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -238,6 +238,8 @@ components:
         pubkey_id:
           format: int64
           type: integer
+        region:
+          type: string
         source_id:
           type: string
       type: object
@@ -259,6 +261,8 @@ components:
         pubkey_id:
           format: int64
           type: integer
+        region:
+          type: string
         reservation_id:
           format: int64
           type: integer

--- a/configs/local_example.yaml
+++ b/configs/local_example.yaml
@@ -26,7 +26,6 @@ logging:
 
 # AWS provisioning account (EC2, STS...)
 aws:
-  region: us-east-1
   key:
   secret:
   session:

--- a/internal/clients/clients_interfaces.go
+++ b/internal/clients/clients_interfaces.go
@@ -3,7 +3,6 @@ package clients
 import (
 	"context"
 
-	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
@@ -30,11 +29,7 @@ type ImageBuilder interface {
 	Ready(ctx context.Context) error
 }
 
-var GetCustomerEC2ClientWithRegion func(ctx context.Context, arn string, region string) (EC2, error)
-
-func GetCustomerEC2Client(ctx context.Context, arn string) (EC2, error) {
-	return GetCustomerEC2ClientWithRegion(ctx, arn, config.AWS.Region)
-}
+var GetCustomerEC2Client func(ctx context.Context, arn string, region string) (EC2, error)
 
 type EC2 interface {
 	ImportPubkey(key *models.Pubkey, tag string) (string, error)

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -16,7 +16,7 @@ var ec2CtxKey ec2CtxKeyType = "ec2-interface"
 type EC2ClientStub struct{}
 
 func init() {
-	clients.GetCustomerEC2ClientWithRegion = getEC2ClientStubWithRegion
+	clients.GetCustomerEC2Client = getEC2ClientStubWithRegion
 }
 
 // EC2Client

--- a/internal/config/0_common_config.go
+++ b/internal/config/0_common_config.go
@@ -48,7 +48,6 @@ func init() {
 	parser.Viper.SetDefault("worker.maxBeats", 10)
 
 	// AWS
-	parser.Viper.SetDefault("aws.region", "us-east-1")
 	parser.Viper.SetDefault("aws.key", "")
 	parser.Viper.SetDefault("aws.secret", "")
 	parser.Viper.SetDefault("aws.session", "")

--- a/internal/config/main_config.go
+++ b/internal/config/main_config.go
@@ -51,7 +51,6 @@ var config struct {
 		Stream  string
 	}
 	AWS struct {
-		Region         string
 		Key            string
 		Secret         string
 		Session        string

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -20,6 +20,9 @@ type LaunchInstanceAWSTaskArgs struct {
 	// Associated account
 	AccountID int64 `json:"account_id"`
 
+	// Region to provision the instances into
+	Region string `json:"region"`
+
 	// Associated public key
 	PubkeyID int64 `json:"pubkey_id"`
 
@@ -81,7 +84,7 @@ func handleLaunchInstanceAWS(ctx context.Context, args *LaunchInstanceAWSTaskArg
 	}
 	logger.Trace().Bool("userdata", true).Msg(string(userData))
 
-	ec2Client, err := clients.GetCustomerEC2Client(ctx, args.ARN)
+	ec2Client, err := clients.GetCustomerEC2Client(ctx, args.ARN, args.Region)
 	if err != nil {
 		return fmt.Errorf("cannot create new ec2 client from config: %w", err)
 	}

--- a/internal/jobs/pubkey_upload_aws_job.go
+++ b/internal/jobs/pubkey_upload_aws_job.go
@@ -16,6 +16,7 @@ import (
 type PubkeyUploadAWSTaskArgs struct {
 	AccountID     int64  `json:"account_id"`
 	ReservationID int64  `json:"reservation_id"`
+	Region        string `json:"region"`
 	PubkeyID      int64  `json:"pubkey_id"`
 	SourceID      string `json:"source_id"`
 	ARN           string `json:"arn"`
@@ -90,7 +91,7 @@ func handlePubkeyUploadAWS(ctx context.Context, args *PubkeyUploadAWSTaskArgs) e
 	pkr.RandomizeTag()
 
 	// upload to cloud with a tag
-	ec2Client, err := clients.GetCustomerEC2Client(ctx, args.ARN)
+	ec2Client, err := clients.GetCustomerEC2Client(ctx, args.ARN, args.Region)
 	if err != nil {
 		return fmt.Errorf("cannot create new ec2 client from config: %w", err)
 	}

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -46,6 +46,8 @@ type NoopReservation struct {
 }
 
 type AWSDetail struct {
+	Region string `json:"region"`
+
 	// Optional instance name
 	Name *string `json:"name"`
 

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -48,7 +48,10 @@ type AWSReservationResponsePayload struct {
 	// Source ID.
 	SourceID string `json:"source_id"`
 
-	//AWS Instance type.
+	// AWS region.
+	Region string `json:"region"`
+
+	// AWS Instance type.
 	InstanceType string `json:"instance_type"`
 
 	// Amount of instances to provision of type: Instance type.
@@ -77,6 +80,9 @@ type AWSReservationRequestPayload struct {
 
 	// Source ID.
 	SourceID string `json:"source_id"`
+
+	// AWS region.
+	Region string `json:"region"`
 
 	// Optional name of the instance(s).
 	Name *string `json:"name"`
@@ -114,6 +120,7 @@ func NewAWSReservationResponse(reservation *models.AWSReservation) render.Render
 	response := AWSReservationResponsePayload{
 		ImageID:          reservation.ImageID,
 		SourceID:         reservation.SourceID,
+		Region:           reservation.Detail.Region,
 		Amount:           reservation.Detail.Amount,
 		InstanceType:     reservation.Detail.InstanceType,
 		AWSReservationID: reservation.AWSReservationID,

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -42,6 +42,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	detail := &models.AWSDetail{
+		Region:       payload.Region,
 		InstanceType: payload.InstanceType,
 		Amount:       payload.Amount,
 		PowerOff:     payload.PowerOff,
@@ -112,6 +113,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 		Body: &jobs.PubkeyUploadAWSTaskArgs{
 			AccountID:     accountId,
 			ReservationID: reservation.ID,
+			Region:        reservation.Detail.Region,
 			PubkeyID:      pk.ID,
 			ARN:           arn,
 			SourceID:      reservation.SourceID,
@@ -144,6 +146,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 		Body: &jobs.LaunchInstanceAWSTaskArgs{
 			AccountID:     accountId,
 			ReservationID: reservation.ID,
+			Region:        reservation.Detail.Region,
 			PubkeyID:      pk.ID,
 			Detail:        reservation.Detail,
 			AMI:           ami,

--- a/internal/services/instance_types_service.go
+++ b/internal/services/instance_types_service.go
@@ -42,7 +42,7 @@ func ListInstanceTypes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ec2Client, err := clients.GetCustomerEC2ClientWithRegion(r.Context(), arn, region)
+	ec2Client, err := clients.GetCustomerEC2Client(r.Context(), arn, region)
 	if err != nil {
 		renderError(w, r, payloads.NewAWSError(r.Context(), "failed to establish ec2 connection", err))
 		return


### PR DESCRIPTION
Reservation endpoint was missing a region to deploy into.
We are using one region for now, but we need this for future use.