### PR TITLE
Fetch HEAD^ for DAO tests

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -49,6 +49,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18"


### PR DESCRIPTION
Our "do not touch migrations" check does not work on CI because it creates a shallow git checkout by default :-)

This should fix this.