### PR TITLE
Add a make/CI target to check migration changes

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -58,7 +58,7 @@ jobs:
           DATABASE_USER: postgres
           DATABASE_PASSWORD: foobar
           DATABASE_NAME: provisioning_test
-        run: make integration-test
+        run: make integration-test migrations
 
   openapi:
     name: "🪆 Generated code diff check"

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -58,7 +58,7 @@ jobs:
           DATABASE_USER: postgres
           DATABASE_PASSWORD: foobar
           DATABASE_NAME: provisioning_test
-        run: make integration-test migrations
+        run: make integration-test check-migrations
 
   openapi:
     name: "🪆 Generated code diff check"

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -38,6 +38,12 @@ Most of our team members use either Jetbrains GoLand, or VSCode. Here are the re
 }
 ```
 
+## Code checking and linting
+
+We use several formatting and linting tools (like go fmt, goimports, golangci-lint) to enforce code style and quality. There are multiple make targets available and an alias which runs them all: `make fmt`.
+
+Additionally, migration files (`internal/db/migrations/*.sql`) must not be modified, you are only allowed to add new files into this directory. One of the validators will enforce this, however, it is possible to skip it by creating an empty commit on top of the change in case it's necessary (e.g. reformat the SQL code).
+
 ## Additional Go versions
 
 Go language fully supports multi-version installation. Just follow [the official documentation](https://go.dev/doc/manage-install) by using the `go install` command.

--- a/docs/make.md
+++ b/docs/make.md
@@ -9,8 +9,10 @@ HTTP Clients
   validate-clients      Compare generated client code with git
 
 Code quality
-  fmt                   Format the project using `go fmt`
+  format                Format Go source code using `go fmt`
+  imports               Rearrange imports using `goimports`
   lint                  Run Go language linter `golangci-lint`
+  check-migrations      Check migration files for changes
 
 Building
   build                 Build all binaries

--- a/mk/code.mk
+++ b/mk/code.mk
@@ -19,6 +19,10 @@ imports: ## Rearrange imports using `goimports`
 lint: ## Run Go language linter `golangci-lint`
 	golangci-lint run
 
+.PHONY: check-migrations
+check-migrations: ## Check migration files for changes
+	@scripts/check_migrations.sh
+
 .PHONY: fmt
-fmt: format imports lint
+fmt: format imports lint check-migrations
 

--- a/mk/code.mk
+++ b/mk/code.mk
@@ -23,6 +23,6 @@ lint: ## Run Go language linter `golangci-lint`
 check-migrations: ## Check migration files for changes
 	@scripts/check_migrations.sh
 
-.PHONY: fmt
+.PHONY: fmt ## Alias to perform all code formatting and linting
 fmt: format imports lint check-migrations
 

--- a/mk/db.mk
+++ b/mk/db.mk
@@ -1,5 +1,7 @@
 ##@ Database migrations
 
+MIGRATION_NAME ?= unnamed
+
 .PHONY: migrate
 migrate: ## Run database migration
 	go run ./cmd/pbmigrate
@@ -11,5 +13,5 @@ purgedb: ## Delete database (dangerous!)
 .PHONY: generate-migration
 MIGRATION_NAME?=unnamed
 generate-migration: ## Generate new migration file, use MIGRATION_NAME=name
-	migrate create -ext sql -dir internal/db/migrations -seq -digits 3 $(MIGRATION_NAME)
+	tern new -m internal/db/migrations $(MIGRATION_NAME)
 

--- a/mk/help.mk
+++ b/mk/help.mk
@@ -12,3 +12,10 @@
 .PHONY: help
 help: ## Print out the help content
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+.PHONY: generate-help-doc
+generate-help-doc:
+	echo '# Make documentation' > $(MAKE_DOC)
+	echo '```' >> $(MAKE_DOC)
+	make help | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" >> $(MAKE_DOC)
+	echo '```' >> $(MAKE_DOC)

--- a/mk/z_common.mk
+++ b/mk/z_common.mk
@@ -4,13 +4,6 @@
 
 MAKE_DOC=docs/make.md
 
-.PHONY: validate-make
-validate-make:
-	echo '# Make documentation' > $(MAKE_DOC)
-	echo '```' >> $(MAKE_DOC)
-	make help | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]//g" >> $(MAKE_DOC)
-	echo '```' >> $(MAKE_DOC)
-
 .PHONY: validate
-validate: validate-make validate-spec validate-clients
+validate: validate-spec validate-clients
 

--- a/scripts/check_migrations.sh
+++ b/scripts/check_migrations.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+CHANGED_COMMITED=$(git diff --name-status --oneline HEAD..HEAD^ | grep '^M' | grep 'internal/db/migrations/.*sql')
+CHANGED=$(git diff --name-status --oneline | grep '^M' | grep 'internal/db/migrations/.*sql')
+
+if [[ -n "$CHANGED$CHANGED_COMMITED" ]]; then
+  echo "Last commit, staged or unstaged changes do appear to modify migration(s)."
+  echo "This is not allowed, create a new migration instead either manually or:"
+  echo
+  echo "  make generate-migration MIGRATION_NAME=add_new_column"
+  echo
+  echo "If you still want to pass CI tests, create an additional commit to get this"
+  echo "check passing as it only checks the latest one. Use with care!"
+  echo
+  echo "The following files were modified:"
+  echo
+  echo $CHANGED
+  echo $CHANGED_COMMITED
+  exit 1
+fi


### PR DESCRIPTION
This makefile/CI job will enforce that no migration files are modified, only added/deleted files are allowed. The makefile target has a nice explanation of what happened and guides you through the process of either skipping the check (by creating an extra/empty commit), or generating a new migration file using the tern utility.

It is executed on GH after integration tests, it's better to run it after because if someone skips the check via the extra commit, tests must be passing.

I also moved few things around in makefile, updated the makefile document markdown and fixed migration target which was still using gomigrate instead of the new tern utility.