### PR TITLE
Rename clowder service to 'api'

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -68,7 +68,7 @@ objects:
               requests:
                 cpu: ${CPU_REQUESTS}
                 memory: ${MEMORY_REQUESTS}
-        - name: service
+        - name: api
           minReplicas: ${{MIN_REPLICAS}}
           webServices:
             public:


### PR DESCRIPTION
This will fail until https://gitlab.cee.redhat.com/insights-qe/iqe-provisioning-plugin/-/blob/master/iqe_provisioning/conf/provisioning.default.yaml#L56 is updated too. Not sure how to approach this without breaking the pipeline tho.

@RHEnVision/qe 