### PR TITLE
Refactor Sources and Cloud provider APIs

### DIFF
--- a/cmd/pbapi/main.go
+++ b/cmd/pbapi/main.go
@@ -9,6 +9,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/azure"
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/ec2"
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/gcp"
+
 	// HTTP client implementations
 	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/image_builder"
 	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/sources"

--- a/configs/local_example.yaml
+++ b/configs/local_example.yaml
@@ -36,14 +36,16 @@ app:
     # Individual application cache features
     typeAppId: true
     account: true
+  # Instance name prefix for all providers (useful only for testing)
+  instancePrefix:
 
 # AWS service account credentials
 aws:
   key:
   secret:
   session:
-  # instance name prefix for all VMs created via the app
-  #instancePrefix:
+  # default region for non-regional requests
+  defaultRegion: us-east-1
 
 # Azure service account credentials
 azure:
@@ -55,6 +57,15 @@ azure:
   clientId: 00000000-0000-0000-0000-000000000000
   # Secret value
   clientSecret:
+  # default region for non-regional requests
+  defaultRegion: eastus
+
+# GCP service account credentials
+gcp:
+  # Base64-encoded credentials JSON file (defaults to empty JSON)
+  json:
+  # default region for non-regional requests
+  defaultZone: us-east1-b
 
 # AWS CloudWatch logger
 cloudwatch:

