### PR TITLE
Add azure instance types endpoint

### DIFF
--- a/internal/clients/filter_instances_test.go
+++ b/internal/clients/filter_instances_test.go
@@ -73,13 +73,13 @@ func TestNewInstanceTypes(t *testing.T) {
 	res, err := ec2.NewInstanceTypes(context.Background(), AWSInstanceTypes)
 	assert.Nil(t, err)
 	// Check that two instance types were created, one per architecture
-	assert.Equal(t, len(*res), 3)
-	assert.Equal(t, clients.InstanceTypeName("a1.2xlarge"), (*res)[0].Name)
-	assert.Equal(t, clients.InstanceTypeName("a1.2xlarge"), (*res)[1].Name)
-	assert.Equal(t, clients.InstanceTypeName("c5.xlarge"), (*res)[2].Name)
+	assert.Equal(t, len(res), 3)
+	assert.Equal(t, clients.InstanceTypeName("a1.2xlarge"), (res)[0].Name)
+	assert.Equal(t, clients.InstanceTypeName("a1.2xlarge"), (res)[1].Name)
+	assert.Equal(t, clients.InstanceTypeName("c5.xlarge"), (res)[2].Name)
 	// Check that instance types which does not appear in supported_instance_yml are marked as unsupported
-	assert.Equal(t, (*res)[0].Supported, false)
-	assert.Equal(t, (*res)[1].Supported, false)
+	assert.Equal(t, (res)[0].Supported, false)
+	assert.Equal(t, (res)[1].Supported, false)
 	// Check that instance types which appear in supported_instance_yml are marked as supported
-	assert.Equal(t, (*res)[2].Supported, true)
+	assert.Equal(t, (res)[2].Supported, true)
 }

--- a/internal/clients/http/azure/types/azure_types.go
+++ b/internal/clients/http/azure/types/azure_types.go
@@ -1,49 +1,92 @@
 package types
 
 import (
+	"bytes"
 	"embed"
+	"fmt"
+	"path/filepath"
+	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/middleware"
 )
 
 //go:embed *.yaml availability/*.yaml
 var fsTypes embed.FS
 
-var registeredTypes clients.RegisteredInstanceTypes
-var regionalAvailability clients.RegionalTypeAvailability
+const availabilityPath = "availability"
+
+var etag *middleware.ETag
+
+var typeInfo clients.InstanceTypeInfo
 
 func init() {
 	// load instance types
-	buffer, err := fsTypes.ReadFile("types.yaml")
+	typesBuf, err := fsTypes.ReadFile("types.yaml")
 	if err != nil {
 		panic(err)
 	}
-	err = registeredTypes.Load(buffer)
+	err = typeInfo.RegisteredTypes.Load(typesBuf)
 	if err != nil {
 		panic(err)
 	}
 
 	// load supported types
-	buffer, err = fsTypes.ReadFile("supported.yaml")
+	supportedBuf, err := fsTypes.ReadFile("supported.yaml")
 	if err != nil {
 		panic(err)
 	}
-	err = registeredTypes.LoadSupported(buffer)
+	err = typeInfo.RegisteredTypes.LoadSupported(supportedBuf)
 	if err != nil {
 		panic(err)
 	}
 
 	// load availability information
-	err = regionalAvailability.Load(fsTypes, "availability")
+	err = typeInfo.RegionalAvailability.Load(fsTypes, availabilityPath)
+	if err != nil {
+		panic(err)
+	}
+
+	// calculate etag
+	// concatenate all yamls into one 1 MiB buffer
+	dirEntries, err := fsTypes.ReadDir(availabilityPath)
+	if err != nil {
+		panic(err)
+	}
+	availBuf := bytes.NewBuffer(make([]byte, 0, 2^20))
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() {
+			continue
+		}
+		file := filepath.Join(availabilityPath, dirEntry.Name())
+		buffer, errBuf := fsTypes.ReadFile(file)
+		if errBuf != nil {
+			panic(errBuf)
+		}
+		availBuf.Write(buffer)
+	}
+	etag, err = middleware.GenerateETagFromBuffer("azure-types", 30*time.Minute, typesBuf, supportedBuf, availBuf.Bytes())
 	if err != nil {
 		panic(err)
 	}
 }
 
+func ETagValue() *middleware.ETag {
+	return etag
+}
+
 func PrintRegisteredTypes(typeName string) {
-	registeredTypes.Print(typeName)
+	typeInfo.RegisteredTypes.Print(typeName)
 }
 
 func PrintRegionalAvailability(region, zone string) {
-	regionalAvailability.Print(region, zone)
+	typeInfo.RegionalAvailability.Print(region, zone)
+}
+
+func InstanceTypesForZone(region, zone string, supported *bool) ([]*clients.InstanceType, error) {
+	result, err := typeInfo.InstanceTypesForZone(region, zone, supported)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list instance types for region and zone: %w", err)
+	}
+	return result, nil
 }

