### PR TITLE
Unify service test assertions and error handling

### DIFF
--- a/internal/services/aws_reservation_service_test.go
+++ b/internal/services/aws_reservation_service_test.go
@@ -1,10 +1,9 @@
-package services
+package services_test
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,9 +11,11 @@ import (
 	Clientstubs "github.com/RHEnVision/provisioning-backend/internal/clients/stubs"
 	"github.com/RHEnVision/provisioning-backend/internal/dao/stubs"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/services"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
 	_ "github.com/RHEnVision/provisioning-backend/internal/testing/initialization"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateAWSReservationHandler(t *testing.T) {
@@ -28,7 +29,7 @@ func TestCreateAWSReservationHandler(t *testing.T) {
 	ctx = stubs.WithPubkeyDao(ctx)
 	pk := models.Pubkey{Name: "new", Body: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8w6DONv1qn3IdgxSpkYOClq7oe7davWFqKVHPbLoS6+dFInru7gdEO5byhTih6+PwRhHv/b1I+Mtt5MDZ8Sv7XFYpX/3P/u5zQiy1PkMSFSz0brRRUfEQxhXLW97FJa7l+bej2HJDt7f9Gvcj+d/fNWC9Z58/GX11kWk4SIXaKotkN+kWn54xGGS7Zvtm86fP59Srt6wlklSsG8mZBF7jVUjyhAgm/V5gDFb2/6jfiwSb2HyJ9/NbhLkWNdwrvpdGZqQlYhnwTfEZdpwizW/Mj3MxP5O31HN45aE0wog0UeWY4gvTl4Ogb6kescizAM6pCff3RBslbFxLdOO7cR17 lzap+rsakey@redhat.com"}
 	err = stubs.AddPubkey(ctx, &pk)
-	assert.Nil(t, err, fmt.Sprintf("Error GeneratePubkey: %v", err))
+	require.NoError(t, err, "failed to generate pubkey")
 
 	values := map[string]interface{}{
 		"source_id":     "1",
@@ -38,20 +39,20 @@ func TestCreateAWSReservationHandler(t *testing.T) {
 		"pubkey_id":     pk.ID,
 	}
 	if json_data, err = json.Marshal(values); err != nil {
-		t.Fatal("unable to marshal values to json")
+		t.Fatalf("unable to marshal values to json: %v", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/reservations/aws", bytes.NewBuffer(json_data))
+	require.NoError(t, err, "failed to create request")
 	req.Header.Add("Content-Type", "application/json")
-	assert.Nil(t, err, fmt.Sprintf("Error creating a new request: %v", err))
 
 	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(CreateAWSReservation)
+	handler := http.HandlerFunc(services.CreateAWSReservation)
 	handler.ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
+	require.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
 
-	storecnt, err := stubs.ReservationStubCount(ctx)
-	assert.Nil(t, err, fmt.Sprintf("Error reading stub count: %v", err))
-	assert.Equal(t, 1, storecnt, "Reservation has not been Created through DAO")
+	stubCount, err := stubs.ReservationStubCount(ctx)
+	require.NoError(t, err, "failed to read count from stubbed store")
+	assert.Equal(t, 1, stubCount, "Reservation has not been Created through DAO")
 }

--- a/internal/services/noop_reservation_service_test.go
+++ b/internal/services/noop_reservation_service_test.go
@@ -1,4 +1,4 @@
-package services
+package services_test
 
 import (
 	"context"
@@ -25,6 +25,6 @@ func TestEnqueueNoopJob(t *testing.T) {
 	}
 }
 
-func TestCreateNoopReservation(t *testing.T) {
+func TestCreateNoopReservationHandler(t *testing.T) {
 	// TODO full service test
 }

--- a/internal/services/sources_service_test.go
+++ b/internal/services/sources_service_test.go
@@ -3,12 +3,12 @@ package services
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	_ "github.com/RHEnVision/provisioning-backend/internal/testing/initialization"
+	"github.com/stretchr/testify/require"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http/sources"
 	clientStub "github.com/RHEnVision/provisioning-backend/internal/clients/stubs"
@@ -23,21 +23,18 @@ func TestListSourcesHandler(t *testing.T) {
 	ctx = clientStub.WithSourcesClient(ctx)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", "/api/provisioning/sources", nil)
-	assert.Nil(t, err, fmt.Sprintf("Error creating a new request: %v", err))
+	require.NoError(t, err, "failed to create request")
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(ListSources)
 	handler.ServeHTTP(rr, req)
 
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("Handler returned wrong status code. Expected: %d. Got: %d.", http.StatusOK, status)
-	}
+	require.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
 
 	var result []sources.Source
 
-	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
-		t.Errorf("Error decoding response body: %v", err)
-	}
+	err = json.NewDecoder(rr.Body).Decode(&result)
+	require.NoError(t, err, "failed to decode response body")
 
 	assert.Equal(t, 2, len(result), "expected two result in response json")
 }


### PR DESCRIPTION
Puts all service tests under the services_test package.
Uses require for cases where we want to stop further test execution
Unify failures handling accros the test files.