### PR TITLE
Package ptr with generics

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   linting:
-    name: code format, imports and linters
+    name: "🎯 Code format, imports and style"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,12 +16,12 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48.0
+          #version: v1.48.0
           only-new-issues: true
           skip-go-installation: true
 
   testing:
-    name: go test
+    name: "📎 Go tests"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
           make test
 
   test-dao:
-    name: "🗄 DAO test"
+    name: "🗄 DAO tests"
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -61,7 +61,7 @@ jobs:
         run: make integration-test
 
   openapi:
-    name: validate and compare spec and client code
+    name: "🪆 Generated code diff check"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -5,19 +5,8 @@ on:
       - main
   pull_request:
 jobs:
-  formatting:
-    name: go fmt and goimports
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.18"
-      - uses: Jerome1337/gofmt-action@v1.0.4
-      - uses: Jerome1337/goimports-action@v1.0.3
-
   linting:
-    name: golangci-lint
+    name: code format, imports and linters
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,11 +11,15 @@ linters:
     - sql
     - module
     - unused
+    - format
+    - import
   enable:
     - predeclared
   disable:
     - maligned # deprecated by fieldalignment
     - scopelint # deprecated by exportloopref
+    - gci # too strict
+    - gofumpt # too strict
 linters-settings:
   govet:
     check-shadowing: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - performance
     - sql
     - module
-    - unused
     - format
     - import
   enable:
@@ -20,9 +19,13 @@ linters:
     - scopelint # deprecated by exportloopref
     - gci # too strict
     - gofumpt # too strict
+    - contextcheck # too restrictive
 linters-settings:
   govet:
     check-shadowing: true
+  gosec:
+    excludes:
+      - G112 # slowloris attack - TODO (easyfix)
 issues:
   exclude-rules:
     # If a Stmt is prepared on a DB, it will remain usable for the lifetime of the DB. When the Stmt needs to execute

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/smithy-go/ptr"
 )
 
 type ec2CtxKeyType string
