### PR TITLE
Rename architectures X86_64

### DIFF
--- a/internal/clients/architecture.go
+++ b/internal/clients/architecture.go
@@ -10,12 +10,11 @@ import (
 type ArchitectureType string
 
 const (
-	ArchitectureTypeI386 ArchitectureType = "i386"
-	// TODO rename to X86_64
-	ArchitectureTypeX8664      ArchitectureType = "x86_64"
-	ArchitectureTypeArm64      ArchitectureType = "arm64"
-	ArchitectureTypeAppleX8664 ArchitectureType = "apple-x86_64"
-	ArchitectureTypeAppleArm64 ArchitectureType = "apple-arm64"
+	ArchitectureTypeI386        ArchitectureType = "i386"
+	ArchitectureTypeX86_64      ArchitectureType = "x86_64"
+	ArchitectureTypeArm64       ArchitectureType = "arm64"
+	ArchitectureTypeAppleX86_64 ArchitectureType = "apple-x86_64"
+	ArchitectureTypeAppleArm64  ArchitectureType = "apple-arm64"
 )
 
 func (at *ArchitectureType) String() string {
@@ -25,13 +24,13 @@ func (at *ArchitectureType) String() string {
 func MapArchitectures(_ context.Context, arch string) (ArchitectureType, error) {
 	switch {
 	case arch == "x86_64_mac":
-		return ArchitectureTypeAppleX8664, nil
+		return ArchitectureTypeAppleX86_64, nil
 	case arch == "arm64_mac":
 		return ArchitectureTypeAppleArm64, nil
 	case arch == "i386":
 		return ArchitectureTypeI386, nil
 	case arch == "x86-64" || arch == "x86_64" || arch == "x64":
-		return ArchitectureTypeX8664, nil
+		return ArchitectureTypeX86_64, nil
 	case arch == "aarch64" || arch == "arm64" || arch == "Arm64" || arch == "arm":
 		return ArchitectureTypeArm64, nil
 	}

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -84,7 +84,7 @@ func (mock *EC2ClientStub) ListInstanceTypesWithPaginator(ctx context.Context) (
 			MemoryMiB:          16000,
 			EphemeralStorageGB: 0,
 			Supported:          true,
-			Architecture:       clients.ArchitectureTypeX8664,
+			Architecture:       clients.ArchitectureTypeX86_64,
 		},
 		{
 			Name:               "c5.xlarge",
@@ -93,7 +93,7 @@ func (mock *EC2ClientStub) ListInstanceTypesWithPaginator(ctx context.Context) (
 			MemoryMiB:          8000,
 			EphemeralStorageGB: 0,
 			Supported:          true,
-			Architecture:       clients.ArchitectureTypeX8664,
+			Architecture:       clients.ArchitectureTypeX86_64,
 		},
 	}, nil
 }

--- a/internal/clients/supported/filter_instances_test.go
+++ b/internal/clients/supported/filter_instances_test.go
@@ -15,7 +15,7 @@ import (
 func TestEC2MapArchitectures(t *testing.T) {
 	result, err := clients.MapArchitectures(context.Background(), "x86-64")
 	assert.Nil(t, err)
-	assert.Equal(t, clients.ArchitectureTypeX8664, result)
+	assert.Equal(t, clients.ArchitectureTypeX86_64, result)
 	result, err = clients.MapArchitectures(context.Background(), "i386")
 	assert.Nil(t, err)
 	assert.Equal(t, clients.ArchitectureTypeI386, result)
@@ -24,7 +24,7 @@ func TestEC2MapArchitectures(t *testing.T) {
 	assert.Equal(t, clients.ArchitectureTypeArm64, result)
 	result, err = clients.MapArchitectures(context.Background(), "x86_64_mac")
 	assert.Nil(t, err)
-	assert.Equal(t, clients.ArchitectureTypeAppleX8664, result)
+	assert.Equal(t, clients.ArchitectureTypeAppleX86_64, result)
 	result, err = clients.MapArchitectures(context.Background(), "arm64_mac")
 	assert.Nil(t, err)
 	assert.Equal(t, clients.ArchitectureTypeAppleArm64, result)
@@ -35,7 +35,7 @@ func TestEC2MapArchitectures(t *testing.T) {
 func TestAzureMapArchitectures(t *testing.T) {
 	result, err := clients.MapArchitectures(context.Background(), "x64")
 	assert.Nil(t, err)
-	assert.Equal(t, clients.ArchitectureTypeX8664, result)
+	assert.Equal(t, clients.ArchitectureTypeX86_64, result)
 	result, err = clients.MapArchitectures(context.Background(), "arm64")
 	assert.Nil(t, err)
 	assert.Equal(t, clients.ArchitectureTypeArm64, result)


### PR DESCRIPTION
I have renamed x86_64 architectures. We are using types.ArchitectureTypeX8664 from ec2 package. I hope that it will not confuse us in the future.