### PR TITLE
Add prometheus pgx metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 // go get github.com/georgysavva/scany/v2@v2.0.0-alpha.2
 // go get github.com/jackc/tern/v2@v2.0.0-beta.2
+// go get github.com/IBM/pgxpoolprometheus@v1.1.0-beta.1
 
 require (
 	cloud.google.com/go/compute v1.10.0
@@ -32,7 +33,6 @@ require (
 	github.com/jackc/pgx-zerolog v0.0.0-20220923130014-7856b90a65ae
 	github.com/jackc/pgx/v5 v5.0.1
 	github.com/jackc/tern/v2 v2.0.0-beta.2
-	github.com/jmoiron/sqlx v1.3.5
 	github.com/lzap/cloudwatchwriter2 v1.0.0
 	github.com/lzap/dejq v1.0.2
 	github.com/pkg/errors v0.9.1
@@ -49,7 +49,7 @@ require (
 	go.opentelemetry.io/otel/exporters/jaeger v1.10.0
 	go.opentelemetry.io/otel/sdk v1.10.0
 	go.opentelemetry.io/otel/trace v1.10.0
-	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be
+	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b
 	google.golang.org/api v0.98.0
 	google.golang.org/genproto v0.0.0-20220930163606-c98284e70a91
 	gopkg.in/yaml.v3 v3.0.1
@@ -60,6 +60,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 // indirect
+	github.com/IBM/pgxpoolprometheus v1.1.0-beta.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0 h1:VgSJlZH5u0k
 github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/IBM/pgxpoolprometheus v1.1.0-beta.1 h1:7l6FzmQkmFPF7CboypLcNQjmDgPWYimL06T78kbYD9o=
+github.com/IBM/pgxpoolprometheus v1.1.0-beta.1/go.mod h1:kQjcEoXO2PzM2EBr5/rONZyTB56jxc2svmDolsfKhIc=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
@@ -808,6 +810,8 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCztao/kbYFnWjoqop8dHx05A=
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b h1:huxqepDufQpLLIRXiVkTvnxrzJlpwmIWAObmcCcUFr0=
+golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/IBM/pgxpoolprometheus"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/version"
 	"github.com/exaring/otelpgx"
 	pgxlog "github.com/jackc/pgx-zerolog"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/tracelog"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -97,6 +100,15 @@ func Initialize(ctx context.Context, schema string) error {
 	if err != nil {
 		return fmt.Errorf("unable to ping the database: %w", err)
 	}
+
+	// Register telemetry
+	labels := map[string]string{
+		"service": version.PrometheusLabelName,
+		"db_host": config.Database.Host,
+		"db_name": config.Database.Name,
+	}
+	collector := pgxpoolprometheus.NewCollector(Pool, labels)
+	prometheus.MustRegister(collector)
 
 	return nil
 }


### PR DESCRIPTION
I know I know, another beta dependency! This one is really cool, just hit `/metrics` with this patch:

```
# HELP pgxpool_acquire_count Cumulative count of successful acquires from the pool.
# TYPE pgxpool_acquire_count counter
pgxpool_acquire_count{db_host="nuc",db_name="pb_dev",service="provisioning"} 6

# HELP pgxpool_acquire_duration_ns Total duration of all successful acquires from the pool in nanoseconds.
# TYPE pgxpool_acquire_duration_ns counter
pgxpool_acquire_duration_ns{db_host="nuc",db_name="pb_dev",service="provisioning"} 1.196325e+07

# HELP pgxpool_acquired_conns Number of currently acquired connections in the pool.
# TYPE pgxpool_acquired_conns gauge
pgxpool_acquired_conns{db_host="nuc",db_name="pb_dev",service="provisioning"} 0

# HELP pgxpool_canceled_acquire_count Cumulative count of acquires from the pool that were canceled by a context.
# TYPE pgxpool_canceled_acquire_count counter
pgxpool_canceled_acquire_count{db_host="nuc",db_name="pb_dev",service="provisioning"} 0

# HELP pgxpool_constructing_conns Number of conns with construction in progress in the pool.
# TYPE pgxpool_constructing_conns gauge
pgxpool_constructing_conns{db_host="nuc",db_name="pb_dev",service="provisioning"} 0

# HELP pgxpool_empty_acquire Cumulative count of successful acquires from the pool that waited for a resource to be released or constructed because the pool was empty.
# TYPE pgxpool_empty_acquire counter
pgxpool_empty_acquire{db_host="nuc",db_name="pb_dev",service="provisioning"} 1

# HELP pgxpool_idle_conns Number of currently idle conns in the pool.
# TYPE pgxpool_idle_conns gauge
pgxpool_idle_conns{db_host="nuc",db_name="pb_dev",service="provisioning"} 3

# HELP pgxpool_max_conns Maximum size of the pool.
# TYPE pgxpool_max_conns gauge
pgxpool_max_conns{db_host="nuc",db_name="pb_dev",service="provisioning"} 100

# HELP pgxpool_total_conns Total number of resources currently in the pool. The value is the sum of ConstructingConns, AcquiredConns, and IdleConns.
# TYPE pgxpool_total_conns gauge
pgxpool_total_conns{db_host="nuc",db_name="pb_dev",service="provisioning"} 3
```

Connection leaking is a common thing in (not only) Go applications, this will allow us to identify this easily.

https://issues.redhat.com/browse/HMSPROV-303