### PR TITLE
Split Makefile and create devel docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ TAGS
 /deploy/bonfire.yaml
 /Containerfile
 /tern.conf
+/mk/private.mk
 /scripts/sources-*/
 /scripts/sources.local.conf
 /scripts/rest_examples/*.local.http

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -1,0 +1,88 @@
+# Setting up dev environment
+
+This document elaborates the main [README](../README.md) into more details.
+
+## Go
+
+We do recommend to use the [official Go build](https://go.dev/doc/install) in the version that is the minimum required version as specified in the README. Avoid using distributions from Linux package management or MacOS Homebrew because they may carry additional patches and the update pace is different.
+
+The ideal installation location is `~/go`, then just add `~/go/bin` to PATH and restart all terminals. If you choose a different location, make sure to also set GOROOT [environment variable](https://pkg.go.dev/cmd/go#hdr-Environment_variables). There are also other variables available to change specific directories, this can be useful for moving cache or temp directories outside of your home directory and out of your backups.
+
+Tip: Go installation can be fully done in GoLang preferences, the default installation location is `~/go`.
+
+## Editor or IDE
+
+Luckily, Go language contains the very cool `go fmt` utility which we take advantage. We stick with the Go language recommendations, on top of that we use `goimports` tool for import sorting to prevent git conflicts.
+
+We do have [EditorConfig](../.editorconfig) file that should automatically configure most of the editors and IDEs in regard to tabs vs spaces and other small details.
+
+Most of our team members use either Jetbrains GoLand, or VSCode. Here are the recommended settings for **GoLand**:
+
+* Make sure to select the correct Go version in Preferences - Go - GOROOT.
+* You need to set `goimports` import sort style in Preferences - Editor - Code Style - Go, otherwise our CI job (and your `make fmt` target) will complain about it all the time.
+* GoLand comes with batteries included, no other changes or plugins are needed.
+
+**VSCode** recommended settings:
+
+* Install the official Go language plugin and HTTP Client plugin.
+* For the HTTP plugin to work with the provided [HTTP files](../scripts/rest_examples), open up the user settings JSON file and enter the snippet from below (copy variables from `http-client.env.json`).
+
+```json
+{
+  "rest-client.environmentVariables": {
+    "dev": {
+      "hostname": "x",
+      "port": "x"
+    }
+  }
+}
+```
+
+## Additional Go versions
+
+Go language fully supports multi-version installation. Just follow [the official documentation](https://go.dev/doc/manage-install) by using the `go install` command.
+
+Tip: GoLang fully supports multi-version installation and you can switch versions in preferences.
+
+## Make
+
+A make utility is used, we test on GNU Make which is available on all supported platforms. Use `make help` or read the [on-line make help](../docs/make.md) for additional help on what's available.
+
+## Additional utilities
+
+There are few utilities that you will need like code linter, `goimports` or migration tool for creating new migrations. Install them with `make install-tools`.
+
+## Postgres
+
+Installation and configuration of Postgres is not covered neither in this article nor in the README. Full administrator access into an empty database is assumed as the application performs DDL commands during start. Or create a user with create table privileges.
+
+Tip: On MacOS, you can install Postgres on a remote Linux (or a small VM) and configure the application to connect there, instead of localhost.
+
+## Compilation and startup
+
+Use `make` command to compile the main application, use `make run` or start it manually via `./pbapi`.
+
+The application performs automatic migration of database tables and keeps the schema up-to-date. In addition, it maintains initial data ([seed data](../internal/db/seeds/dev_small.sql)) in the database. If you delete such data, it will attempt to create it again.
+
+Notable records created via seed script:
+
+* Account number 13 with organization id 000013. This account is the first account (ID=1) and it is very often used on many examples (including this document). For [example](../scripts/rest_examples/http-client.env.json), RH-Identity-Header is an HTTP header that MUST be present in ALL requests, it is a base64-encoded JSON string which includes account number.
+* An example SSH public key.
+
+## Backend services
+
+The application integrates with multiple backend services which are required to be available for most HTTP request to complete successfully.
+
+## Sources
+
+[Sources](https://github.com/RedHatInsights/sources-api-go) is an authentication inventory. Since it only requires Go, Redis and Postgres, we created a shell script that automatically checks out sources from git, compiles it, installs and creates postgres database, seeds data and starts the sources application.
+
+Follow [instructions](../scripts/README.sources) to perform the setup. Note that configuration via `sources.local.conf` is **required** before the setup procedure. This has been written and tested for Fedora Linux, in other operating systems perform all the commands manually.
+
+Tip: On MacOS, you can install Sources on a remote Fedora Linux (or a small VM) and configure the application to connect there, instead of localhost.
+
+Tip: Alternatively, the application supports connecting to the stage environment through a HTTP proxy. See [configuration example](../configs/local_example.yaml) for more details. Make sure to use account number from stage environment instead of the pre-seeded account number 000013.
+
+## Image Builder
+
+Because Image Builder is more complex for installation, we do not recommend installing it on your local machine right now. Configure connection through HTTP proxy to the stage environment in `local.yaml`. See [configuration example](../configs/local_example.yaml) for an example, you will need to ask someone from the company for real URLs for the service and the proxy.

--- a/docs/make.md
+++ b/docs/make.md
@@ -1,0 +1,53 @@
+# Make documentation
+```
+
+Usage:
+  make <target>
+
+HTTP Clients
+  update-clients        Update HTTP client stubs from upstream git repos
+  validate-clients      Compare generated client code with git
+
+Code quality
+  fmt                   Format the project using `go fmt`
+  lint                  Run Go language linter `golangci-lint`
+
+Building
+  build                 Build all binaries
+  pbapi                 Build backend API service
+  pbworker              Build worker service
+  pbmigrate             Build migration command
+  strip                 Strip debug information
+  run-go                Run backend API using `go run`
+  run                   Build and run backend API
+  clean                 Clean build artifacts
+
+Image building
+  build-podman          Build container image using Podman
+
+Database migrations
+  migrate               Run database migration
+  purgedb               Delete database (dangerous!)
+  generate-migration    Generate new migration file, use MIGRATION_NAME=name
+
+Go modules
+  tidy-deps             Cleanup Go modules
+  download-deps         Download Go modules
+  update-deps           Update Go modules to latest versions
+  help                  Print out the help content
+
+OpenAPI
+  generate-spec         Generate OpenAPI spec
+  validate-spec         Compare OpenAPI spec with git
+
+Testing
+  test                  Run unit tests
+  integration-test      Run integration tests (require database)
+
+Go commands
+  install-tools         Install required Go commands
+
+Instance types
+  generate-azure-types  Generate instance types for Azure
+  generate-types        Generate instance types for all providers
+```

--- a/mk/0_initial.mk
+++ b/mk/0_initial.mk
@@ -1,0 +1,5 @@
+#
+# Initial file (included as the first)
+#
+
+PROJECT_DIR := $(shell dirname $(abspath $(firstword $(MAKEFILE_LIST))))

--- a/mk/clients.mk
+++ b/mk/clients.mk
@@ -1,0 +1,19 @@
+##@ HTTP Clients
+
+.PHONY: update-clients
+update-clients: ## Update HTTP client stubs from upstream git repos
+	wget -O ./configs/ib_api.yaml -qN https://raw.githubusercontent.com/osbuild/image-builder/main/internal/v1/api.yaml
+	wget -O ./configs/sources_api.json -qN https://raw.githubusercontent.com/RedHatInsights/sources-api-go/main/public/openapi-3-v3.1.json
+
+generate-clients: internal/clients/http/image_builder/client.gen.go internal/clients/http/sources/client.gen.go
+
+internal/clients/http/sources/client.gen.go: configs/sources_config.yml configs/sources_api.json
+	oapi-codegen -config ./configs/sources_config.yml ./configs/sources_api.json
+
+internal/clients/http/image_builder/client.gen.go: configs/ib_config.yaml configs/ib_api.yaml
+	oapi-codegen -config ./configs/ib_config.yaml ./configs/ib_api.yaml
+
+.PHONY: validate-clients
+validate-clients: generate-clients ## Compare generated client code with git
+	git diff --exit-code internal/clients/*/client.gen.go
+

