### PR TITLE
Do not use colors for logs when clowder is active

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -35,6 +35,14 @@ objects:
                   - /pbmigrate
                 inheritEnv: true
             env:
+              - name: LOGGING_LEVEL
+                value: ${LOGGING_LEVEL}
+              - name: DATABASE_LOGGING_LEVEL
+                value: ${DATABASE_LOGGING_LEVEL}
+              - name: TELEMETRY_ENABLED
+                value: ${TELEMETRY_ENABLED}
+              - name: TELEMETRY_LOGGER_ENABLED
+                value: ${TELEMETRY_LOGGER_ENABLED}
               - name: CLOWDER_ENABLED
                 value: ${CLOWDER_ENABLED}
               - name: CLOUDWATCH_ENABLED
@@ -103,6 +111,14 @@ objects:
               successThreshold: 1
               timeoutSeconds: 120
             env:
+              - name: LOGGING_LEVEL
+                value: ${LOGGING_LEVEL}
+              - name: DATABASE_LOGGING_LEVEL
+                value: ${DATABASE_LOGGING_LEVEL}
+              - name: TELEMETRY_ENABLED
+                value: ${TELEMETRY_ENABLED}
+              - name: TELEMETRY_LOGGER_ENABLED
+                value: ${TELEMETRY_LOGGER_ENABLED}
               - name: CLOWDER_ENABLED
                 value: ${CLOWDER_ENABLED}
               - name: CLOUDWATCH_ENABLED
@@ -168,6 +184,18 @@ parameters:
   - description: Image name
     name: IMAGE
     value: quay.io/cloudservices/provisioning-backend
+  - description: Logging level (trace, debug, info, warn, error, fatal, panic)
+    name: LOGGING_LEVEL
+    value: "info"
+  - description: Postgres driver logging level (trace, debug, info, warn, error, fatal, panic)
+    name: DATABASE_LOGGING_LEVEL
+    value: "info"
+  - description: OpenTelemetry collecting
+    name: TELEMETRY_ENABLED
+    value: "true"
+  - description: OpenTelemetry export into the logger
+    name: TELEMETRY_LOGGER_ENABLED
+    value: "true"
   - description: Enable compression of the API responses
     name: APP_COMPRESSION
     value: "true"

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/url"
+	"strings"
 
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/rs/zerolog"
@@ -11,6 +12,11 @@ import (
 // production, stage or ephemeral.
 func InClowder() bool {
 	return clowder.IsClowderEnabled()
+}
+
+// InEphemeralClowder returns true, when the app is running in ephemeral clowder environment.
+func InEphemeralClowder() bool {
+	return clowder.IsClowderEnabled() && strings.HasPrefix(*clowder.LoadedConfig.Metadata.EnvName, "env-ephemeral")
 }
 
 func StringToURL(urlStr string) *url.URL {

--- a/internal/logging/zerolog.go
+++ b/internal/logging/zerolog.go
@@ -9,7 +9,6 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http/cloudwatchlogs"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/version"
-
 	cww "github.com/lzap/cloudwatchwriter2"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -62,8 +61,10 @@ func InitializeStdout() {
 		panic(fmt.Errorf("cannot parse log level '%s': %w", config.Logging.Level, err))
 	}
 	zerolog.SetGlobalLevel(level)
+
 	log.Logger = decorate(log.Output(zerolog.ConsoleWriter{
 		Out:        os.Stdout,
+		NoColor:    config.InEphemeralClowder(),
 		TimeFormat: time.Kitchen,
 		FormatFieldValue: func(i interface{}) string {
 			return truncateText(fmt.Sprintf("%s", i), config.Logging.MaxField)


### PR DESCRIPTION
SSIA

Looks ugly, e.g. https://ci.int.devshift.net/job/RHEnVision-provisioning-backend-pr-check/464/artifact/artifacts/k8s_artifacts/ephemeral-ewuczi/logs/provisioning-backend-api-service-7d8b9d888c-kn7tc_provisioning-backend-api-service.log

However, I don't know how to test this because our CI does not archive logs when job is successful. Any ideas @RHEnVision/qe ? :-)