### PR TITLE
changelog: update types and add docs

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -9,16 +9,24 @@ options:
       Type:
         - feat
         - fix
-        - perf
         - refactor
+        - perf
         - chore
+        - demo
+        - docs
+        - style
+        - test
   commit_groups:
     title_maps:
       feat: Features
       fix: Bug Fixes
-      perf: Performance
       refactor: Refactoring
+      perf: Performance
       chore: Chores
+      demo: Demo
+      docs: Documentation
+      style: Code Style
+      test: Testing
   header:
     pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
     pattern_maps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,31 @@
 # Contributing to Provisioning
 
+## Commit messages
+
+Commit messages must be in the form of:
+
+* `type: brief summary` (maximum 70 characters)
+* `type(component): brief summary`
+
+Supported types:
+
+* feat (Feature)
+* fix
+* refactor
+* perf
+* revert
+* chore
+* demo
+* docs
+* style
+* test
+
+For components, use Go package names which have the most changes. This is optional.
+
+For WIP branches, start commit message with `WIP` and it will pass on CI.
+
+Use `make check-commits` to check commit message locally.
+
 ## Basic guidelines for code contributions
 
 Here are few points before you start contributing:

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -92,3 +92,7 @@ Tip: Alternatively, the application supports connecting to the stage environment
 ## Image Builder
 
 Because Image Builder is more complex for installation, we do not recommend installing it on your local machine right now. Configure connection through HTTP proxy to the stage environment in `config/api.env`. See [configuration example](../config/api.env.example) for an example, you will need to ask someone from the company for real URLs for the service and the proxy.
+
+## Writing Go code
+
+Ready to write some Go code? Read [contributing guide](../CONTRIBUTING.md).

--- a/scripts/check_commits.sh
+++ b/scripts/check_commits.sh
@@ -1,27 +1,29 @@
 #!/bin/bash
 
 MESSAGE=$(git log --pretty=format:%s HEAD^..HEAD)
-
-MAX_LENGTH=70
-TYPES="chore demo docs feat fix refactor revert style test"
-PATTERN="^([a-z]+)\([a-z\-\*]+\)\:\ (.*)$"
-
-if [[ ${#MESSAGE} > $MAX_LENGTH ]]; then
-     echo "ERROR: Commit message was ${#MESSAGE} characters long, but should be at most $MAX_LENGTH characters"
-     exit 1
+if [[ "$MESSAGE" =~ ^WIP ]]; then
+  exit 0
 fi
 
-if [[ "$MESSAGE" =~ ^WIP ]]; then
-    exit 0
+MAX_LENGTH=70
+TYPES="feat fix refactor perf revert chore demo docs style test"
+PATTERN="^[a-z\(\)]+\:\ (.*)$"
+SCOPED_PATTERN="^([a-z]+)\([a-z\-\*]+\)\:\ (.*)$"
+
+if [[ ${#MESSAGE} > $MAX_LENGTH ]]; then
+  echo "ERROR: Commit message length too long (70): ${#MESSAGE}"
+  exit 1
 fi
 
 if ! [[ "$MESSAGE" =~ $PATTERN ]]; then
-    echo "ERROR: Commit message did not match 'type(scope): subject': $MESSAGE"
-    exit 1
+  echo "ERROR: Commit message did not match 'type: subject': $MESSAGE"
+  exit 1
 fi
 
-TYPE=${BASH_REMATCH[1]}
-if ! [[ $TYPES =~ (^| )$TYPE($| ) ]]; then
+if [[ "$MESSAGE" =~ $SCOPED_PATTERN ]]; then
+  TYPE=${BASH_REMATCH[1]}
+  if ! [[ $TYPES =~ (^| )$TYPE($| ) ]]; then
     echo "ERROR: Commit message's type '$TYPE' must be one of '$TYPES'"
     exit 1
+  fi
 fi


### PR DESCRIPTION
The CI check did not allow commit messages without component: `feat: no component`.

This fixes it, also sorts all possible types and sync them with the check script (and configuration of the changelog tool).

Finally, adds some documentation.