--- a/mk/code.mk
+++ b/mk/code.mk
@@ -1,0 +1,11 @@
+##@ Code quality
+
+.PHONY: fmt
+fmt: ## Format the project using `go fmt`
+	go fmt ./...
+	goimports -w .
+
+.PHONY: lint
+lint: ## Run Go language linter `golangci-lint`
+	golangci-lint run
+

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -1,0 +1,35 @@
+##@ Building
+
+SRC_GO := $(shell find . -name \*.go -print)
+SRC_SQL := $(shell find . -name \*.sql -print)
+SRC_YAML := $(shell find . -name \*.yaml -print)
+
+PACKAGE_BASE = github.com/RHEnVision/provisioning-backend/internal
+LDFLAGS = "-X $(PACKAGE_BASE)/version.BuildCommit=$(shell git rev-parse --short HEAD) -X $(PACKAGE_BASE)/version.BuildTime=$(shell date +'%Y-%m-%d_%T')"
+
+build: pbapi pbmigrate pbworker ## Build all binaries
+
+pbapi: $(SRC_GO) $(SRC_SQL) $(SRC_YAML) ## Build backend API service
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o pbapi ./cmd/pbapi
+
+pbworker: $(SRC_GO) $(SRC_SQL) $(SRC_YAML) ## Build worker service
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o pbworker ./cmd/pbworker
+
+pbmigrate: $(SRC_GO) $(SRC_SQL) $(SRC_YAML) ## Build migration command
+	CGO_ENABLED=0 go build -o pbmigrate ./cmd/pbmigrate
+
+.PHONY: strip
+strip: build ## Strip debug information
+	strip pbapi pbworker pbmigrate
+
+.PHONY: run-go
+run-go: ## Run backend API using `go run`
+	go run ./cmd/pbapi
+
+.PHONY: run
+run: pbapi ## Build and run backend API
+	./pbapi
+
+.PHONY: clean
+clean: ## Clean build artifacts
+	rm pbapi pbmigrate pbworker