@@ -46,11 +46,11 @@ func (mock *EC2ClientStub) ListInstanceTypesWithPaginator() ([]types.InstanceTyp
 		{
 			InstanceType: types.InstanceTypeA12xlarge,
 			VCpuInfo: &types.VCpuInfo{
-				DefaultCores: ptr.Int32(2),
-				DefaultVCpus: ptr.Int32(2),
+				DefaultCores: ptr.ToInt32(2),
+				DefaultVCpus: ptr.ToInt32(2),
 			},
 			MemoryInfo: &types.MemoryInfo{
-				SizeInMiB: ptr.Int64(22),
+				SizeInMiB: ptr.ToInt64(22),
 			},
 			ProcessorInfo: &types.ProcessorInfo{
 				SupportedArchitectures: []types.ArchitectureType{types.ArchitectureTypeX8664, types.ArchitectureTypeArm64},
@@ -59,11 +59,11 @@ func (mock *EC2ClientStub) ListInstanceTypesWithPaginator() ([]types.InstanceTyp
 		{
 			InstanceType: types.InstanceTypeC5Xlarge,
 			VCpuInfo: &types.VCpuInfo{
-				DefaultCores: ptr.Int32(2),
-				DefaultVCpus: ptr.Int32(2),
+				DefaultCores: ptr.ToInt32(2),
+				DefaultVCpus: ptr.ToInt32(2),
 			},
 			MemoryInfo: &types.MemoryInfo{
-				SizeInMiB: ptr.Int64(22),
+				SizeInMiB: ptr.ToInt64(22),
 			},
 			ProcessorInfo: &types.ProcessorInfo{
 				SupportedArchitectures: []types.ArchitectureType{types.ArchitectureTypeX8664},

--- a/internal/clients/stubs/sources_stub.go
+++ b/internal/clients/stubs/sources_stub.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http/sources"
-	"github.com/aws/smithy-go/ptr"
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 )
 
 type sourcesCtxKeyType string
@@ -53,16 +53,16 @@ func (mock *SourcesClientStub) GetProvisioningTypeId(ctx context.Context) (strin
 func (mock *SourcesClientStub) ListProvisioningSources(ctx context.Context) (*[]clients.Source, error) {
 	var TestSourceData = []clients.Source{
 		{
-			Id:           ptr.String("1"),
-			Name:         ptr.String("source1"),
-			SourceTypeId: ptr.String("1"),
-			Uid:          ptr.String("5eebe172-7baa-4280-823f-19e597d091e9"),
+			Id:           ptr.To("1"),
+			Name:         ptr.To("source1"),
+			SourceTypeId: ptr.To("1"),
+			Uid:          ptr.To("5eebe172-7baa-4280-823f-19e597d091e9"),
 		},
 		{
-			Id:           ptr.String("2"),
-			Name:         ptr.String("source2"),
-			SourceTypeId: ptr.String("2"),
-			Uid:          ptr.String("31b5338b-685d-4056-ba39-d00b4d7f19cc"),
+			Id:           ptr.To("2"),
+			Name:         ptr.To("source2"),
+			SourceTypeId: ptr.To("2"),
+			Uid:          ptr.To("31b5338b-685d-4056-ba39-d00b4d7f19cc"),
 		},
 	}
 	return &TestSourceData, nil

--- a/internal/clients/supported/filter_instances_test.go
+++ b/internal/clients/supported/filter_instances_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http/ec2"
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,11 +46,11 @@ func TestNewInstanceTypes(t *testing.T) {
 		{
 			InstanceType: types.InstanceTypeA12xlarge,
 			VCpuInfo: &types.VCpuInfo{
-				DefaultCores: ptr.Int32(2),
-				DefaultVCpus: ptr.Int32(2),
+				DefaultCores: ptr.ToInt32(2),
+				DefaultVCpus: ptr.ToInt32(2),
 			},
 			MemoryInfo: &types.MemoryInfo{
-				SizeInMiB: ptr.Int64(22),
+				SizeInMiB: ptr.ToInt64(22),
 			},
 			ProcessorInfo: &types.ProcessorInfo{
 				SupportedArchitectures: []types.ArchitectureType{types.ArchitectureTypeX8664, types.ArchitectureTypeArm64},
@@ -59,11 +59,11 @@ func TestNewInstanceTypes(t *testing.T) {
 		{
 			InstanceType: types.InstanceTypeC5Xlarge,
 			VCpuInfo: &types.VCpuInfo{
-				DefaultCores: ptr.Int32(2),
-				DefaultVCpus: ptr.Int32(2),
+				DefaultCores: ptr.ToInt32(2),
+				DefaultVCpus: ptr.ToInt32(2),
 			},
 			MemoryInfo: &types.MemoryInfo{
-				SizeInMiB: ptr.Int64(22),
+				SizeInMiB: ptr.ToInt64(22),
 			},
 			ProcessorInfo: &types.ProcessorInfo{
 				SupportedArchitectures: []types.ArchitectureType{types.ArchitectureTypeX8664},

--- a/internal/middleware/account_test.go
+++ b/internal/middleware/account_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/dao/stubs"
 	"github.com/RHEnVision/provisioning-backend/internal/middleware"
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
-	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,7 +39,7 @@ func TestAccountMiddleware(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 	})
 	t.Run("create non-existing account", func(t *testing.T) {
-		ctx := identity.WithCustomIdentity(t, context.Background(), "124", ptr.String("12"))
+		ctx := identity.WithCustomIdentity(t, context.Background(), "124", ptr.To("12"))
 		ctx = stubs.WithAccountDaoOne(ctx)
 
 		req, err := http.NewRequestWithContext(ctx, "GET", "/test", nil)
@@ -92,7 +92,7 @@ func TestAccountMiddleware(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 	})
 	t.Run("create non-existing null account", func(t *testing.T) {
-		ctx := identity.WithCustomIdentity(t, context.Background(), "124", ptr.String("12"))
+		ctx := identity.WithCustomIdentity(t, context.Background(), "124", ptr.To("12"))
 		ctx = stubs.WithAccountDaoNull(ctx)
 
 		req, err := http.NewRequestWithContext(ctx, "GET", "/api/provisioning/v1/pubkeys", nil)

--- a/internal/ptr/any.go
+++ b/internal/ptr/any.go
@@ -1,0 +1,20 @@
+// Package ptr provides value to pointer and pointer to value functions.
+//
+// In most cases, simply use ptr.To or ptr.From functions. There are some
+// extra functions for types which would normally need type conversions
+// from constants, such as ptr.ToInt64.
+package ptr
+
+// To returns a pointer to the given value.
+func To[T any](value T) *T {
+	return &value
+}
+
+// From returns the value from a given pointer. If ref is nil, a zero
+// value of type T will be returned.
+func From[T any](ref *T) (value T) {
+	if ref != nil {
+		value = *ref
+	}
+	return
+}

--- a/internal/ptr/from.go
+++ b/internal/ptr/from.go
@@ -1,0 +1,11 @@
+package ptr
+
+// FromInt64 is equal to ptr.From(int64(v))
+func FromInt64(v *int64) int64 {
+	return From(v)
+}
+
+// FromInt32 is equal to ptr.From(int32(v))
+func FromInt32(v *int32) int32 {
+	return From(v)
+}

--- a/internal/ptr/to.go
+++ b/internal/ptr/to.go
@@ -1,0 +1,11 @@
+package ptr
+
+// ToInt64 is equal to ptr.To(int64(v))
+func ToInt64(v int64) *int64 {
+	return To(v)
+}
+
+// ToInt32 is equal to ptr.To(int32(v))
+func ToInt32(v int32) *int32 {
+	return To(v)
+}

--- a/internal/testing/identity/dummy_identity.go
+++ b/internal/testing/identity/dummy_identity.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
-	"github.com/aws/smithy-go/ptr"
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	rhidentity "github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
@@ -20,7 +20,7 @@ const (
 	DefaultAccountNumber = "1"
 )
 
-var xRhId = newIdentity(DefaultOrgId, ptr.String(DefaultAccountNumber))
+var xRhId = newIdentity(DefaultOrgId, ptr.To(DefaultAccountNumber))
 
 func AddIdentityHeader(t *testing.T, req *http.Request) *http.Request {
 	req.Header.Add("X-Rh-Identity", setUpValidIdentity(t))

--- a/mk/code.mk
+++ b/mk/code.mk
@@ -1,11 +1,17 @@
 ##@ Code quality
 
-.PHONY: fmt
-fmt: ## Format the project using `go fmt`
+.PHONY: format
+format: ## Format Go source code using `go fmt`
 	go fmt ./...
+
+.PHONY: imports
+imports: ## Rearrange imports using `goimports`
 	goimports -w .
 
 .PHONY: lint
 lint: ## Run Go language linter `golangci-lint`
 	golangci-lint run
+
+.PHONY: fmt
+fmt: format imports lint
 

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -3,8 +3,8 @@
 .PHONY: install-tools
 install-tools: ## Install required Go commands
 	go install golang.org/x/tools/cmd/goimports@latest
-	# pin for a bug: https://github.com/golangci/golangci-lint/issues/2851
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	go install github.com/jackc/tern@latest
 	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
+	go install mvdan.cc/gofumpt@latest
 


### PR DESCRIPTION
Up until now we used the `ptr` package from smithy library. With Go 1.18, we can now take advantage of generics and have a single function `ptr.To` that will work with any type. This patch creates a new `internal/ptr` package with functions `To` and `From` for easy pointer copying. On top of that, there are also `ToInt64` (and 32) variants so you don't have to type `ptr.To(int64(42))` for constants because the default type for number is `int`.

Feel free to add new functions for other types (unsigned ints) or floats if needed: https://go.dev/tour/basics/11