### PR TITLE
Add the new instance_types to OpenAPI

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -265,6 +265,61 @@
   },
   "openapi": "3.0.0",
   "paths": {
+    "/instance_types/{PROVIDER}": {
+      "get": {
+        "description": "Return a list of instance types for particular provider. A region must be provided. A zone must be provided for Azure.\n",
+        "operationId": "getInstanceTypeListAll",
+        "parameters": [
+          {
+            "description": "Cloud provider: aws, azure",
+            "in": "path",
+            "name": "PROVIDER",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Region to list instance types within. This is required.",
+            "in": "query",
+            "name": "region",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Availability zone (or location) to list instance types within. Not applicable for AWS EC2 as all zones within a region are the same (will lead to an error when used). Required for Azure.",
+            "in": "query",
+            "name": "zone",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/v1.InstanceTypeResponse"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Return on success. Instance types have a field \"supported\" that indicates whether that particular type is supported by Red Hat. Typically, instances with less than 1.5 GiB RAM are not supported, but other rules may apply.\n"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/pubkeys": {
       "get": {
         "description": "A pubkey represents an SSH public portion of a key pair with name and body. This operation returns list of all pubkeys for particular account.\n",
@@ -562,7 +617,7 @@
     },
     "/sources/{ID}/instance_types": {
       "get": {
-        "description": "Return a list of instance types",
+        "description": "Return a list of instance types (DEPRECATED: use /instance_types)",
         "operationId": "getInstanceTypeList",
         "parameters": [
           {

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -118,7 +118,7 @@ paths:
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/instance_types:
       get:
-        description: 'Return a list of instance types'
+        description: 'Return a list of instance types (DEPRECATED: use /instance_types)'
         operationId: getInstanceTypeList
         parameters:
         - in: path
@@ -147,6 +147,48 @@ paths:
             $ref: "#/components/responses/NotFound"
           '500':
             $ref: "#/components/responses/InternalError"
+  /instance_types/{PROVIDER}:
+    get:
+      description: >
+        Return a list of instance types for particular provider. A region must be provided. A zone must be provided
+        for Azure.
+      operationId: getInstanceTypeListAll
+      parameters:
+        - in: path
+          name: PROVIDER
+          schema:
+            type: string
+          required: true
+          description: 'Cloud provider: aws, azure'
+        - in: query
+          name: region
+          schema:
+            type: string
+          required: true
+          description: Region to list instance types within. This is required.
+        - in: query
+          name: zone
+          schema:
+            type: string
+          required: false
+          description: Availability zone (or location) to list instance types within. Not applicable for AWS EC2 as
+            all zones within a region are the same (will lead to an error when used). Required for Azure.
+      responses:
+        '200':
+          description: >
+            Return on success. Instance types have a field "supported" that indicates
+            whether that particular type is supported by Red Hat. Typically, instances
+            with less than 1.5 GiB RAM are not supported, but other rules may apply.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/v1.InstanceTypeResponse'
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '500':
+          $ref: "#/components/responses/InternalError"
   /reservations:
     get:
       operationId: getReservationsList

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -118,7 +118,7 @@ paths:
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/instance_types:
       get:
-        description: 'Return a list of instance types'
+        description: 'Return a list of instance types (DEPRECATED: use /instance_types)'
         operationId: getInstanceTypeList
         parameters:
         - in: path
@@ -147,6 +147,48 @@ paths:
             $ref: "#/components/responses/NotFound"
           '500':
             $ref: "#/components/responses/InternalError"
+  /instance_types/{PROVIDER}:
+    get:
+      description: >
+        Return a list of instance types for particular provider. A region must be provided. A zone must be provided
+        for Azure.
+      operationId: getInstanceTypeListAll
+      parameters:
+        - in: path
+          name: PROVIDER
+          schema:
+            type: string
+          required: true
+          description: 'Cloud provider: aws, azure'
+        - in: query
+          name: region
+          schema:
+            type: string
+          required: true
+          description: Region to list instance types within. This is required.
+        - in: query
+          name: zone
+          schema:
+            type: string
+          required: false
+          description: Availability zone (or location) to list instance types within. Not applicable for AWS EC2 as
+            all zones within a region are the same (will lead to an error when used). Required for Azure.
+      responses:
+        '200':
+          description: >
+            Return on success. Instance types have a field "supported" that indicates
+            whether that particular type is supported by Red Hat. Typically, instances
+            with less than 1.5 GiB RAM are not supported, but other rules may apply.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/v1.InstanceTypeResponse'
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '500':
+          $ref: "#/components/responses/InternalError"
   /reservations:
     get:
       operationId: getReservationsList


### PR DESCRIPTION
SSIA

Note: only EC2 and Azure are implemented. Also keep in mind that region and zone are required only for some clouds:

* EC2: region required, zone not (must not be passed in)
* Azure: region required, zone required