### PR TITLE
Fix integration config loading, introduced NoError in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,10 @@ TAGS
 /pbworker
 /vendor/
 /configs/local.yaml
+/configs/local.*.yaml
 /deploy/bonfire.yaml
 /Containerfile
 /tern.conf
-/cmd/dao_tests/local.yaml
 /scripts/sources-*/
 /scripts/sources.local.conf
 /scripts/rest_examples/*.local.http

--- a/Makefile
+++ b/Makefile
@@ -113,4 +113,4 @@ update-test-deps: update-deps test
 
 .PHONY: integration-test
 integration-test:
-	go test --count=1 -v -tags=integration ./cmd/dao_tests
+	go test --count=1 -v -tags=integration ./internal/dao/tests

--- a/internal/config/5_integration_config.go
+++ b/internal/config/5_integration_config.go
@@ -3,8 +3,17 @@
 
 package config
 
-import "github.com/RHEnVision/provisioning-backend/internal/config/parser"
+import (
+	"github.com/RHEnVision/provisioning-backend/internal/config/parser"
+)
 
 func init() {
 	parser.Viper.Set("featureFlags.environment", "test")
+
+	// load configs/local.integration.yaml
+	parser.Viper.AddConfigPath("./configs")
+	// and relative to internal/dao/tests (go test utility changes workdir)
+	parser.Viper.AddConfigPath("../../../configs")
+	parser.Viper.SetConfigName("local.integration")
+	_ = parser.Viper.ReadInConfig()
 }

--- a/internal/config/5_normal_config.go
+++ b/internal/config/5_normal_config.go
@@ -4,38 +4,14 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/RHEnVision/provisioning-backend/internal/config/parser"
-	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 )
 
 func init() {
-	if clowder.IsClowderEnabled() {
-		cfg := clowder.LoadedConfig
-		parser.Viper.Set("featureFlags.environment", "production")
-		parser.Viper.Set("database.host", cfg.Database.Hostname)
-		parser.Viper.Set("database.port", cfg.Database.Port)
-		parser.Viper.Set("database.user", cfg.Database.Username)
-		parser.Viper.Set("database.password", cfg.Database.Password)
-		parser.Viper.Set("database.name", cfg.Database.Name)
-		parser.Viper.Set("prometheus.port", cfg.MetricsPort)
-		parser.Viper.Set("prometheus.path", cfg.MetricsPath)
-		if endpoint, ok := clowder.DependencyEndpoints["sources-api"]["svc"]; ok {
-			parser.Viper.Set("restEndpoints.sources.url", fmt.Sprintf("http://%s:%d/api/sources/v3.1", endpoint.Hostname, endpoint.Port))
-		}
-	} else {
-		parser.Viper.SetDefault("featureFlags.environment", "development")
+	parser.Viper.SetDefault("featureFlags.environment", "development")
 
-		// load from main subdirectory
-		parser.Viper.AddConfigPath("./configs")
-		// load from working directory for integration tests
-		parser.Viper.AddConfigPath(".")
-		parser.Viper.SetConfigName("local")
-
-		err := parser.Viper.ReadInConfig()
-		if err != nil {
-			fmt.Println("Could not read configs/local.yaml, continuing with defaults")
-		}
-	}
+	// load configs/local.yaml
+	parser.Viper.AddConfigPath("./configs")
+	parser.Viper.SetConfigName("local")
+	_ = parser.Viper.ReadInConfig()
 }

--- a/internal/config/main_config.go
+++ b/internal/config/main_config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/config/parser"
+	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/rs/zerolog"
 )
 
@@ -100,6 +101,21 @@ var Sources = &config.RestEndpoints.Sources
 var Worker = &config.Worker
 
 func Initialize() {
+	if clowder.IsClowderEnabled() {
+		cfg := clowder.LoadedConfig
+		parser.Viper.Set("featureFlags.environment", "production")
+		parser.Viper.Set("database.host", cfg.Database.Hostname)
+		parser.Viper.Set("database.port", cfg.Database.Port)
+		parser.Viper.Set("database.user", cfg.Database.Username)
+		parser.Viper.Set("database.password", cfg.Database.Password)
+		parser.Viper.Set("database.name", cfg.Database.Name)
+		parser.Viper.Set("prometheus.port", cfg.MetricsPort)
+		parser.Viper.Set("prometheus.path", cfg.MetricsPath)
+		if endpoint, ok := clowder.DependencyEndpoints["sources-api"]["svc"]; ok {
+			parser.Viper.Set("restEndpoints.sources.url", fmt.Sprintf("http://%s:%d/api/sources/v3.1", endpoint.Hostname, endpoint.Port))
+		}
+	}
+
 	err := parser.Viper.Unmarshal(&config)
 	if err != nil {
 		panic(err)

--- a/internal/config/parser/known.go
+++ b/internal/config/parser/known.go
@@ -16,6 +16,7 @@ var known = [][]string{
 	{"APP.NAME", ""},
 	{"APP.PORT", ""},
 	{"APP.VERSION", ""},
+	{"APP.COMPRESSION", ""},
 	{"AWS", ""},
 	{"AWS.INSTANCEPREFIX", "AWS_INSTANCE_PREFIX"},
 	{"AWS.KEY", ""},

--- a/internal/dao/tests/account_test.go
+++ b/internal/dao/tests/account_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createAccount() *models.Account {
@@ -47,13 +48,10 @@ func TestCreateAccount(t *testing.T) {
 	defer teardownAccount(t)
 	acc := createAccount()
 	err := accDao.Create(ctx, acc)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
+
 	account, err := accDao.GetById(ctx, 2)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, acc.OrgID, account.OrgID)
 	assert.Equal(t, acc.AccountNumber.String, account.AccountNumber.String)
@@ -65,13 +63,10 @@ func TestCreateAccountWithNullAccountNumber(t *testing.T) {
 	defer teardownAccount(t)
 	acc := createAccountWithNullAccountNumber()
 	err := accDao.Create(ctx, acc)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
+
 	account, err := accDao.GetById(ctx, 2)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, acc.OrgID, account.OrgID)
 	assert.Equal(t, acc.AccountNumber.String, account.AccountNumber.String)
@@ -82,9 +77,7 @@ func TestListAccount(t *testing.T) {
 	accDao, ctx := setupAccount(t)
 	defer teardownAccount(t)
 	accounts, err := accDao.List(ctx, 100, 0)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(accounts))
 }
@@ -93,9 +86,7 @@ func TestGetByIdAccount(t *testing.T) {
 	accDao, ctx := setupAccount(t)
 	defer teardownAccount(t)
 	account, err := accDao.GetById(ctx, 1)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, "1", account.OrgID)
 	assert.Equal(t, "1", account.AccountNumber.String)
@@ -105,9 +96,7 @@ func TestGetByAccountNumber(t *testing.T) {
 	accDao, ctx := setupAccount(t)
 	defer teardownAccount(t)
 	account, err := accDao.GetByAccountNumber(ctx, "1")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, "1", account.OrgID)
 }
@@ -116,9 +105,7 @@ func TestGetByOrgId(t *testing.T) {
 	accDao, ctx := setupAccount(t)
 	defer teardownAccount(t)
 	account, err := accDao.GetByOrgId(ctx, "1")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, int64(1), account.ID)
 	assert.Equal(t, "1", account.AccountNumber.String)
@@ -128,9 +115,7 @@ func TestGetOrCreateByIdentityGet(t *testing.T) {
 	accDao, ctx := setupAccount(t)
 	defer teardownAccount(t)
 	account, err := accDao.GetOrCreateByIdentity(ctx, "1", "1")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, "1", account.OrgID)
 	assert.Equal(t, "1", account.AccountNumber.String)
@@ -140,21 +125,13 @@ func TestGetOrCreateByIdentityAccountCreate(t *testing.T) {
 	accDao, ctx := setupAccount(t)
 	defer teardownAccount(t)
 	accountsBefore, err := accDao.List(ctx, 100, 0)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	_, err = accDao.GetOrCreateByIdentity(ctx, "2", "100")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	accountsAfter, err := accDao.List(ctx, 100, 0)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	account, err := accDao.GetByOrgId(ctx, "2")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, len(accountsBefore)+1, len(accountsAfter))
 	assert.Equal(t, "2", account.OrgID)

--- a/internal/dao/tests/account_test.go
+++ b/internal/dao/tests/account_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 // +build integration
 
-package main
+package tests
 
 import (
 	"context"

--- a/internal/dao/tests/main_test.go
+++ b/internal/dao/tests/main_test.go
@@ -3,7 +3,7 @@
 
 // To override application configuration for integration tests, copy local.yaml into this directory.
 
-package main
+package tests
 
 import (
 	"fmt"

--- a/internal/dao/tests/pubkey_resource_test.go
+++ b/internal/dao/tests/pubkey_resource_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 // +build integration
 
-package main
+package tests
 
 import (
 	"context"

--- a/internal/dao/tests/pubkey_test.go
+++ b/internal/dao/tests/pubkey_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createLukas2021Key() *models.Pubkey {
@@ -48,16 +49,10 @@ func TestCreatePubkey(t *testing.T) {
 	defer teardownPubkey(t)
 	pk := createLukas2013Key()
 	err := pkDao.Create(ctx, pk)
-	if err != nil {
-		t.Errorf("Create pubkey test had failed: %v", err)
-		return
-	}
+	require.NoError(t, err)
 
 	pk2, err := pkDao.GetById(ctx, pk.ID)
-	if err != nil {
-		t.Errorf("Create pubkey test had failed: %v", err)
-		return
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, pk.Name, pk2.Name, "Create pubkey test had failed.")
 }
@@ -67,10 +62,7 @@ func TestCreatePubkeyFingerprintSuccess(t *testing.T) {
 	defer teardownPubkey(t)
 	pk := createLukas2013Key()
 	err := pkDao.Create(ctx, pk)
-	if err != nil {
-		t.Errorf("Create pubkey test had failed: %v", err)
-		return
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, "SHA256:ENShRe/0uDLSw9c+7tc9PxkD/p4blyB/DTgBSIyTAJY", pk.Fingerprint)
 }
@@ -88,10 +80,7 @@ func TestListPubkey(t *testing.T) {
 	defer teardownPubkey(t)
 	err := pkDao.Create(ctx, createLukas2013Key())
 	pubkeys, err := pkDao.List(ctx, 100, 0)
-	if err != nil {
-		t.Errorf("List pubkey test had failed: %v", err)
-		return
-	}
+	require.NoError(t, err)
 	assert.Equal(t, 2, len(pubkeys), "List Pubkey error.")
 }
 
@@ -105,21 +94,12 @@ func TestUpdatePubkey(t *testing.T) {
 	pkDao, ctx := setupPubkey(t)
 	defer teardownPubkey(t)
 	err := pkDao.Create(ctx, createLukas2013Key())
-	if err != nil {
-		t.Errorf("Create pubkey test failed. %s", err)
-		return
-	}
+	require.NoError(t, err)
 	err = pkDao.Update(ctx, updatePk)
-	if err != nil {
-		t.Errorf("Update pubkey test failed. %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	pubkeys, err := pkDao.List(ctx, 10, 0)
-	if err != nil {
-		t.Errorf("Update pubkey test failed. %s", err)
-		return
-	}
+	require.NoError(t, err)
 	assert.Equal(t, updatePk.Name, pubkeys[0].Name, "Update pubkey test had failed.")
 }
 
@@ -127,15 +107,9 @@ func TestGetPubkeyById(t *testing.T) {
 	pkDao, ctx := setupPubkey(t)
 	defer teardownPubkey(t)
 	err := pkDao.Create(ctx, createLukas2013Key())
-	if err != nil {
-		t.Errorf("Delete pubkey test had failed. %s", err)
-		return
-	}
+	require.NoError(t, err)
 	pubkey, err := pkDao.GetById(ctx, 1)
-	if err != nil {
-		t.Errorf("Get pubkey test had failed.")
-		return
-	}
+	require.NoError(t, err)
 	assert.Equal(t, "lzap-ed25519-2021", pubkey.Name, "Get Pubkey error: pubkey name does not match.")
 	assert.Equal(t, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEhnn80ZywmjeBFFOGm+cm+5HUwm62qTVnjKlOdYFLHN lzap", pubkey.Body, "Get Pubkey error: pubkey body does not match.")
 
@@ -145,24 +119,12 @@ func TestDeletePubkeyById(t *testing.T) {
 	pkDao, ctx := setupPubkey(t)
 	defer teardownPubkey(t)
 	err := pkDao.Create(ctx, createLukas2013Key())
-	if err != nil {
-		t.Errorf("Delete pubkey test had failed. %s", err)
-		return
-	}
+	require.NoError(t, err)
 	pubkeys, err := pkDao.List(ctx, 10, 0)
-	if err != nil {
-		t.Errorf("Delete pubkey test had failed")
-		return
-	}
+	require.NoError(t, err)
 	err = pkDao.Delete(ctx, 1)
-	if err != nil {
-		t.Errorf("Delete pubkey test had failed")
-		return
-	}
+	require.NoError(t, err)
 	pubkeysAfter, err := pkDao.List(ctx, 10, 0)
-	if err != nil {
-		t.Errorf("Delete pubkey test had failed")
-		return
-	}
+	require.NoError(t, err)
 	assert.Equal(t, len(pubkeys)-1, len(pubkeysAfter), "Delete Pubkey error.")
 }

--- a/internal/dao/tests/pubkey_test.go
+++ b/internal/dao/tests/pubkey_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 // +build integration
 
-package main
+package tests
 
 import (
 	"context"

--- a/internal/dao/tests/reservation_test.go
+++ b/internal/dao/tests/reservation_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 // +build integration
 
-package main
+package tests
 
 import (
 	"context"


### PR DESCRIPTION
Fixes configuration of tests, add missing ENV variable and adds NoError in all DAO tests.

Three commits, see commit messages for more details.

ACTION REQUIRED: This patch also fixes configuration loading, it now properly finds the path to the config file. Please move your `cmd/dao_test/local.yaml` to `configs/local.integration.yaml` to get it loaded properly.