### PR TITLE
Launch worker alongside api

### DIFF
--- a/build/RedHat.dockerfile
+++ b/build/RedHat.dockerfile
@@ -7,6 +7,7 @@ RUN make prep build strip
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=build /build/pbapi /pbapi
+COPY --from=build /build/pbworker /pbworker
 COPY --from=build /build/pbmigrate /pbmigrate
 USER 1001
 CMD ["/pbapi"]

--- a/build/Upstream.dockerfile
+++ b/build/Upstream.dockerfile
@@ -14,6 +14,7 @@ RUN make prep build strip
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=build /build/pbapi /pbapi
+COPY --from=build /build/pbworker /pbworker
 COPY --from=build /build/pbmigrate /pbmigrate
 USER 1001
 CMD ["/pbapi"]

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -22,6 +22,52 @@ objects:
       testing:
         iqePlugin: provisioning
       deployments:
+        - name: worker
+          minReplicas: ${{WORKER_MIN_REPLICAS}}
+          podSpec:
+            image: ${IMAGE}:${IMAGE_TAG}
+            command:
+              - /pbworker
+            initContainers:
+              - name: run-migrations
+                image: "${IMAGE}:${IMAGE_TAG}"
+                command:
+                  - /pbmigrate
+                inheritEnv: true
+            env:
+              - name: CLOWDER_ENABLED
+                value: ${CLOWDER_ENABLED}
+              - name: CLOUDWATCH_ENABLED
+                value: ${CLOUDWATCH_ENABLED}
+              - name: AWS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: provisioning-aws-acc
+                    key: aws_access_key_id
+                    optional: false
+              - name: AWS_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: provisioning-aws-acc
+                    key: aws_secret_access_key
+                    optional: false
+              - name: APP_INSTANCE_PREFIX
+                value: ${APP_INSTANCE_PREFIX}
+              - name: WORKER_QUEUE
+                value: ${WORKER_QUEUE}
+              - name: WORKER_CONCURRENCY
+                value: ${WORKER_CONCURRENCY}
+              - name: WORKER_HEARTBEAT_SEC
+                value: ${WORKER_HEARTBEAT_SEC}
+              - name: WORKER_MAX_BEATS
+                value: ${WORKER_MAX_BEATS}
+            resources:
+              limits:
+                cpu: ${{CPU_LIMIT}}
+                memory: ${MEMORY_LIMIT}
+              requests:
+                cpu: ${CPU_REQUESTS}
+                memory: ${MEMORY_REQUESTS}
         - name: service
           minReplicas: ${{MIN_REPLICAS}}
           webServices:
@@ -80,13 +126,8 @@ objects:
               - name: APP_INSTANCE_PREFIX
                 value: ${APP_INSTANCE_PREFIX}
               - name: WORKER_QUEUE
-                value: ${WORKER_QUEUE}
-              - name: WORKER_CONCURRENCY
-                value: ${WORKER_CONCURRENCY}
-              - name: WORKER_HEARTBEAT_SEC
-                value: ${WORKER_HEARTBEAT_SEC}
-              - name: WORKER_MAX_BEATS
-                value: ${WORKER_MAX_BEATS}
+                # this is temporary until we get backend-job-worker running
+                value: memory
             resources:
               limits:
                 cpu: ${{CPU_LIMIT}}
@@ -117,6 +158,8 @@ parameters:
     name: MEMORY_REQUESTS
     value: 100Mi
   - name: MIN_REPLICAS
+    value: "1"
+  - name: WORKER_MIN_REPLICAS
     value: "1"
   - description: Image tag
     name: IMAGE_TAG


### PR DESCRIPTION
This should launch a backend worker alongside with the API service. It's in memory mode, meaning it's useless for now. I will configure dbjobqueue or sqs soon, I just want to test the deployment for now at this point.

Feel free to merge if this passes and I will do followup PRs, I want to take slow steps with this :-)