### PR TITLE
Avoid appending when copying slices

### DIFF
--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -190,9 +190,9 @@ func (c *ec2Client) RunInstances(ctx context.Context, name *string, amount int32
 
 func (c *ec2Client) parseRunInstancesResponse(respAWS *ec2.RunInstancesOutput) []*string {
 	instances := respAWS.Instances
-	list := make([]*string, 0, len(instances))
-	for _, instance := range instances {
-		list = append(list, instance.InstanceId)
+	list := make([]*string, len(instances))
+	for i, instance := range instances {
+		list[i] = instance.InstanceId
 	}
 	return list
 }

--- a/internal/clients/instance_type_info.go
+++ b/internal/clients/instance_type_info.go
@@ -14,17 +14,17 @@ type InstanceTypeInfo struct {
 }
 
 func (iii *InstanceTypeInfo) InstanceTypesForZone(region, zone string, supported *bool) ([]*InstanceType, error) {
-	result := make([]*InstanceType, 0, 64)
 	names, err := iii.RegionalAvailability.NamesForZone(region, zone)
 	if err != nil {
 		return nil, err
 	}
-	for _, name := range names {
+	result := make([]*InstanceType, len(names))
+	for i, name := range names {
 		rt := iii.RegisteredTypes.Get(name)
 		if supported != nil && *supported != rt.Supported {
 			continue
 		}
-		result = append(result, rt)
+		result[i] = rt
 	}
 	return result, nil
 }

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -14,7 +14,7 @@ var GetSourcesClient func(ctx context.Context) (Sources, error)
 // Sources interface provides access to the Sources backend service API
 type Sources interface {
 	// ListProvisioningSources returns all sources that have provisioning credentials assigned
-	ListProvisioningSources(ctx context.Context) (*[]Source, error)
+	ListProvisioningSources(ctx context.Context) ([]*Source, error)
 
 	// GetArn returns ARN associated with provisioning app for given sourceId
 	GetArn(ctx context.Context, sourceId ID) (string, error)

--- a/internal/clients/stubs/sources_stub.go
+++ b/internal/clients/stubs/sources_stub.go
@@ -50,8 +50,8 @@ func (mock *SourcesClientStub) GetProvisioningTypeId(ctx context.Context) (strin
 	return "11", nil
 }
 
-func (mock *SourcesClientStub) ListProvisioningSources(ctx context.Context) (*[]clients.Source, error) {
-	var TestSourceData = []clients.Source{
+func (mock *SourcesClientStub) ListProvisioningSources(ctx context.Context) ([]*clients.Source, error) {
+	var TestSourceData = []*clients.Source{
 		{
 			Id:           ptr.String("1"),
 			Name:         ptr.String("source1"),
@@ -65,7 +65,7 @@ func (mock *SourcesClientStub) ListProvisioningSources(ctx context.Context) (*[]
 			Uid:          ptr.String("31b5338b-685d-4056-ba39-d00b4d7f19cc"),
 		},
 	}
-	return &TestSourceData, nil
+	return TestSourceData, nil
 }
 
 // APIClient

--- a/internal/payloads/instance_types_payload.go
+++ b/internal/payloads/instance_types_payload.go
@@ -20,9 +20,9 @@ func (s *InstanceTypeResponse) Render(_ http.ResponseWriter, _ *http.Request) er
 }
 
 func NewListInstanceTypeResponse(sl []*clients.InstanceType) []render.Renderer {
-	list := make([]render.Renderer, 0, len(sl))
-	for _, instanceType := range sl {
-		list = append(list, &InstanceTypeResponse{instanceType})
+	list := make([]render.Renderer, len(sl))
+	for i, instanceType := range sl {
+		list[i] = &InstanceTypeResponse{instanceType}
 	}
 	return list
 }

--- a/internal/payloads/pubkey_payload.go
+++ b/internal/payloads/pubkey_payload.go
@@ -29,9 +29,9 @@ func NewPubkeyResponse(pubkey *models.Pubkey) render.Renderer {
 }
 
 func NewPubkeyListResponse(pubkeys []*models.Pubkey) []render.Renderer {
-	list := make([]render.Renderer, 0, len(pubkeys))
-	for _, pubkey := range pubkeys {
-		list = append(list, &PubkeyResponse{Pubkey: pubkey})
+	list := make([]render.Renderer, len(pubkeys))
+	for i, pubkey := range pubkeys {
+		list[i] = &PubkeyResponse{Pubkey: pubkey}
 	}
 	return list
 }

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -138,8 +138,8 @@ func NewNoopReservationResponse(reservation *models.NoopReservation) render.Rend
 }
 
 func NewReservationListResponse(reservations []*models.Reservation) []render.Renderer {
-	list := make([]render.Renderer, 0, len(reservations))
-	for _, reservation := range reservations {
+	list := make([]render.Renderer, len(reservations))
+	for i, reservation := range reservations {
 		var finishedAt *time.Time
 		if reservation.FinishedAt.Valid {
 			finishedAt = &reservation.FinishedAt.Time
@@ -148,7 +148,7 @@ func NewReservationListResponse(reservations []*models.Reservation) []render.Ren
 		if reservation.Success.Valid {
 			success = &reservation.Success.Bool
 		}
-		list = append(list, &GenericReservationResponsePayload{
+		list[i] = &GenericReservationResponsePayload{
 			ID:         reservation.ID,
 			Provider:   int(reservation.Provider),
 			CreatedAt:  reservation.CreatedAt,
@@ -158,7 +158,7 @@ func NewReservationListResponse(reservations []*models.Reservation) []render.Ren
 			Steps:      reservation.Steps,
 			Step:       reservation.Step,
 			Error:      reservation.Error,
-		})
+		}
 	}
 	return list
 }

--- a/internal/payloads/sources_payload.go
+++ b/internal/payloads/sources_payload.go
@@ -22,11 +22,10 @@ func (s *SourceResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
 
-func NewListSourcesResponse(sl *[]clients.Source) []render.Renderer {
-	sList := *sl
-	list := make([]render.Renderer, 0, len(sList))
-	for i := range sList {
-		list = append(list, &SourceResponse{Source: &sList[i]})
+func NewListSourcesResponse(sourceList []*clients.Source) []render.Renderer {
+	list := make([]render.Renderer, len(sourceList))
+	for i, source := range sourceList {
+		list[i] = &SourceResponse{Source: source}
 	}
 	return list
 }


### PR DESCRIPTION
I have realized that we do unnecessary `append` calls when copying slices from one to the other when length is fixed (known before). In these cases, it's actually more efficient and more readable to allocate array buffer to the exact size and copy without append call.

@ezr-ondrej @avitova @adiabramovitch @amirfefer 