### PR TITLE
Improve EC2 error handling

### DIFF
--- a/internal/clients/clients_errors.go
+++ b/internal/clients/clients_errors.go
@@ -1,0 +1,6 @@
+package clients
+
+import "errors"
+
+var UnauthorizedErr = errors.New("operation not permitted by client, check the provided account permissions")
+var DuplicatePubkeyErr = errors.New("pubkey already exists in the target account")

--- a/internal/clients/http/ec2/ec2_errors.go
+++ b/internal/clients/http/ec2/ec2_errors.go
@@ -7,16 +7,14 @@ import (
 	"github.com/aws/smithy-go"
 )
 
-var DuplicatePubkeyErr = errors.New("pubkey already exists")
-var OperationNotPermittedErr = errors.New("operation not permitted")
-var RegionNotFoundErr = errors.New("region was not found")
+func isAWSUnauthorizedError(err error) bool {
+	return isAWSOperationError(err, "api error UnauthorizedOperation")
+}
 
-func IsOperationError(err error, substr string) bool {
-	if err != nil {
-		var oe *smithy.OperationError
-		if errors.As(err, &oe) && strings.Contains(oe.Unwrap().Error(), substr) {
-			return true
-		}
+func isAWSOperationError(err error, substr string) bool {
+	var oe *smithy.OperationError
+	if errors.As(err, &oe) {
+		return strings.Contains(oe.Unwrap().Error(), substr)
 	}
 	return false
 }

--- a/internal/jobs/pubkey_upload_aws_job.go
+++ b/internal/jobs/pubkey_upload_aws_job.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
-	"github.com/RHEnVision/provisioning-backend/internal/clients/http/ec2"
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
@@ -97,7 +96,7 @@ func handlePubkeyUploadAWS(ctx context.Context, args *PubkeyUploadAWSTaskArgs) e
 
 	pkr.Handle, err = ec2Client.ImportPubkey(pubkey, pkr.FormattedTag())
 	if err != nil {
-		if errors.Is(err, ec2.DuplicatePubkeyErr) {
+		if errors.Is(err, clients.DuplicatePubkeyErr) {
 			logger.Warn().Msgf("Pubkey '%s' already present, skipping", pubkey.Name)
 		} else {
 			return fmt.Errorf("cannot upload aws pubkey: %w", err)

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -10,6 +10,14 @@ import (
 	"github.com/go-chi/render"
 )
 
+type ParamMissingError struct {
+	ParamName string
+}
+
+func (e ParamMissingError) Error() string {
+	return fmt.Sprintf("parameter %s was not provided in the request", e.ParamName)
+}
+
 // ResponseError implements Go standard error interface as well as Wrapper and Renderer
 type ResponseError struct {
 	// HTTP status code

--- a/internal/services/instance_types_service.go
+++ b/internal/services/instance_types_service.go
@@ -19,7 +19,7 @@ func ListInstanceTypes(w http.ResponseWriter, r *http.Request) {
 	sourceId := chi.URLParam(r, "ID")
 	region := r.URL.Query().Get("region")
 	if region == "" {
-		renderError(w, r, payloads.NewNotFoundError(r.Context(), ec2.RegionNotFoundErr))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), payloads.ParamMissingError{ParamName: "region"}))
 	}
 
 	sourcesClient, err := clients.GetSourcesClient(r.Context())


### PR DESCRIPTION
Adds explicit param missing error.
Adds Unauthorized error in clients, for global clients use and refactors the ec2 client to throw this error.