--- a/configs/sources_api.json
+++ b/configs/sources_api.json
@@ -2604,6 +2604,7 @@
           },
           "authtype": {
             "description": "The type of the authentication",
+            "type": "string",
             "enum": [
               "access_key_secret_key",
               "api_token_account_id",

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -77,8 +77,8 @@ objects:
                     name: provisioning-aws-acc
                     key: aws_secret_access_key
                     optional: false
-              - name: AWS_INSTANCE_PREFIX
-                value: ${AWS_INSTANCE_PREFIX}
+              - name: APP_INSTANCE_PREFIX
+                value: ${APP_INSTANCE_PREFIX}
               - name: WORKER_QUEUE
                 value: ${WORKER_QUEUE}
               - name: WORKER_CONCURRENCY
@@ -133,8 +133,8 @@ parameters:
   - description: AWS CloudWatch logging integration
     name: CLOUDWATCH_ENABLED
     value: "false"
-  - description: AWS instance prefix adds string to all instance names, leave blank for production
-    name: AWS_INSTANCE_PREFIX
+  - description: Instance prefix adds string to all instance names, leave blank for production
+    name: APP_INSTANCE_PREFIX
     value: ""
   - description: Internal queue type (memory/sqs/postgres).
     name: WORKER_QUEUE

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	cloud.google.com/go/compute v1.6.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.0.0
 	github.com/aws/aws-sdk-go-v2 v1.16.13
 	github.com/aws/aws-sdk-go-v2/config v1.17.4
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.17
@@ -38,6 +40,7 @@ require (
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
+	google.golang.org/api v0.81.0
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -123,7 +126,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/api v0.81.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/grpc v1.46.2 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,9 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.0.0 h1:lMW1lD/
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 h1:QM6sE5k2ZT/vI5BEe0r7mqjsUSnhVBFbOsVkEuaEfiA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0 h1:ECsQtyERDVz3NP3kvDOTLvbQhqWp/x9EsGKtb4ogUr8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0/go.mod h1:s1tW/At+xHqjNFvWU4G0c0Qv33KOhvbGNj0RCTQDV8s=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.0.0 h1:xXmHA6JxGDHOY2anNQhpgIibZOiEaOvPLZOiAs07/4k=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.0.0/go.mod h1:qkZjuhvy20x2Ckq4BzopZ8UjZLhib6nRJbRQiC6EFXY=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1 h1:BWe8a+f/t+7KY7zH2mqygeUD0t8hNFXe08p1Pb3/jKE=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.5.1/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/internal/clients/authentication.go
+++ b/internal/clients/authentication.go
@@ -1,0 +1,62 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+)
+
+type Authentication struct {
+	ProviderType models.ProviderType `json:"type"`
+	Payload      string              `json:"payload"`
+}
+
+func NewAuthentication(str string, provType models.ProviderType) *Authentication {
+	a := Authentication{
+		Payload:      str,
+		ProviderType: provType,
+	}
+	return &a
+}
+
+func NewAuthenticationFromSourceAuthType(ctx context.Context, str, authType string) *Authentication {
+	a := Authentication{Payload: str}
+	switch authType {
+	case "provisioning-arn":
+		a.ProviderType = models.ProviderTypeAWS
+	case "provisioning_lighthouse_subscription_id":
+		a.ProviderType = models.ProviderTypeAzure
+	case "provisioning_project_id":
+		a.ProviderType = models.ProviderTypeGCP
+	default:
+		ctxval.Logger(ctx).Warn().Msgf("Unknown auth type returned from sources: %s", authType)
+		a.ProviderType = models.ProviderTypeUnknown
+	}
+	return &a
+}
+
+// Type returns authentication provider type
+func (auth *Authentication) Type() models.ProviderType {
+	return auth.ProviderType
+}
+
+// Is checks if Authentication is of a given provider type
+func (auth *Authentication) Is(providerType models.ProviderType) bool {
+	return auth.ProviderType == providerType
+}
+
+// MustBe returns nil, if authentication is of given type. Otherwise, returns an error.
+func (auth *Authentication) MustBe(providerType models.ProviderType) error {
+	if !auth.Is(providerType) {
+		return fmt.Errorf("%w: %s", UnknownAuthenticationTypeErr, auth.ProviderType.String())
+	}
+
+	return nil
+}
+
+// String returns authentication payload string (ARN, Subscription UUID, Project-ID...)
+func (auth *Authentication) String() string {
+	return auth.Payload
+}

--- a/internal/clients/errors.go
+++ b/internal/clients/errors.go
@@ -3,8 +3,12 @@ package clients
 import "errors"
 
 var (
+	// Common errors
 	NotFoundErr       = errors.New("backend service returned not found (404) or no data")
 	UnauthorizedErr   = errors.New("backend service returned unauthorized (401)")
 	ForbiddenErr      = errors.New("backend service returned forbidden (403)")
 	Non2xxResponseErr = errors.New("backend service did not return 2xx")
+
+	// Sources errors (some others are defined in http package too)
+	UnknownAuthenticationTypeErr = errors.New("unknown authentication type")
 )

--- a/internal/clients/http/azure/azure_client.go
+++ b/internal/clients/http/azure/azure_client.go
@@ -1,0 +1,77 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/rs/zerolog"
+)
+
+type azureClient struct {
+	subscriptionID string
+	credential     *azidentity.ClientSecretCredential
+}
+
+func init() {
+	clients.GetAzureClient = newAzureClient
+}
+
+func logger(ctx context.Context) zerolog.Logger {
+	return ctxval.Logger(ctx).With().Str("client", "azure").Logger()
+}
+
+func newAzureClient(ctx context.Context, auth *clients.Authentication) (clients.Azure, error) {
+	opts := azidentity.ClientSecretCredentialOptions{}
+	identityClient, err := azidentity.NewClientSecretCredential(config.Azure.TenantID, config.Azure.ClientID, config.Azure.ClientSecret, &opts)
+	if err != nil {
+		return nil, fmt.Errorf("unable to init Azure credentials: %w", err)
+	}
+
+	return &azureClient{
+		subscriptionID: auth.Payload,
+		credential:     identityClient,
+	}, nil
+}
+
+func (c *azureClient) newResourcesClient(ctx context.Context) (*armresources.Client, error) {
+	client, err := armresources.NewClient(c.subscriptionID, c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create resources Azure client: %w", err)
+	}
+	return client, nil
+}
+
+func (c *azureClient) newSubscriptionsClient(ctx context.Context) (*armsubscriptions.Client, error) {
+	client, err := armsubscriptions.NewClient(c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create subscriptioons Azure client: %w", err)
+	}
+	return client, nil
+}
+
+func (c *azureClient) newSshKeysClient(ctx context.Context) (*armcompute.SSHPublicKeysClient, error) {
+	client, err := armcompute.NewSSHPublicKeysClient(c.subscriptionID, c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create SSH keys Azure client: %w", err)
+	}
+	return client, nil
+}
+
+func (c *azureClient) Status(ctx context.Context) error {
+	client, err := c.newSubscriptionsClient(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to initialize status request: %w", err)
+	}
+	_, err = client.Get(ctx, c.subscriptionID, nil)
+	if err != nil {
+		return fmt.Errorf("unable to perform status request: %w", err)
+	}
+	return nil
+}

--- a/internal/clients/http/sources/client.gen.go
+++ b/internal/clients/http/sources/client.gen.go
@@ -49,6 +49,27 @@ const (
 	AuthenticationCreateResourceTypeSource         AuthenticationCreateResourceType = "Source"
 )
 
+// Defines values for AuthenticationReadAuthtype.
+const (
+	AuthenticationReadAuthtypeAccessKeySecretKey           AuthenticationReadAuthtype = "access_key_secret_key"
+	AuthenticationReadAuthtypeApiTokenAccountId            AuthenticationReadAuthtype = "api_token_account_id"
+	AuthenticationReadAuthtypeArn                          AuthenticationReadAuthtype = "arn"
+	AuthenticationReadAuthtypeBitbucketAppPassword         AuthenticationReadAuthtype = "bitbucket-app-password"
+	AuthenticationReadAuthtypeCloudMeterArn                AuthenticationReadAuthtype = "cloud-meter-arn"
+	AuthenticationReadAuthtypeDockerAccessToken            AuthenticationReadAuthtype = "docker-access-token"
+	AuthenticationReadAuthtypeGithubPersonalAccessToken    AuthenticationReadAuthtype = "github-personal-access-token"
+	AuthenticationReadAuthtypeGitlabPersonalAccessToken    AuthenticationReadAuthtype = "gitlab-personal-access-token"
+	AuthenticationReadAuthtypeLighthouseSubscriptionId     AuthenticationReadAuthtype = "lighthouse_subscription_id"
+	AuthenticationReadAuthtypeMarketplaceToken             AuthenticationReadAuthtype = "marketplace-token"
+	AuthenticationReadAuthtypeOcid                         AuthenticationReadAuthtype = "ocid"
+	AuthenticationReadAuthtypeProjectIdServiceAccountJson  AuthenticationReadAuthtype = "project_id_service_account_json"
+	AuthenticationReadAuthtypeQuayEncryptedPassword        AuthenticationReadAuthtype = "quay-encrypted-password"
+	AuthenticationReadAuthtypeReceptorNode                 AuthenticationReadAuthtype = "receptor_node"
+	AuthenticationReadAuthtypeTenantIdClientIdClientSecret AuthenticationReadAuthtype = "tenant_id_client_id_client_secret"
+	AuthenticationReadAuthtypeToken                        AuthenticationReadAuthtype = "token"
+	AuthenticationReadAuthtypeUsernamePassword             AuthenticationReadAuthtype = "username_password"
+)
+
 // Defines values for AuthenticationReadResourceType.
 const (
 	AuthenticationReadResourceTypeApplication    AuthenticationReadResourceType = "Application"
@@ -334,7 +355,7 @@ type AuthenticationCreateResourceType string
 // Authentication object
 type AuthenticationRead struct {
 	// The type of the authentication
-	Authtype *interface{} `json:"authtype,omitempty"`
+	Authtype *AuthenticationReadAuthtype `json:"authtype,omitempty"`
 
 	// The availability status of the authentication
 	AvailabilityStatus *interface{} `json:"availability_status,omitempty"`
@@ -373,6 +394,9 @@ type AuthenticationRead struct {
 	// The username for the authentication
 	Username *string `json:"username,omitempty"`
 }
+
+// The type of the authentication
+type AuthenticationReadAuthtype string
 
 // The type of the resource this authentication belongs to
 type AuthenticationReadResourceType string

--- a/internal/clients/instance_type_info.go
+++ b/internal/clients/instance_type_info.go
@@ -18,13 +18,13 @@ func (iii *InstanceTypeInfo) InstanceTypesForZone(region, zone string, supported
 	if err != nil {
 		return nil, err
 	}
-	result := make([]*InstanceType, len(names))
-	for i, name := range names {
+	result := make([]*InstanceType, 0, len(names))
+	for _, name := range names {
 		rt := iii.RegisteredTypes.Get(name)
 		if supported != nil && *supported != rt.Supported {
 			continue
 		}
-		result[i] = rt
+		result = append(result, rt)
 	}
 	return result, nil
 }

--- a/internal/clients/region.go
+++ b/internal/clients/region.go
@@ -1,0 +1,17 @@
+package clients
+
+// Region represents a provider's region (e.g. 'us-east-1' for EC2 or 'eastus' for Azure)
+type Region string
+
+func (r Region) String() string {
+	return string(r)
+}
+
+// Zone represents a provider's zone. There are multiple types of zones (regional, wireless, cities)
+// based on the provider. This type does not make any difference, as long as they have unique names.
+// The name must include region in the name, so it is unique for each provider.
+type Zone string
+
+func (z Zone) String() string {
+	return string(z)
+}

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -25,7 +25,7 @@ func WithEC2Client(parent context.Context) context.Context {
 	return ctx
 }
 
-func getEC2ClientStubWithRegion(ctx context.Context, _ string, _ string) (si clients.EC2, err error) {
+func getEC2ClientStubWithRegion(ctx context.Context, _ *clients.Authentication, _ string) (si clients.EC2, err error) {
 	var ok bool
 	if si, ok = ctx.Value(ec2CtxKey).(*EC2ClientStub); !ok {
 		err = &contextReadError{}
@@ -33,15 +33,37 @@ func getEC2ClientStubWithRegion(ctx context.Context, _ string, _ string) (si cli
 	return si, err
 }
 
-func (mock *EC2ClientStub) ImportPubkey(key *models.Pubkey, tag string) (string, error) {
-	return "", nil
-}
-
-func (mock *EC2ClientStub) DeleteSSHKey(handle string) error {
+func (mock *EC2ClientStub) Status(ctx context.Context) error {
 	return nil
 }
 
-func (mock *EC2ClientStub) ListInstanceTypesWithPaginator() ([]types.InstanceTypeInfo, error) {
+func (mock *EC2ClientStub) ImportPubkey(ctx context.Context, key *models.Pubkey, tag string) (string, error) {
+	return "", nil
+}
+
+func (mock *EC2ClientStub) DeleteSSHKey(ctx context.Context, handle string) error {
+	return nil
+}
+
+func (mock *EC2ClientStub) ListAllRegions(ctx context.Context) ([]clients.Region, error) {
+	return []clients.Region{
+		"us-east-1",
+		"eu-central-1",
+	}, nil
+}
+
+func (mock *EC2ClientStub) ListAllZones(ctx context.Context, region clients.Region) ([]clients.Zone, error) {
+	return []clients.Zone{
+		"us-east-1a",
+		"us-east-1b",
+		"us-east-1c",
+		"eu-central-1a",
+		"eu-central-1b",
+		"eu-central-1c",
+	}, nil
+}
+
+func (mock *EC2ClientStub) ListInstanceTypesWithPaginator(ctx context.Context) ([]types.InstanceTypeInfo, error) {
 	return []types.InstanceTypeInfo{
 		{
 			InstanceType: types.InstanceTypeA12xlarge,

--- a/internal/clients/stubs/gcp_stub.go
+++ b/internal/clients/stubs/gcp_stub.go
@@ -22,7 +22,7 @@ func WithGCPClient(parent context.Context) context.Context {
 	return ctx
 }
 
-func getGCPClientStub(ctx context.Context) (si clients.GCP, err error) {
+func getGCPClientStub(ctx context.Context, auth *clients.Authentication) (si clients.GCP, err error) {
 	var ok bool
 	if si, ok = ctx.Value(gcpCtxKey).(*GCPClientStub); !ok {
 		err = &contextReadError{}
@@ -30,9 +30,26 @@ func getGCPClientStub(ctx context.Context) (si clients.GCP, err error) {
 	return si, err
 }
 
-func (mock *GCPClientStub) Close() {
+func (mock *GCPClientStub) Status(ctx context.Context) error {
+	return nil
 }
 
-func (mock *GCPClientStub) RunInstances(ctx context.Context, projectID string, namePattern *string, imageName *string, amount int64, machineType string, zone string, keyBody string) (*string, error) {
+func (mock *GCPClientStub) ListAllRegionsAndZones(ctx context.Context) ([]clients.Region, []clients.Zone, error) {
+	regions := []clients.Region{
+		"us-east1",
+		"us-west1",
+	}
+	zones := []clients.Zone{
+		"us-east1-b",
+		"us-east1-c",
+		"us-east1-d",
+		"us-west1-a",
+		"us-west1-b",
+		"us-west1-c",
+	}
+	return regions, zones, nil
+}
+
+func (mock *GCPClientStub) RunInstances(ctx context.Context, namePattern *string, imageName *string, amount int64, machineType string, zone string, keyBody string) (*string, error) {
 	return nil, NotImplementedErr
 }

--- a/internal/clients/stubs/sources_stub.go
+++ b/internal/clients/stubs/sources_stub.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http/sources"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 )
 
@@ -42,8 +43,8 @@ func (*SourcesClientStub) Ready(ctx context.Context) error {
 	return nil
 }
 
-func (mock *SourcesClientStub) GetArn(ctx context.Context, sourceId sources.ID) (string, error) {
-	return "arn:aws:iam::230214684733:role/Test", nil
+func (mock *SourcesClientStub) GetAuthentication(ctx context.Context, sourceId sources.ID) (*clients.Authentication, error) {
+	return clients.NewAuthentication("arn:aws:iam::230214684733:role/Test", models.ProviderTypeAWS), nil
 }
 
 func (mock *SourcesClientStub) GetProvisioningTypeId(ctx context.Context) (string, error) {

--- a/internal/config/0_common_config.go
+++ b/internal/config/0_common_config.go
@@ -62,4 +62,12 @@ func init() {
 	parser.Viper.SetDefault("aws.secret", "")
 	parser.Viper.SetDefault("aws.session", "")
 	parser.Viper.SetDefault("aws.instancePrefix", "")
+	parser.Viper.SetDefault("aws.defaultRegion", "us-east-1")
+
+	// Azure
+	parser.Viper.SetDefault("azure.defaultRegion", "eastus")
+
+	// GCP
+	parser.Viper.SetDefault("gcp.json", "e30K")
+	parser.Viper.SetDefault("gcp.defaultZone", "us-east1")
 }

--- a/internal/config/parser/known.go
+++ b/internal/config/parser/known.go
@@ -5,11 +5,11 @@ package parser
 // library.
 //
 // The second column is optional. When not set, environment variable is the same,
-// except "." are replaced with "_". Otherwise, the value from the second column
+// except "." are replaced with "_". Otherwise the value from the second column
 // is used. Examples:
 //
 // APP_NAME (implicit from APP.NAME)
-// AWS_INSTANCE_PREFIX (explicitly set)
+// APP_INSTANCE_PREFIX (explicitly set)
 //
 // This is not great solution, but the alternative would be to remove viper dependency.
 var known = [][]string{
@@ -23,12 +23,23 @@ var known = [][]string{
 	{"APP.PORT", ""},
 	{"APP.VERSION", ""},
 	{"APP.COMPRESSION", ""},
+	{"APP.INSTANCEPREFIX", "APP_INSTANCE_PREFIX"},
 	{"AWS", ""},
 	{"AWS.INSTANCEPREFIX", "AWS_INSTANCE_PREFIX"},
 	{"AWS.KEY", ""},
 	{"AWS.REGION", ""},
 	{"AWS.SECRET", ""},
 	{"AWS.SESSION", ""},
+	{"AWS.DEFAULTREGION", "AWS_DEFAULT_REGION"},
+	{"AZURE", ""},
+	{"AZURE.TENANTID", "AZURE_TENANT_ID"},
+	{"AZURE.SUBSCRIPTIONID", "AZURE_SUBSCRIPTION_ID"},
+	{"AZURE.CLIENTID", "AZURE_CLIENT_ID"},
+	{"AZURE.CLIENTSECRET", "AZURE_CLIENT_SECRET"},
+	{"AZURE.DEFAULTREGION", "AZURE_DEFAULT_REGION"},
+	{"GCP", ""},
+	{"GCP.JSON", ""},
+	{"GCP.DEFAULTZONE", "GCP_DEFAULT_ZONE"},
 	{"CLOUDWATCH", ""},
 	{"CLOUDWATCH.ENABLED", ""},
 	{"CLOUDWATCH.GROUP", ""},

--- a/internal/config/parser/replacer_test.go
+++ b/internal/config/parser/replacer_test.go
@@ -22,6 +22,6 @@ func TestCamelCaseReplacerApp(t *testing.T) {
 }
 
 func TestCamelCaseReplacerFromMap(t *testing.T) {
-	result := customReplacer{}.Replace("AWS.INSTANCEPREFIX")
-	assert.Equal(t, "AWS_INSTANCE_PREFIX", result)
+	result := customReplacer{}.Replace("APP.INSTANCEPREFIX")
+	assert.Equal(t, "APP_INSTANCE_PREFIX", result)
 }

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -33,7 +33,7 @@ type LaunchInstanceAWSTaskArgs struct {
 	AMI string `json:"ami"`
 
 	// The ARN fetched from Sources which is linked to a specific source
-	ARN string `json:"arn"`
+	ARN *clients.Authentication `json:"arn"`
 }
 
 // Unmarshall arguments and handle error

--- a/internal/jobs/launch_instance_gcp.go
+++ b/internal/jobs/launch_instance_gcp.go
@@ -34,7 +34,7 @@ type LaunchInstanceGCPTaskArgs struct {
 	ImageName string `json:"image_name"`
 
 	// The project id from Sources which is linked to a specific source
-	ProjectID string `json:"project_id"`
+	ProjectID *clients.Authentication `json:"project_id"`
 }
 
 // Unmarshall arguments and handle error
@@ -76,14 +76,12 @@ func handleLaunchInstanceGCP(ctx context.Context, args *LaunchInstanceGCPTaskArg
 		return fmt.Errorf("cannot get pubkey by id: %w", err)
 	}
 
-	gcpClient, err := clients.GetGCPClient(ctx)
+	gcpClient, err := clients.GetGCPClient(ctx, args.ProjectID)
 	if err != nil {
 		return fmt.Errorf("cannot get gcp client: %w", err)
 	}
 
-	defer gcpClient.Close()
-
-	opName, err := gcpClient.RunInstances(ctx, args.ProjectID, ptr.To("inst-####"), &args.ImageName, args.Detail.Amount, args.Detail.MachineType, args.Zone, pk.Body)
+	opName, err := gcpClient.RunInstances(ctx, ptr.To("inst-####"), &args.ImageName, args.Detail.Amount, args.Detail.MachineType, args.Zone, pk.Body)
 	if err != nil {
 		return fmt.Errorf("cannot run instances for gcp client: %w", err)
 	}

--- a/internal/jobs/pubkey_upload_aws_job.go
+++ b/internal/jobs/pubkey_upload_aws_job.go
@@ -14,12 +14,12 @@ import (
 )
 
 type PubkeyUploadAWSTaskArgs struct {
-	AccountID     int64  `json:"account_id"`
-	ReservationID int64  `json:"reservation_id"`
-	Region        string `json:"region"`
-	PubkeyID      int64  `json:"pubkey_id"`
-	SourceID      string `json:"source_id"`
-	ARN           string `json:"arn"`
+	AccountID     int64                   `json:"account_id"`
+	ReservationID int64                   `json:"reservation_id"`
+	Region        string                  `json:"region"`
+	PubkeyID      int64                   `json:"pubkey_id"`
+	SourceID      string                  `json:"source_id"`
+	ARN           *clients.Authentication `json:"arn"`
 }
 
 // Unmarshall arguments and handle error
@@ -96,7 +96,7 @@ func handlePubkeyUploadAWS(ctx context.Context, args *PubkeyUploadAWSTaskArgs) e
 		return fmt.Errorf("cannot create new ec2 client from config: %w", err)
 	}
 
-	pkr.Handle, err = ec2Client.ImportPubkey(pubkey, pkr.FormattedTag())
+	pkr.Handle, err = ec2Client.ImportPubkey(ctx, pubkey, pkr.FormattedTag())
 	if err != nil {
 		if errors.Is(err, http.DuplicatePubkeyErr) {
 			logger.Warn().Msgf("Pubkey '%s' already present, skipping", pubkey.Name)

--- a/internal/models/model_constants.go
+++ b/internal/models/model_constants.go
@@ -35,3 +35,20 @@ func ProviderTypeFromString(str string) ProviderType {
 		return ProviderTypeUnknown
 	}
 }
+
+func (pt ProviderType) String() string {
+	switch pt {
+	case ProviderTypeNoop:
+		return "noop"
+	case ProviderTypeAWS:
+		return "aws"
+	case ProviderTypeAzure:
+		return "azure"
+	case ProviderTypeGCP:
+		return "gcp"
+	case ProviderTypeUnknown:
+	default:
+		return ""
+	}
+	return ""
+}

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -44,6 +44,7 @@ func (e *ResponseError) Unwrap() error {
 func NewInvalidRequestError(ctx context.Context, err error) *ResponseError {
 	msg := fmt.Sprintf("invalid request: %v", err)
 	if logger := ctxval.Logger(ctx); logger != nil {
+		// TODO we should also call .Err(err) to log error
 		logger.Warn().Msg(msg)
 	}
 	return &ResponseError{
@@ -194,8 +195,50 @@ func NewURLParsingError(ctx context.Context, paramName string, err error) *Respo
 	}
 }
 
+func NewStatusError(ctx context.Context, err error) *ResponseError {
+	msg := fmt.Sprintf("status check error: %v", err)
+	if logger := ctxval.Logger(ctx); logger != nil {
+		logger.Error().Msg(msg)
+	}
+	return &ResponseError{
+		HTTPStatusCode: 500,
+		Message:        msg,
+		RequestId:      ctxval.RequestId(ctx),
+		Err:            err,
+		Context:        ctx,
+	}
+}
+
 func NewAWSError(ctx context.Context, message string, err error) *ResponseError {
 	msg := fmt.Sprintf("AWS error: %s: %v", message, err)
+	if logger := ctxval.Logger(ctx); logger != nil {
+		logger.Error().Msg(msg)
+	}
+	return &ResponseError{
+		HTTPStatusCode: 500,
+		Message:        msg,
+		RequestId:      ctxval.RequestId(ctx),
+		Err:            err,
+		Context:        ctx,
+	}
+}
+
+func NewAzureError(ctx context.Context, message string, err error) *ResponseError {
+	msg := fmt.Sprintf("Azure error: %s: %v", message, err)
+	if logger := ctxval.Logger(ctx); logger != nil {
+		logger.Error().Msg(msg)
+	}
+	return &ResponseError{
+		HTTPStatusCode: 500,
+		Message:        msg,
+		RequestId:      ctxval.RequestId(ctx),
+		Err:            err,
+		Context:        ctx,
+	}
+}
+
+func NewGCPError(ctx context.Context, message string, err error) *ResponseError {
+	msg := fmt.Sprintf("GCP error: %s: %v", message, err)
 	if logger := ctxval.Logger(ctx); logger != nil {
 		logger.Error().Msg(msg)
 	}

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -57,6 +57,9 @@ func apiRouter() http.Handler {
 		r.Route("/sources", func(r chi.Router) {
 			r.Get("/", s.ListSources)
 			r.Route("/{ID}", func(r chi.Router) {
+				r.Get("/status", s.SourcesStatus)
+
+				// TODO move this to outside of /sources (see below)
 				r.Get("/instance_types", s.ListInstanceTypes)
 			})
 		})

--- a/internal/services/gcp_reservation_service.go
+++ b/internal/services/gcp_reservation_service.go
@@ -21,11 +21,14 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 
 	var accountId int64 = ctxval.AccountId(r.Context())
 
+	// TODO fetch authentication from sources
+	auth := clients.NewAuthentication("citric-expanse-361512", models.ProviderTypeAWS)
+
 	// TODO: meanwhile these values are hardcoded until we will have instance types, sources, ssh endpoints,
 	payload := &payloads.GCPReservationRequestPayload{
 		PubkeyID: 2,
 		// TODO: The project id change to source id from sources
-		SourceID:    "citric-expanse-361512",
+		SourceID:    auth.Payload,
 		Zone:        "us-central1-a",
 		MachineType: "n1-standard-1",
 		ImageID:     "bc97177c-9d07-4db9-ad59-8b2c0bf4174e",
@@ -120,7 +123,7 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 			PubkeyID:      reservation.PubkeyID,
 			Detail:        reservation.Detail,
 			ImageName:     name,
-			ProjectID:     reservation.SourceID,
+			ProjectID:     auth,
 		},
 	}
 

--- a/internal/services/instance_types_service.go
+++ b/internal/services/instance_types_service.go
@@ -27,7 +27,7 @@ func ListInstanceTypes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	arn, err := sourcesClient.GetArn(r.Context(), sourceId)
+	authentication, err := sourcesClient.GetAuthentication(r.Context(), sourceId)
 	if err != nil {
 		if errors.Is(err, clients.NotFoundErr) {
 			renderError(w, r, payloads.ClientError(r.Context(), "Sources", "can't fetch arn from sources", err, 404))
@@ -37,13 +37,13 @@ func ListInstanceTypes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ec2Client, err := clients.GetCustomerEC2Client(r.Context(), arn, region)
+	ec2Client, err := clients.GetCustomerEC2Client(r.Context(), authentication, region)
 	if err != nil {
 		renderError(w, r, payloads.NewAWSError(r.Context(), "failed to establish ec2 connection", err))
 		return
 	}
 
-	res, err := ec2Client.ListInstanceTypesWithPaginator()
+	res, err := ec2Client.ListInstanceTypesWithPaginator(r.Context())
 	if err != nil {
 		renderError(w, r, payloads.NewAWSError(r.Context(), "can't list EC2 instance types", err))
 		return

--- a/internal/services/sources_status_service.go
+++ b/internal/services/sources_status_service.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"errors"
+	stdhttp "net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/clients/http"
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+	"github.com/go-chi/chi/v5"
+)
+
+var UnknownProviderFromSourcesErr = errors.New("unknown provider returned from sources")
+
+// SourcesStatus fetches information from sources and then performs a smallest possible
+// request on the cloud provider (list keys or similar). Reports an error if sources configuration
+// is no longer valid.
+func SourcesStatus(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	sourceId := chi.URLParam(r, "ID")
+
+	sourcesClient, err := clients.GetSourcesClient(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewClientInitializationError(r.Context(), "can't init sources client", err))
+		return
+	}
+
+	auth, err := sourcesClient.GetAuthentication(r.Context(), sourceId)
+	if err != nil {
+		if errors.Is(err, http.ApplicationNotFoundErr) {
+			renderError(w, r, payloads.ClientError(r.Context(), "Sources", "can't fetch arn from sources: application not found", err, 404))
+			return
+		}
+		if errors.Is(err, http.AuthenticationForSourcesNotFoundErr) {
+			renderError(w, r, payloads.ClientError(r.Context(), "Sources", "can't fetch arn from sources: authentication not found", err, 404))
+			return
+		}
+		renderError(w, r, payloads.ClientError(r.Context(), "Sources", "can't fetch arn from sources", err, 500))
+		return
+	}
+
+	var statusClient clients.ClientStatuser
+	switch auth.Type() {
+	case models.ProviderTypeAWS:
+		statusClient, err = clients.GetCustomerEC2Client(r.Context(), auth, config.AWS.DefaultRegion)
+		if err != nil {
+			renderError(w, r, payloads.NewAWSError(r.Context(), "unable to get client", err))
+			return
+		}
+	case models.ProviderTypeGCP:
+		statusClient, err = clients.GetGCPClient(r.Context(), auth)
+		if err != nil {
+			renderError(w, r, payloads.NewGCPError(r.Context(), "unable to get client", err))
+			return
+		}
+	case models.ProviderTypeAzure:
+		statusClient, err = clients.GetAzureClient(r.Context(), auth)
+		if err != nil {
+			renderError(w, r, payloads.NewAzureError(r.Context(), "unable to get client", err))
+			return
+		}
+	case models.ProviderTypeNoop:
+	case models.ProviderTypeUnknown:
+	default:
+		renderError(w, r, payloads.NewStatusError(r.Context(), UnknownProviderFromSourcesErr))
+		return
+	}
+
+	err = statusClient.Status(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewStatusError(r.Context(), err))
+		return
+	}
+
+	write200(w, r)
+}

--- a/scripts/rest_examples/source-1-status.http
+++ b/scripts/rest_examples/source-1-status.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources/1/status HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/source-2-status.http
+++ b/scripts/rest_examples/source-2-status.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources/2/status HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/source-3-status.http
+++ b/scripts/rest_examples/source-3-status.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources/3/status HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/sources-list.http
+++ b/scripts/rest_examples/sources-list.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}

--- a/scripts/sources.conf
+++ b/scripts/sources.conf
@@ -18,11 +18,26 @@ export REDIS_CACHE_HOST=localhost
 export REDIS_CACHE_PORT=6379
 export SOURCES_API_HOST=http://localhost
 export SOURCES_API_PORT=$PORT
-# AWS ARN, see docs/ for more info.
-# Example: aws:iam::123456789:role/redhat-provisioning-1
-export ARN_ROLE=
+# Delete git working trees during sources.clean.sh
+export CLEAN_CHECKOUTS=1
+
 # Default account to create in sources app (use the same account to use the ARN).
 export ACCOUNT_ID=13
 export ORG_ID=000013
-# Delete git working trees during sources.clean.sh
-export CLEAN_CHECKOUTS=1
+
+# TENANT ACCOUNT INFORMATION - MUST BE OVERWRITTEN IN sources.local.conf!
+# See docs/ for more info.
+
+# Tenant AWS ARN string for EC2.
+# Example: aws:iam::123456789:role/redhat-provisioning-1
+export ARN_ROLE=
+
+# Azure Subscription ID. A subscription that was allowed access through Azure Lighthouse.
+# Can be found on tenant's account, or in the service account on Azure.
+# Example: 4d3df606-608d-4e5a-ab17-7b3d71d775a6
+export SUBSCRIPTION_ID=
+
+# Google Cloud Platform project ID. Can be found on tenant's account, or in the
+# credentials JSON from the service account.
+# Example: my-project-13554
+export PROJECT_ID=

--- a/scripts/sources.seed.sh
+++ b/scripts/sources.seed.sh
@@ -18,27 +18,57 @@ curl --location -g  --request POST "http://localhost:$PORT/api/sources/v3.1/bulk
 --header "$IDENTITY" \
 -d "$(cat <<EOF
 {
-	"sources": [
-		{
-			"name": "Amazon source",
-			"source_type_name": "amazon",
-			"app_creation_workflow": "manual_configuration"
-		}
-	],
-	"applications": [
-		{
-			"source_name": "Amazon source",
-			"application_type_name": "provisioning"
-		}
-	],
-	"authentications": [
-		{
-			"resource_type": "Application",
-			"resource_name": "provisioning",
-			"username": "$ARN_ROLE",
-			"authtype":"provisioning-arn"
-		}
-	]
+  "sources": [
+    {
+      "name": "Amazon source",
+      "source_type_name": "amazon",
+      "app_creation_workflow": "manual_configuration"
+    },
+    {
+      "name": "Azure source",
+      "source_type_name": "azure",
+      "app_creation_workflow": "manual_configuration"
+    },
+    {
+      "name": "Google source",
+      "source_type_name": "google",
+      "app_creation_workflow": "manual_configuration"
+    }
+  ],
+  "applications": [
+    {
+      "source_name": "Amazon source",
+      "application_type_name": "provisioning"
+    },
+    {
+      "source_name": "Azure source",
+      "application_type_name": "provisioning"
+    },
+    {
+      "source_name": "Google source",
+      "application_type_name": "provisioning"
+    }
+  ],
+  "authentications": [
+    {
+      "resource_type": "Application",
+      "resource_name": "provisioning",
+      "username": "$ARN_ROLE",
+      "authtype":"provisioning-arn"
+    },
+    {
+      "resource_type": "Application",
+      "resource_name": "provisioning",
+      "username": "$SUBSCRIPTION_ID",
+      "authtype":"provisioning_lighthouse_subscription_id"
+    },
+    {
+      "resource_type": "Application",
+      "resource_name": "provisioning",
+      "username": "$PROJECT_ID",
+      "authtype":"provisioning_project_id"
+    }
+  ]
 }
 EOF
 )"


### PR DESCRIPTION
_Warning: This is a monster patch, it's not my fault my cat jumped on enter and squashed all commits..._

Jokes aside, it's big because nobody was working, PTOs and sick and hackathon. So as the PR got bigger and bigger, I kept adding more and more changes. In general, the theme of this patch is **refactoring of our Sources integration and cloud clients interface** and worry do not, I will write an extensive explanation of what is going on in the PR. Before you start any code changes around sources or ec2/azure/gcp beware of possible conflicts with this PR. @adiabramovitch @avitova @ezr-ondrej @amirfefer 

**Generalizing sources ARN**

Previously, our Sources API was designed around AWS and its ARN token (string). Since Sources are a generic service and can hold authentication artifacts of any kind, I created a new generic interface `clients.Authentication`. You can think of it as basically a wrapper for ARN/SubscriptionID/ProjectID. It carries a payload (string) and a provider type. There are some helper functions to make decisions easier.

The `GetArn` function therefore changes to `GetAuthentication` and callers need to decide if they only want the payload which can be fetched via `String()` function, or to do some decisions based on type. It is worth nothing that I found a bug in Sources OpenAPI (missing type) which doesn't allow to retrieve authentication type from their API via generated clients, so I fixed it and this PR contains the updated OpenAPI spec. I am assuming it gets merged soon: https://github.com/RedHatInsights/sources-api-go/pull/566 and we can simply merge this as-is because the next time we sync OpenAPI specs it will get pulled too.

**Improving our cloud interface**

When working on the new Azure interface, I realized that we don't pass context in all functions and we keep logger and context in the client struct itself. I don't think this is a good practice, tho, I think it was me who created this. This patch makes sure that:

* All functions in all cloud interfaces (ec2, azure, gcp) accepts Context as the first parameter.
* All implementations has a `logger` function that extracts and configures logger for local use.
* Client struct only has credentials information, clients themselves are always initialized from functions. This is important for GCP since that is not a REST API, it's gRPC HTTP/2 protocol which requires explicit closing, so this is much safer.
* All implementation-clients are created via `newXXXClient` functions.
* All errors are wrapped properly and root cause is always returned to the caller.

**Status call for each source**

To properly test this patch with all three providers, I had to have some call available for Azure. Actually, this feature was actually the initial thought thus the branch name. What this does it it adds a new endpoint `/sources/ID/status` which is very simple. It returns 200 if the source is active and correctly configured (have valid credentials), 500 otherwise. It performs a quick "ping" call, but since none of the three cloud APIs have a ping/status call, I use something that is fast: "get subscription detail" for Azure and "list all regions" for others.

To be actually able to implement those status requests, new functions are available for each implementation: `ListAllRegions`, `ListAllZones` and `ListAllRegionsAndZones` for GCP (it's just a single call in that API). These functions are exported but unused at the moment, the plan is to use them in the `typesctl` command line utility to actually extract the data into YAML. New types were created in the `clients` package: `Region` and `Zone`, both are strings for the moment but we might want to expand this (e.g. there are multiple Zone types).

Now, to test this you simply hit `/sources/1/status` or 2 or 3 depending on your source number (I have three, 1 for EC2, 2 for Azure and 3 for GCP). I created `source-X-status.http` file that can be used to do the call, it's just a simple GET with no payload. Before that, you need to update sources backend app to the latest version, edit your `sources.local.conf` (see sources.conf for more details about ENV variables) and run the `sources.seed.sh` script. This will create you sources 1, 2 and 3 that can be then used nicely with these `.http` files directly from your IDE.

You will find a new small interface called `Statuser` which has just a single function `Status(ctx)` and this is embedded into all three interfaces. This allows a nice and generic code in the status service function. This is idiomatic Go, these small interfaces are very often called Somethinger (Reader, Stringer etc in the standard library).

**Configuration changes**

The patch adds new GCP configuration tree with `json` field which must be base64-encoded credentials GCP JSON. I propose this solution because I think it's the cleanest way of providing a string full of quotes via environment variables. On Linux, there is typically very big limit on env var length (32kB or something), my own GCP JSON is around 3k characters encoded. So as long as clowder and k8s supports this, it's the best option. There is also a validator that immediately stops the app if the value was not decoded correctly.

All cloud provider configuration now has default region setting (zone for GCP). This setting can be used for requests which are non-regional (e.g. global, typically fetching instance types or other generic info). It should be as close as possible to the datacenter that production runs in. My wild guess is useast1, therefore this is the default value.

I am moving the instance prefix from AWS tree to the APP tree, therefore AWS_INSTANCE_PREFIX will be now APP_INSTANCE_PREFIX. Reason being we want the same setting to have for all clouds typically (for development and testing), therefore there's no sense to configure this separately as this will almost always be `test-` anyways. @RHEnVision/qe please keep this in mind.
