### PR TITLE
Pin linter to 1.47.3

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -16,9 +16,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          #version: v1.48.0
-          only-new-issues: true
-          skip-go-installation: true
+          # https://github.com/golangci/golangci-lint-action/issues/535
+          version: v1.47.3
 
   testing:
     name: "📎 Go tests"


### PR DESCRIPTION
This just pins the linter because of an error. I think we should simply keep it pinned and casually update it as `latest` breaks quite often.

The reason: https://github.com/golangci/golangci-lint-action/issues/535