### PR TITLE
Add CPU and MEMORY _REQUESTS parameter defaults

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -107,9 +107,15 @@ parameters:
   - description: Cpu limit of service
     name: CPU_LIMIT
     value: "1"
+  - description: Cpu request increment
+    name: CPU_REQUESTS
+    value: 100m
   - description: memory limit of service
     name: MEMORY_LIMIT
     value: 1Gi
+  - description: memory request increment
+    name: MEMORY_REQUESTS
+    value: 100Mi
   - name: MIN_REPLICAS
     value: "1"
   - description: Image tag


### PR DESCRIPTION
Addressing SRE integration failure, same for MEMORY_REQUESTS.

```
The ClowdApp "provisioning-backend" is invalid: 
* spec.deployments[0].podSpec.resources.requests.cpu: Invalid value: "${CPU_REQUESTS}": spec.deployments[0].podSpec.resources.requests.cpu in body should match '^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'
```
**Checklist**
- [ * ] https://github.com/RHEnVision/provisioning-backend#contributing
- [ * ] https://github.com/RedHatInsights/secure-coding-checklist