--- a/mk/container.mk
+++ b/mk/container.mk
@@ -1,0 +1,11 @@
+##@ Image building
+
+CONTAINER_BUILD_OPTS ?= --build-arg=quay_expiration=2d
+CONTAINER_IMAGE ?= provisioning-backend
+
+.PHONY: build-podman
+build-podman: ## Build container image using Podman
+	# remote podman build has problem with -f option, so we link the file as workaround
+	ln -sf build/Dockerfile Containerfile
+	podman build $(CONTAINER_BUILD_OPTS) -t $(CONTAINER_IMAGE) .
+

--- a/mk/db.mk
+++ b/mk/db.mk
@@ -1,0 +1,15 @@
+##@ Database migrations
+
+.PHONY: migrate
+migrate: ## Run database migration
+	go run ./cmd/pbmigrate
+
+.PHONY: purgedb
+purgedb: ## Delete database (dangerous!)
+	go run ./cmd/pbmigrate purgedb
+
+.PHONY: generate-migration
+MIGRATION_NAME?=unnamed
+generate-migration: ## Generate new migration file, use MIGRATION_NAME=name
+	migrate create -ext sql -dir internal/db/migrations -seq -digits 3 $(MIGRATION_NAME)
+

--- a/mk/deps.mk
+++ b/mk/deps.mk
@@ -1,0 +1,18 @@
+##@ Go modules
+
+.PHONY: tidy-deps
+tidy-deps: ## Cleanup Go modules
+	go mod tidy
+
+.PHONY: download-deps
+download-deps: ## Download Go modules
+	go mod download
+
+.PHONY: update-deps
+update-deps: ## Update Go modules to latest versions
+	go get -u all
+	go mod tidy
+
+# alias for download-deps
+.PHONY: prep
+prep: download-deps

--- a/mk/help.mk
+++ b/mk/help.mk
@@ -1,0 +1,14 @@
+#
+# This file only contains the rule that generate the
+# help content from the comments in the different files.
+#
+# Use '##@ My group text' at the beginning of a line to
+# print out a group text.
+#
+# Use '## My help text' at the end of a rule to print out
+# content related with a rule. Try to short the description.
+#
+
+.PHONY: help
+help: ## Print out the help content
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/mk/openapi.mk
+++ b/mk/openapi.mk
@@ -1,0 +1,10 @@
+##@ OpenAPI
+
+.PHONY: generate-spec
+generate-spec: ## Generate OpenAPI spec
+	go run ./cmd/spec
+
+.PHONY: validate-spec
+validate-spec: generate-spec ## Compare OpenAPI spec with git
+	git diff --exit-code api/openapi.gen.json
+

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -1,0 +1,13 @@
+##@ Testing
+
+TEST_TAGS?=test
+
+.PHONY: test
+test: ## Run unit tests
+	go test -tags=$(TEST_TAGS) ./...
+
+.PHONY: integration-test
+integration-test: ## Run integration tests (require database)
+	go test --count=1 -v -tags=integration ./internal/dao/tests
+
+

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -1,0 +1,10 @@
+##@ Go commands
+
+.PHONY: install-tools
+install-tools: ## Install required Go commands
+	go install golang.org/x/tools/cmd/goimports@latest
+	# pin for a bug: https://github.com/golangci/golangci-lint/issues/2851
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	go install github.com/jackc/tern@latest
+	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
+

--- a/mk/types.mk
+++ b/mk/types.mk
@@ -1,0 +1,8 @@
+##@ Instance types
+
+.PHONY: generate-azure-types
+generate-azure-types: ## Generate instance types for Azure
+	go run cmd/typesctl/main.go -provider azure -generate
+
+.PHONY: generate-types
+generate-types: generate-azure-types ## Generate instance types for all providers

--- a/mk/z_common.mk
+++ b/mk/z_common.mk
@@ -1,0 +1,16 @@
+#
+# Common targets (included as the last, undocumented, used on CI)
+#
+
+MAKE_DOC=docs/make.md
+
+.PHONY: validate-make
+validate-make:
+	echo '# Make documentation' > $(MAKE_DOC)
+	echo '```' >> $(MAKE_DOC)
+	make help | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" >> $(MAKE_DOC)
+	echo '```' >> $(MAKE_DOC)
+
+.PHONY: validate
+validate: validate-make validate-spec validate-clients
+


### PR DESCRIPTION
No changes in the Makefile other than split. Inspired from https://github.com/content-services/content-sources-backend/tree/main/mk and big thanks for the AWK command which generates the help page.

I haven't implemented the loading as it was designed there, I am using include glob to pick all the mk files.

There are some targets which we might adopt as well, feel free to review and we might pull something from there. Container looks interesting, they support both docker and podman. That could be nice.