--- a/internal/clients/http/ec2/aws_supported_types.go
+++ b/internal/clients/http/ec2/aws_supported_types.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
-func NewInstanceTypes(ctx context.Context, types []types.InstanceTypeInfo) (*[]clients.InstanceType, error) {
-	list := make([]clients.InstanceType, 0, len(types))
+func NewInstanceTypes(ctx context.Context, types []types.InstanceTypeInfo) ([]*clients.InstanceType, error) {
+	list := make([]*clients.InstanceType, 0, len(types))
 	for i := range types {
 		architectures := types[i].ProcessorInfo.SupportedArchitectures
 		for _, arch := range architectures {
@@ -29,8 +29,8 @@ func NewInstanceTypes(ctx context.Context, types []types.InstanceTypeInfo) (*[]c
 			if types[i].InstanceStorageInfo != nil {
 				it.EphemeralStorageGB = *types[i].InstanceStorageInfo.TotalSizeInGB
 			}
-			list = append(list, it)
+			list = append(list, &it)
 		}
 	}
-	return &list, nil
+	return list, nil
 }

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -10,14 +10,6 @@ import (
 	"github.com/go-chi/render"
 )
 
-type ParamMissingError struct {
-	ParamName string
-}
-
-func (e ParamMissingError) Error() string {
-	return fmt.Sprintf("parameter %s was not provided in the request", e.ParamName)
-}
-
 // ResponseError implements Go standard error interface as well as Wrapper and Renderer
 type ResponseError struct {
 	// HTTP status code
@@ -52,7 +44,7 @@ func (e *ResponseError) Unwrap() error {
 func NewInvalidRequestError(ctx context.Context, err error) *ResponseError {
 	msg := fmt.Sprintf("invalid request: %v", err)
 	if logger := ctxval.Logger(ctx); logger != nil {
-		logger.Error().Msg(msg)
+		logger.Warn().Msg(msg)
 	}
 	return &ResponseError{
 		HTTPStatusCode: 400,
@@ -63,10 +55,23 @@ func NewInvalidRequestError(ctx context.Context, err error) *ResponseError {
 	}
 }
 
+func NewMissingRequestParameterError(ctx context.Context, param string) *ResponseError {
+	msg := fmt.Sprintf("missing parameter: %s", param)
+	if logger := ctxval.Logger(ctx); logger != nil {
+		logger.Warn().Msg(msg)
+	}
+	return &ResponseError{
+		HTTPStatusCode: 400,
+		Message:        msg,
+		RequestId:      ctxval.RequestId(ctx),
+		Context:        ctx,
+	}
+}
+
 func PubkeyAlreadyExistsError(ctx context.Context, err error) *ResponseError {
 	msg := "pubkey with such name or fingerprint already exists for this account"
 	if logger := ctxval.Logger(ctx); logger != nil {
-		logger.Error().Msg(msg)
+		logger.Warn().Msg(msg)
 	}
 	return &ResponseError{
 		HTTPStatusCode: 422,
@@ -178,7 +183,7 @@ func NewRenderError(ctx context.Context, message string, err error) *ResponseErr
 func NewURLParsingError(ctx context.Context, paramName string, err error) *ResponseError {
 	msg := fmt.Sprintf("URL parsing error for param '%s': %v", paramName, err)
 	if logger := ctxval.Logger(ctx); logger != nil {
-		logger.Error().Msg(msg)
+		logger.Warn().Msg(msg)
 	}
 	return &ResponseError{
 		HTTPStatusCode: 400,

--- a/internal/payloads/instance_types_payload.go
+++ b/internal/payloads/instance_types_payload.go
@@ -8,7 +8,7 @@ import (
 )
 
 type InstanceTypeResponse struct {
-	clients.InstanceType
+	*clients.InstanceType
 }
 
 func (s *InstanceTypeResponse) Bind(_ *http.Request) error {
@@ -19,9 +19,9 @@ func (s *InstanceTypeResponse) Render(_ http.ResponseWriter, _ *http.Request) er
 	return nil
 }
 
-func NewListInstanceTypeResponse(sl *[]clients.InstanceType) []render.Renderer {
-	list := make([]render.Renderer, 0, len(*sl))
-	for _, instanceType := range *sl {
+func NewListInstanceTypeResponse(sl []*clients.InstanceType) []render.Renderer {
+	list := make([]render.Renderer, 0, len(sl))
+	for _, instanceType := range sl {
 		list = append(list, &InstanceTypeResponse{instanceType})
 	}
 	return list

--- a/internal/services/builtin_types_service.go
+++ b/internal/services/builtin_types_service.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients/http/azure/types"
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+	"github.com/go-chi/render"
+)
+
+func ListAzureBuiltinInstanceTypes(w http.ResponseWriter, r *http.Request) {
+	region := strings.ToLower(r.URL.Query().Get("region"))
+	zone := strings.ToLower(r.URL.Query().Get("zone"))
+	supported, err := ParseBool(r.URL.Query().Get("supported"))
+	if err != nil {
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), err))
+		return
+	}
+
+	if region == "" {
+		renderError(w, r, payloads.NewMissingRequestParameterError(r.Context(), "region"))
+		return
+	}
+	if zone == "" {
+		renderError(w, r, payloads.NewMissingRequestParameterError(r.Context(), "zone"))
+		return
+	}
+
+	start := time.Now()
+	instances, err := types.InstanceTypesForZone(region, zone, supported)
+	logger := ctxval.Logger(r.Context())
+	logger.Trace().TimeDiff("duration", time.Now(), start).Msg("Listed instance types")
+	if err != nil {
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), err))
+		return
+	}
+
+	if err := render.RenderList(w, r, payloads.NewListInstanceTypeResponse(instances)); err != nil {
+		renderError(w, r, payloads.NewRenderError(r.Context(), "list instance types", err))
+		return
+	}
+}

--- a/internal/services/instance_types_service.go
+++ b/internal/services/instance_types_service.go
@@ -19,7 +19,7 @@ func ListInstanceTypes(w http.ResponseWriter, r *http.Request) {
 	sourceId := chi.URLParam(r, "ID")
 	region := r.URL.Query().Get("region")
 	if region == "" {
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), payloads.ParamMissingError{ParamName: "region"}))
+		renderError(w, r, payloads.NewMissingRequestParameterError(r.Context(), "region"))
 	}
 
 	sourcesClient, err := clients.GetSourcesClient(r.Context())
@@ -56,7 +56,7 @@ func ListInstanceTypes(w http.ResponseWriter, r *http.Request) {
 
 	numBefore := len(res)
 	instances, err := ec2.NewInstanceTypes(r.Context(), res)
-	logger.Trace().Msgf("Total AWS EC2 instance types: %d (%d after architecture breakdown)", numBefore, len(*instances))
+	logger.Trace().Msgf("Total AWS EC2 instance types: %d (%d after architecture breakdown)", numBefore, len(instances))
 	if err != nil {
 		renderError(w, r, payloads.NewAWSError(r.Context(), "can't convertAWSTypes", err))
 		return

--- a/internal/services/instance_types_service_test.go
+++ b/internal/services/instance_types_service_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	clientStub "github.com/RHEnVision/provisioning-backend/internal/clients/stubs"
 	"github.com/RHEnVision/provisioning-backend/internal/dao/stubs"
-	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/RHEnVision/provisioning-backend/internal/services"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
 	"github.com/stretchr/testify/assert"
@@ -63,7 +62,7 @@ func TestListInstanceTypesHandler(t *testing.T) {
 
 		require.Equal(t, http.StatusBadRequest, rr.Code, "Handler returned wrong status code")
 
-		assert.Error(t, payloads.ParamMissingError{})
+		assert.Contains(t, rr.Body.String(), "missing parameter")
 	})
 
 }

--- a/internal/services/parameters.go
+++ b/internal/services/parameters.go
@@ -8,10 +8,34 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// ParseInt64 converts param into int64. If param does not exist, it returns an error.
+// TODO: It would be better to move chi.URLParam call out of this function so it can
+// be also used for URL params. See below for an examples (MustParseBool/ParseBool).
 func ParseInt64(r *http.Request, param string) (int64, error) {
 	i, err := strconv.ParseInt(chi.URLParam(r, param), 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("error converting URL param to int64: %w", err)
+		return 0, fmt.Errorf("error parsing URL param '%s' to int64: %w", param, err)
 	}
 	return i, nil
+}
+
+// MustParseBool converts string into bool. If string is empty, it returns an error.
+func MustParseBool(str string) (bool, error) {
+	b, err := strconv.ParseBool(str)
+	if err != nil {
+		return false, fmt.Errorf("error parsing '%s' to bool: %w", str, err)
+	}
+	return b, nil
+}
+
+// ParseBool converts string into bool. Returns nil when string is empty.
+func ParseBool(str string) (*bool, error) {
+	if str == "" {
+		return nil, nil
+	}
+	b, err := strconv.ParseBool(str)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing '%s' to bool: %w", str, err)
+	}
+	return &b, nil
 }

--- a/scripts/rest_examples/instancetypes-azure-list.http
+++ b/scripts/rest_examples/instancetypes-azure-list.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/instance_types/azure/?region=eastus&zone=1&supported=true HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}


### PR DESCRIPTION
This adds a new endpoint, since we don't have Azure sources integration yet, I am adding it as a separate endpoint that is also documented as undocumented :-) Meaning, there is no OpenAPI for this endpoint, it can be used for quick lookups in the instance type database without having any source record. I propose to keep such endpoint for our own development purposes.

This can serve as an example how to implement the same for EC2 for @avitova. In that case, we already have sources integration so both `/sources/ID/instance_types` and `/instance_types` should be implementing returning the very same results. Note EC2 endpoint currently only supports region, we need to add zones as well.