### PR TITLE
Pubkey resource unscoped by account

### DIFF
--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -42,12 +42,15 @@ type PubkeyDao interface {
 
 var GetPubkeyResourceDao func(ctx context.Context) (PubkeyResourceDao, error)
 
-// PubkeyResourceDao TODO
+// PubkeyResourceDao interface for manipulating data of Pubkey deployed into cloud provider.
+// Allows to track the key in the cloud provider and manage it.
+// All methods are unscoped by Account and thus should not get user input as input directly,
+// input should first be validated by PubkeyDao.GetById
 type PubkeyResourceDao interface {
-	GetResourceByProviderType(ctx context.Context, pubkeyId int64, provider models.ProviderType) (*models.PubkeyResource, error)
-	ListByPubkeyId(ctx context.Context, pkId int64) ([]*models.PubkeyResource, error)
-	Create(ctx context.Context, pkr *models.PubkeyResource) error
-	Delete(ctx context.Context, id int64) error
+	UnscopedGetResourceByProviderType(ctx context.Context, pubkeyId int64, provider models.ProviderType) (*models.PubkeyResource, error)
+	UnscopedListByPubkeyId(ctx context.Context, pkId int64) ([]*models.PubkeyResource, error)
+	UnscopedCreate(ctx context.Context, pkr *models.PubkeyResource) error
+	UnscopedDelete(ctx context.Context, id int64) error
 }
 
 var GetReservationDao func(ctx context.Context) (ReservationDao, error)

--- a/internal/dao/sqlx/pubkey_resource_dao.go
+++ b/internal/dao/sqlx/pubkey_resource_dao.go
@@ -59,7 +59,7 @@ func init() {
 	dao.GetPubkeyResourceDao = getPubkeyResourceDao
 }
 
-func (di *pubkeyResourceDaoSqlx) GetResourceByProviderType(ctx context.Context, pubkeyId int64, provider models.ProviderType) (*models.PubkeyResource, error) {
+func (di *pubkeyResourceDaoSqlx) UnscopedGetResourceByProviderType(ctx context.Context, pubkeyId int64, provider models.ProviderType) (*models.PubkeyResource, error) {
 	query := getPubkeyResourceByProviderType
 	stmt := di.getByProviderType
 	result := &models.PubkeyResource{}
@@ -75,7 +75,7 @@ func (di *pubkeyResourceDaoSqlx) GetResourceByProviderType(ctx context.Context, 
 	return result, nil
 }
 
-func (di *pubkeyResourceDaoSqlx) Create(ctx context.Context, pkr *models.PubkeyResource) error {
+func (di *pubkeyResourceDaoSqlx) UnscopedCreate(ctx context.Context, pkr *models.PubkeyResource) error {
 	query := createPubkeyResource
 	stmt := di.create
 
@@ -86,7 +86,7 @@ func (di *pubkeyResourceDaoSqlx) Create(ctx context.Context, pkr *models.PubkeyR
 	return nil
 }
 
-func (di *pubkeyResourceDaoSqlx) Delete(ctx context.Context, id int64) error {
+func (di *pubkeyResourceDaoSqlx) UnscopedDelete(ctx context.Context, id int64) error {
 	query := deletePubkeyResourceById
 	stmt := di.deleteById
 
@@ -101,7 +101,7 @@ func (di *pubkeyResourceDaoSqlx) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
-func (di *pubkeyResourceDaoSqlx) ListByPubkeyId(ctx context.Context, pkId int64) ([]*models.PubkeyResource, error) {
+func (di *pubkeyResourceDaoSqlx) UnscopedListByPubkeyId(ctx context.Context, pkId int64) ([]*models.PubkeyResource, error) {
 	query := listByPubkeyId
 	stmt := di.listByPubkeyId
 	var result []*models.PubkeyResource

--- a/internal/dao/tests/pubkey_resource_test.go
+++ b/internal/dao/tests/pubkey_resource_test.go
@@ -33,7 +33,7 @@ func createPubkeyResourceAzure() *models.PubkeyResource {
 	}
 }
 
-func setupResource(t *testing.T) (dao.PubkeyResourceDao, context.Context) {
+func setupPubkeyResource(t *testing.T) (dao.PubkeyResourceDao, context.Context) {
 	setup()
 	ctx := identity.WithTenant(t, context.Background())
 	resourceDao, err := dao.GetPubkeyResourceDao(ctx)
@@ -48,12 +48,12 @@ func teardownPubkeyResource(_ *testing.T) {
 }
 
 func TestCreateResource(t *testing.T) {
-	resourceDao, ctx := setupResource(t)
+	resourceDao, ctx := setupPubkeyResource(t)
 	defer teardownPubkeyResource(t)
 	resource := createPubkeyResourceNoop()
-	err := resourceDao.Create(ctx, resource)
+	err := resourceDao.UnscopedCreate(ctx, resource)
 	require.NoError(t, err)
-	resources, err := resourceDao.ListByPubkeyId(ctx, resource.PubkeyID)
+	resources, err := resourceDao.UnscopedListByPubkeyId(ctx, resource.PubkeyID)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(resources))
@@ -61,30 +61,30 @@ func TestCreateResource(t *testing.T) {
 }
 
 func TestGetResourceByProviderType(t *testing.T) {
-	resourceDao, ctx := setupResource(t)
+	resourceDao, ctx := setupPubkeyResource(t)
 	defer teardownPubkeyResource(t)
 	resource := createPubkeyResourceNoop()
-	err := resourceDao.Create(ctx, resource)
+	err := resourceDao.UnscopedCreate(ctx, resource)
 	require.NoError(t, err)
-	createdResource, err := resourceDao.GetResourceByProviderType(ctx, resource.PubkeyID, resource.Provider)
+	createdResource, err := resourceDao.UnscopedGetResourceByProviderType(ctx, resource.PubkeyID, resource.Provider)
 	require.NoError(t, err)
 
 	assert.Equal(t, resource, createdResource)
 }
 
 func TestListByPubkeyIdResource(t *testing.T) {
-	resourceDao, ctx := setupResource(t)
+	resourceDao, ctx := setupPubkeyResource(t)
 	defer teardownPubkeyResource(t)
 	pkId := int64(1)
-	resourcesBefore, err := resourceDao.ListByPubkeyId(ctx, pkId)
+	resourcesBefore, err := resourceDao.UnscopedListByPubkeyId(ctx, pkId)
 	require.NoError(t, err)
 	noopResource := createPubkeyResourceNoop()
-	err = resourceDao.Create(ctx, noopResource)
+	err = resourceDao.UnscopedCreate(ctx, noopResource)
 	require.NoError(t, err)
 	azureResource := createPubkeyResourceAzure()
-	err = resourceDao.Create(ctx, azureResource)
+	err = resourceDao.UnscopedCreate(ctx, azureResource)
 	require.NoError(t, err)
-	resourcesAfter, err := resourceDao.ListByPubkeyId(ctx, pkId)
+	resourcesAfter, err := resourceDao.UnscopedListByPubkeyId(ctx, pkId)
 	require.NoError(t, err)
 
 	assert.Equal(t, len(resourcesBefore)+2, len(resourcesAfter))
@@ -93,19 +93,19 @@ func TestListByPubkeyIdResource(t *testing.T) {
 }
 
 func TestDeleteResource(t *testing.T) {
-	resourceDao, ctx := setupResource(t)
+	resourceDao, ctx := setupPubkeyResource(t)
 	defer teardownPubkeyResource(t)
 	resource := createPubkeyResourceNoop()
-	err := resourceDao.Create(ctx, resource)
+	err := resourceDao.UnscopedCreate(ctx, resource)
 	require.NoError(t, err)
-	resources, err := resourceDao.ListByPubkeyId(ctx, resource.PubkeyID)
+	resources, err := resourceDao.UnscopedListByPubkeyId(ctx, resource.PubkeyID)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(resources))
 
-	err = resourceDao.Delete(ctx, resource.ID)
+	err = resourceDao.UnscopedDelete(ctx, resource.ID)
 	require.NoError(t, err)
-	resources, err = resourceDao.ListByPubkeyId(ctx, resource.PubkeyID)
+	resources, err = resourceDao.UnscopedListByPubkeyId(ctx, resource.PubkeyID)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, len(resources))

--- a/internal/jobs/pubkey_upload_aws_job.go
+++ b/internal/jobs/pubkey_upload_aws_job.go
@@ -66,7 +66,7 @@ func handlePubkeyUploadAWS(ctx context.Context, args *PubkeyUploadAWSTaskArgs) e
 
 	// check presence first
 	skip := true
-	pkrCheck, errDao := pkrDao.GetResourceByProviderType(ctx, args.PubkeyID, models.ProviderTypeAWS)
+	pkrCheck, errDao := pkrDao.UnscopedGetResourceByProviderType(ctx, args.PubkeyID, models.ProviderTypeAWS)
 	if errDao != nil {
 		var e dao.NoRowsError
 		if errors.As(errDao, &e) {
@@ -105,7 +105,7 @@ func handlePubkeyUploadAWS(ctx context.Context, args *PubkeyUploadAWSTaskArgs) e
 	}
 
 	// create resource with handle
-	err = pkrDao.Create(ctx, &pkr)
+	err = pkrDao.UnscopedCreate(ctx, &pkr)
 	if err != nil {
 		return fmt.Errorf("cannot upload aws pubkey: %w", err)
 	}


### PR DESCRIPTION
Rename pubkey reservation dao methods.

This might be bit too much to add prefix, suffix might have enough visibility, happy to change to whatever we agree on :)