### PR TITLE
HMSPROV-285: Reservation detail for AWS

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -391,7 +391,7 @@
     },
     "/reservations": {
       "get": {
-        "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. This operation returns list of all reservations for particular account.\n",
+        "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. This operation returns list of all reservations for particular account. To get a reservation with common fields, use /reservations/ID. To get a detailed reservation with all fields which are different per provider, use /reservations/aws/ID.\n",
         "operationId": "getReservationsList",
         "responses": {
           "200": {
@@ -414,6 +414,40 @@
       }
     },
     "/reservations/aws": {
+      "get": {
+        "description": "Return an AWS reservation with details by id",
+        "operationId": "getAWSReservationByID",
+        "parameters": [
+          {
+            "description": "Reservation ID, must be an AWS reservation otherwise 404 is returned",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AWSReservationResponse"
+                }
+              }
+            },
+            "description": "Returns detailed reservation information for an AWS reservation."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
       "post": {
         "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. An AWS reservation is a reservation created for an AWS job. Image Builder UUID image is required, the service will also launch any AMI image prefixed with \"ami-\".\n",
         "operationId": "createAwsReservation",
@@ -466,7 +500,7 @@
     },
     "/reservations/{ID}": {
       "get": {
-        "description": "Return a reservation by id",
+        "description": "Return a generic reservation by id",
         "operationId": "getReservationByID",
         "parameters": [
           {
@@ -489,7 +523,7 @@
                 }
               }
             },
-            "description": "Returned on success."
+            "description": "Returns generic reservation information like status or creation time."
           },
           "404": {
             "$ref": "#/components/responses/NotFound"

--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -414,6 +414,36 @@
       }
     },
     "/reservations/aws": {
+      "post": {
+        "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. An AWS reservation is a reservation created for an AWS job. Image Builder UUID image is required, the service will also launch any AMI image prefixed with \"ami-\".\n",
+        "operationId": "createAwsReservation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AWSReservationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AWSReservationResponse"
+                }
+              }
+            },
+            "description": "Returned on success."
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/reservations/aws/{ID}": {
       "get": {
         "description": "Return an AWS reservation with details by id",
         "operationId": "getAWSReservationByID",
@@ -442,34 +472,6 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
-          },
-          "500": {
-            "$ref": "#/components/responses/InternalError"
-          }
-        }
-      },
-      "post": {
-        "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. An AWS reservation is a reservation created for an AWS job. Image Builder UUID image is required, the service will also launch any AMI image prefixed with \"ami-\".\n",
-        "operationId": "createAwsReservation",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/v1.AWSReservationRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/v1.AWSReservationResponse"
-                }
-              }
-            },
-            "description": "Returned on success."
           },
           "500": {
             "$ref": "#/components/responses/InternalError"

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -152,7 +152,9 @@ paths:
       operationId: getReservationsList
       description: >
         A reservation is a way to activate a job, keeps all data needed for a job to start.
-        This operation returns list of all reservations for particular account.
+        This operation returns list of all reservations for particular account. To get a
+        reservation with common fields, use /reservations/ID. To get a detailed reservation
+        with all fields which are different per provider, use /reservations/aws/ID.
       responses:
         '200':
           description: 'Returned on success.'
@@ -166,7 +168,7 @@ paths:
           $ref: '#/components/responses/InternalError'
   /reservations/{ID}:
     get:
-      description: 'Return a reservation by id'
+      description: 'Return a generic reservation by id'
       operationId: getReservationByID
       parameters:
       - in: path
@@ -178,7 +180,7 @@ paths:
         description: 'Reservation ID'
       responses:
         "200":
-          description: 'Returned on success.'
+          description: 'Returns generic reservation information like status or creation time.'
           content:
             application/json:
               schema:
@@ -206,6 +208,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/v1.AWSReservationResponse'
+        "500":
+          $ref: '#/components/responses/InternalError'
+    get:
+      description: 'Return an AWS reservation with details by id'
+      operationId: getAWSReservationByID
+      parameters:
+        - in: path
+          name: ID
+          schema:
+            type: integer
+            format: int64
+          required: true
+          description: 'Reservation ID, must be an AWS reservation otherwise 404 is returned'
+      responses:
+        "200":
+          description: 'Returns detailed reservation information for an AWS reservation.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v1.AWSReservationResponse'
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: '#/components/responses/InternalError'
   /reservations/noop:

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -210,6 +210,7 @@ paths:
                 $ref: '#/components/schemas/v1.AWSReservationResponse'
         "500":
           $ref: '#/components/responses/InternalError'
+  /reservations/aws/{ID}:
     get:
       description: 'Return an AWS reservation with details by id'
       operationId: getAWSReservationByID

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -152,7 +152,9 @@ paths:
       operationId: getReservationsList
       description: >
         A reservation is a way to activate a job, keeps all data needed for a job to start.
-        This operation returns list of all reservations for particular account.
+        This operation returns list of all reservations for particular account. To get a
+        reservation with common fields, use /reservations/ID. To get a detailed reservation
+        with all fields which are different per provider, use /reservations/aws/ID.
       responses:
         '200':
           description: 'Returned on success.'
@@ -166,7 +168,7 @@ paths:
           $ref: '#/components/responses/InternalError'
   /reservations/{ID}:
     get:
-      description: 'Return a reservation by id'
+      description: 'Return a generic reservation by id'
       operationId: getReservationByID
       parameters:
       - in: path
@@ -178,7 +180,7 @@ paths:
         description: 'Reservation ID'
       responses:
         "200":
-          description: 'Returned on success.'
+          description: 'Returns generic reservation information like status or creation time.'
           content:
             application/json:
               schema:
@@ -206,6 +208,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/v1.AWSReservationResponse'
+        "500":
+          $ref: '#/components/responses/InternalError'
+    get:
+      description: 'Return an AWS reservation with details by id'
+      operationId: getAWSReservationByID
+      parameters:
+        - in: path
+          name: ID
+          schema:
+            type: integer
+            format: int64
+          required: true
+          description: 'Reservation ID, must be an AWS reservation otherwise 404 is returned'
+      responses:
+        "200":
+          description: 'Returns detailed reservation information for an AWS reservation.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/v1.AWSReservationResponse'
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: '#/components/responses/InternalError'
   /reservations/noop:

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -210,6 +210,7 @@ paths:
                 $ref: '#/components/schemas/v1.AWSReservationResponse'
         "500":
           $ref: '#/components/responses/InternalError'
+  /reservations/aws/{ID}:
     get:
       description: 'Return an AWS reservation with details by id'
       operationId: getAWSReservationByID

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -73,6 +73,9 @@ type ReservationDao interface {
 	// GetById returns reservation for a particular account.
 	GetById(ctx context.Context, id int64) (*models.Reservation, error)
 
+	// GetAWSById returns reservation for a particular account.
+	GetAWSById(ctx context.Context, id int64) (*models.AWSReservation, error)
+
 	// List returns reservation for a particular account.
 	List(ctx context.Context, limit, offset int64) ([]*models.Reservation, error)
 

--- a/internal/dao/stubs/reservation_dao.go
+++ b/internal/dao/stubs/reservation_dao.go
@@ -55,6 +55,10 @@ func (stub *reservationDaoStub) GetById(ctx context.Context, id int64) (*models.
 	return nil, nil
 }
 
+func (stub *reservationDaoStub) GetAWSById(ctx context.Context, id int64) (*models.AWSReservation, error) {
+	return nil, nil
+}
+
 func (stub *reservationDaoStub) List(ctx context.Context, limit, offset int64) ([]*models.Reservation, error) {
 	return nil, nil
 }

--- a/internal/db/migrations/010_rename_provider_detail.sql
+++ b/internal/db/migrations/010_rename_provider_detail.sql
@@ -1,0 +1,2 @@
+ALTER TABLE aws_reservation_details RENAME provider TO provider_fk;
+ALTER TABLE gcp_reservation_details RENAME provider TO provider_fk;

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -2,6 +2,9 @@ package models
 
 import (
 	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
 	"time"
 )
 
@@ -61,6 +64,21 @@ type AWSDetail struct {
 	PowerOff bool `json:"poweroff"`
 }
 
+// TODO: Use pgx native driver with scany library instead of sqlx which does not
+func (detail *AWSDetail) Value() (driver.Value, error) {
+	return json.Marshal(detail)
+}
+
+// TODO: Use pgx native driver with scany library instead of sqlx which does not
+func (detail *AWSDetail) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+
+	return json.Unmarshal(b, &detail)
+}
+
 type AWSReservation struct {
 	Reservation
 
@@ -74,10 +92,10 @@ type AWSReservation struct {
 	AWSReservationID string `db:"aws_reservation_id" json:"aws_reservation_id"`
 
 	// The ID of the image from which the instance is created. AMI's must be prefixed with 'ami-'.
-	ImageID string `json:"image_id"`
+	ImageID string `db:"image_id" json:"image_id"`
 
 	// Detail information is stored as JSON in DB
-	Detail *AWSDetail `db:"detail" json:"detail"`
+	Detail *AWSDetail `json:"detail"`
 }
 
 type GCPDetail struct {

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -72,8 +72,14 @@ func apiRouter() http.Handler {
 
 		r.Route("/reservations", func(r chi.Router) {
 			r.Get("/", s.ListReservations)
-			r.Get("/{ID}", s.GetReservation)
-			r.Post("/{type}", s.CreateReservation)
+			// Different types do have different payloads, therefore TYPE must be part of
+			// URL and not a URL (filter) parameter.
+			r.Route("/{TYPE}", func(r chi.Router) {
+				r.Get("/{ID}", s.GetReservationDetail)
+				r.Post("/", s.CreateReservation)
+			})
+			// Generic reservation detail request (no details provided)
+			r.Get("/{ID}", s.GetReservationDetail)
 		})
 
 		// Unsupported routes are not published through OpenAPI, they are documented

--- a/internal/services/error_renderer.go
+++ b/internal/services/error_renderer.go
@@ -1,10 +1,13 @@
 package services
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/render"
 )
 
@@ -22,5 +25,14 @@ func renderError(w http.ResponseWriter, r *http.Request, renderer render.Rendere
 	errRender := render.Render(w, r, renderer)
 	if errRender != nil {
 		writeBasicError(w, r, errRender)
+	}
+}
+
+func renderNotFoundOrDAOError(w http.ResponseWriter, r *http.Request, err error, daoError string) {
+	var e dao.NoRowsError
+	if errors.As(err, &e) {
+		renderError(w, r, payloads.NewNotFoundError(r.Context(), err))
+	} else {
+		renderError(w, r, payloads.NewDAOError(r.Context(), daoError, err))
 	}
 }

--- a/scripts/rest_examples/reservation-aws-get-1.http
+++ b/scripts/rest_examples/reservation-aws-get-1.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/reservations/aws/1 HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/reservation-get-1.http
+++ b/scripts/rest_examples/reservation-get-1.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/reservations/1 HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}


### PR DESCRIPTION
Although I thought for all filtering we would use URL parameters and provider type can be seen as a filter, because of OpenAPI, we must use the provider in the URL because payloads can be different only for different URLs in OpenAPI.

This adds a new endpoint `/reservations/TYPE/ID` that returns reservation with all the details loaded, currently it only works for AWS but the code is ready for extension.

I am leaving the old `/reservations/ID` still active, it returns only generic information and it can be useful for UI to get just basic info for the progress bar. Should be a tad faster as it does not need to join the two tables, so it's a better fit for polling.

There is still the open question for possible conflict between `TYPE` and `ID`, but I don't see this as a problem until someone complains about this, it's `GET` vs `POST` so it should be fine.

There are new `.http` files to test this feature.