### PR TITLE
chore(oapi): update clients, missing make doc

### DIFF
--- a/config/ib_api.yaml
+++ b/config/ib_api.yaml
@@ -138,6 +138,89 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ComposeMetadata'
+  /composes/{composeId}/clone:
+    post:
+      summary: clone a compose
+      description: |
+        Clones a compose. Only composes with the 'aws' image type currently support cloning.
+      parameters:
+        - in: path
+          name: composeId
+          schema:
+            type: string
+            example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: Id of compose to clone
+      operationId: cloneCompose
+      requestBody:
+        required: true
+        description: details of the new clone
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CloneRequest"
+      responses:
+        '201':
+          description: cloning has started
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CloneResponse"
+  /composes/{composeId}/clones:
+    get:
+      summary: get clones of a compose
+      parameters:
+        - in: path
+          name: composeId
+          schema:
+            type: string
+            example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: Id of compose to get the clones of
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+          description: max amount of composes, default 100
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+          description: composes page offset, default 0
+      description: |
+        Returns a list of all the clones which were started for a compose
+      operationId: getComposeClones
+      responses:
+        '200':
+          description: compose clones
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClonesResponse'
+  /clones/{id}:
+    get:
+      summary: get status of a compose clone
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: Id of clone status to get
+      description: status of a clone
+      operationId: getCloneStatus
+      responses:
+        '200':
+          description: clone status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadStatus'
   /compose:
     post:
       summary: compose image
@@ -391,6 +474,10 @@ components:
         - rhel-90
         - centos-8
         - centos-9
+        - fedora-35
+        - fedora-36
+        - fedora-37
+        - fedora-38
     ImageRequest:
       required:
         - architecture
@@ -556,6 +643,16 @@ components:
           example: 'ToucanResourceGroup'
           description: |
             Name of the resource group where the image should be uploaded.
+        image_name:
+          type: string
+          example: 'LinuxImage'
+          pattern: '(^[a-zA-Z0-9]$)|(^[a-zA-Z0-9][a-zA-Z0-9_\.-]*[a-zA-Z0-9_]$)'
+          minLength: 1
+          maxLength: 60
+          description: |
+            Name of the created image.
+            Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens.
+            The total length is limited to 60 characters.
     Customizations:
       type: object
       properties:
@@ -574,6 +671,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Filesystem'
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+          description:
+            "list of users that a customer can add, also specifying their respective groups and SSH keys"
+    User:
+      type: object
+      required:
+        - name
+        - ssh_key
+      properties:
+        name:
+          type: string
+          example: "user1"
+        ssh_key:
+          type: string
+          example: "ssh-rsa AAAAB3NzaC1"
     Filesystem:
       type: object
       required:
@@ -726,3 +841,72 @@ components:
           type: boolean
         ignore_ssl:
           type: boolean
+    ClonesResponse:
+      required:
+        - meta
+        - links
+        - data
+      properties:
+        meta:
+          type: object
+          required:
+            - count
+          properties:
+            count:
+              type: integer
+        links:
+          type: object
+          required:
+            - first
+            - last
+          properties:
+            first:
+              type: string
+              example: "/api/image-builder/v1/composes?limit=10&offset=0"
+            last:
+              type: string
+              example: "/api/image-builder/v1/composes?limit=10&offset=10"
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClonesResponseItem'
+    ClonesResponseItem:
+      required:
+        - id
+        - request
+        - created_at
+      properties:
+        id:
+          type: string
+        request: {}
+        created_at:
+          type: string
+    CloneRequest:
+      oneOf:
+      - $ref: '#/components/schemas/AWSEC2Clone'
+    AWSEC2Clone:
+      type: object
+      required:
+        - region
+      properties:
+        region:
+          type: string
+          description: |
+            A region as described in
+            https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-regions
+        share_with_accounts:
+          type: array
+          example: ['123456789012']
+          description: |
+            An array of AWS account IDs as described in
+            https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html
+          items:
+            type: string
+            pattern: '^[0-9]{12}$'
+    CloneResponse:
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: '123e4567-e89b-12d3-a456-426655440000'

--- a/config/sources_api.json
+++ b/config/sources_api.json
@@ -2540,6 +2540,7 @@
             "type": "string"
           },
           "authtype": {
+            "type": "string",
             "description": "The type of the authentication",
             "enum": [
               "access_key_secret_key",
@@ -2558,7 +2559,10 @@
               "receptor_node",
               "tenant_id_client_id_client_secret",
               "token",
-              "username_password"
+              "username_password",
+              "provisioning-arn",
+              "provisioning_lighthouse_subscription_id",
+              "provisioning_project_id"
             ]
           },
           "username": {
@@ -2603,8 +2607,8 @@
             "type": "string"
           },
           "authtype": {
-            "description": "The type of the authentication",
             "type": "string",
+            "description": "The type of the authentication",
             "enum": [
               "access_key_secret_key",
               "api_token_account_id",
@@ -2622,7 +2626,10 @@
               "receptor_node",
               "tenant_id_client_id_client_secret",
               "token",
-              "username_password"
+              "username_password",
+              "provisioning-arn",
+              "provisioning_lighthouse_subscription_id",
+              "provisioning_project_id"
             ]
           },
           "username": {
@@ -2699,6 +2706,7 @@
             "type": "string"
           },
           "authtype": {
+            "type": "string",
             "description": "The type of the authentication",
             "enum": [
               "access_key_secret_key",
@@ -2717,7 +2725,10 @@
               "receptor_node",
               "tenant_id_client_id_client_secret",
               "token",
-              "username_password"
+              "username_password",
+              "provisioning-arn",
+              "provisioning_lighthouse_subscription_id",
+              "provisioning_project_id"
             ]
           },
           "username": {
@@ -3843,7 +3854,10 @@
                     "receptor_node",
                     "tenant_id_client_id_client_secret",
                     "token",
-                    "username_password"
+                    "username_password",
+                    "provisioning-arn",
+                    "provisioning_lighthouse_subscription_id",
+                    "provisioning_project_id"
                   ],
                   "example": "arn",
                   "type": "string"

--- a/internal/clients/http/sources/client.gen.go
+++ b/internal/clients/http/sources/client.gen.go
@@ -41,6 +41,30 @@ const (
 	ApplicationUpdateAvailabilityStatusUnavailable        ApplicationUpdateAvailabilityStatus = "unavailable"
 )
 
+// Defines values for AuthenticationCreateAuthtype.
+const (
+	AuthenticationCreateAuthtypeAccessKeySecretKey                   AuthenticationCreateAuthtype = "access_key_secret_key"
+	AuthenticationCreateAuthtypeApiTokenAccountId                    AuthenticationCreateAuthtype = "api_token_account_id"
+	AuthenticationCreateAuthtypeArn                                  AuthenticationCreateAuthtype = "arn"
+	AuthenticationCreateAuthtypeBitbucketAppPassword                 AuthenticationCreateAuthtype = "bitbucket-app-password"
+	AuthenticationCreateAuthtypeCloudMeterArn                        AuthenticationCreateAuthtype = "cloud-meter-arn"
+	AuthenticationCreateAuthtypeDockerAccessToken                    AuthenticationCreateAuthtype = "docker-access-token"
+	AuthenticationCreateAuthtypeGithubPersonalAccessToken            AuthenticationCreateAuthtype = "github-personal-access-token"
+	AuthenticationCreateAuthtypeGitlabPersonalAccessToken            AuthenticationCreateAuthtype = "gitlab-personal-access-token"
+	AuthenticationCreateAuthtypeLighthouseSubscriptionId             AuthenticationCreateAuthtype = "lighthouse_subscription_id"
+	AuthenticationCreateAuthtypeMarketplaceToken                     AuthenticationCreateAuthtype = "marketplace-token"
+	AuthenticationCreateAuthtypeOcid                                 AuthenticationCreateAuthtype = "ocid"
+	AuthenticationCreateAuthtypeProjectIdServiceAccountJson          AuthenticationCreateAuthtype = "project_id_service_account_json"
+	AuthenticationCreateAuthtypeProvisioningArn                      AuthenticationCreateAuthtype = "provisioning-arn"
+	AuthenticationCreateAuthtypeProvisioningLighthouseSubscriptionId AuthenticationCreateAuthtype = "provisioning_lighthouse_subscription_id"
+	AuthenticationCreateAuthtypeProvisioningProjectId                AuthenticationCreateAuthtype = "provisioning_project_id"
+	AuthenticationCreateAuthtypeQuayEncryptedPassword                AuthenticationCreateAuthtype = "quay-encrypted-password"
+	AuthenticationCreateAuthtypeReceptorNode                         AuthenticationCreateAuthtype = "receptor_node"
+	AuthenticationCreateAuthtypeTenantIdClientIdClientSecret         AuthenticationCreateAuthtype = "tenant_id_client_id_client_secret"
+	AuthenticationCreateAuthtypeToken                                AuthenticationCreateAuthtype = "token"
+	AuthenticationCreateAuthtypeUsernamePassword                     AuthenticationCreateAuthtype = "username_password"
+)
+
 // Defines values for AuthenticationCreateResourceType.
 const (
 	AuthenticationCreateResourceTypeApplication    AuthenticationCreateResourceType = "Application"
@@ -51,23 +75,26 @@ const (
 
 // Defines values for AuthenticationReadAuthtype.
 const (
-	AuthenticationReadAuthtypeAccessKeySecretKey           AuthenticationReadAuthtype = "access_key_secret_key"
-	AuthenticationReadAuthtypeApiTokenAccountId            AuthenticationReadAuthtype = "api_token_account_id"
-	AuthenticationReadAuthtypeArn                          AuthenticationReadAuthtype = "arn"
-	AuthenticationReadAuthtypeBitbucketAppPassword         AuthenticationReadAuthtype = "bitbucket-app-password"
-	AuthenticationReadAuthtypeCloudMeterArn                AuthenticationReadAuthtype = "cloud-meter-arn"
-	AuthenticationReadAuthtypeDockerAccessToken            AuthenticationReadAuthtype = "docker-access-token"
-	AuthenticationReadAuthtypeGithubPersonalAccessToken    AuthenticationReadAuthtype = "github-personal-access-token"
-	AuthenticationReadAuthtypeGitlabPersonalAccessToken    AuthenticationReadAuthtype = "gitlab-personal-access-token"
-	AuthenticationReadAuthtypeLighthouseSubscriptionId     AuthenticationReadAuthtype = "lighthouse_subscription_id"
-	AuthenticationReadAuthtypeMarketplaceToken             AuthenticationReadAuthtype = "marketplace-token"
-	AuthenticationReadAuthtypeOcid                         AuthenticationReadAuthtype = "ocid"
-	AuthenticationReadAuthtypeProjectIdServiceAccountJson  AuthenticationReadAuthtype = "project_id_service_account_json"
-	AuthenticationReadAuthtypeQuayEncryptedPassword        AuthenticationReadAuthtype = "quay-encrypted-password"
-	AuthenticationReadAuthtypeReceptorNode                 AuthenticationReadAuthtype = "receptor_node"
-	AuthenticationReadAuthtypeTenantIdClientIdClientSecret AuthenticationReadAuthtype = "tenant_id_client_id_client_secret"
-	AuthenticationReadAuthtypeToken                        AuthenticationReadAuthtype = "token"
-	AuthenticationReadAuthtypeUsernamePassword             AuthenticationReadAuthtype = "username_password"
+	AuthenticationReadAuthtypeAccessKeySecretKey                   AuthenticationReadAuthtype = "access_key_secret_key"
+	AuthenticationReadAuthtypeApiTokenAccountId                    AuthenticationReadAuthtype = "api_token_account_id"
+	AuthenticationReadAuthtypeArn                                  AuthenticationReadAuthtype = "arn"
+	AuthenticationReadAuthtypeBitbucketAppPassword                 AuthenticationReadAuthtype = "bitbucket-app-password"
+	AuthenticationReadAuthtypeCloudMeterArn                        AuthenticationReadAuthtype = "cloud-meter-arn"
+	AuthenticationReadAuthtypeDockerAccessToken                    AuthenticationReadAuthtype = "docker-access-token"
+	AuthenticationReadAuthtypeGithubPersonalAccessToken            AuthenticationReadAuthtype = "github-personal-access-token"
+	AuthenticationReadAuthtypeGitlabPersonalAccessToken            AuthenticationReadAuthtype = "gitlab-personal-access-token"
+	AuthenticationReadAuthtypeLighthouseSubscriptionId             AuthenticationReadAuthtype = "lighthouse_subscription_id"
+	AuthenticationReadAuthtypeMarketplaceToken                     AuthenticationReadAuthtype = "marketplace-token"
+	AuthenticationReadAuthtypeOcid                                 AuthenticationReadAuthtype = "ocid"
+	AuthenticationReadAuthtypeProjectIdServiceAccountJson          AuthenticationReadAuthtype = "project_id_service_account_json"
+	AuthenticationReadAuthtypeProvisioningArn                      AuthenticationReadAuthtype = "provisioning-arn"
+	AuthenticationReadAuthtypeProvisioningLighthouseSubscriptionId AuthenticationReadAuthtype = "provisioning_lighthouse_subscription_id"
+	AuthenticationReadAuthtypeProvisioningProjectId                AuthenticationReadAuthtype = "provisioning_project_id"
+	AuthenticationReadAuthtypeQuayEncryptedPassword                AuthenticationReadAuthtype = "quay-encrypted-password"
+	AuthenticationReadAuthtypeReceptorNode                         AuthenticationReadAuthtype = "receptor_node"
+	AuthenticationReadAuthtypeTenantIdClientIdClientSecret         AuthenticationReadAuthtype = "tenant_id_client_id_client_secret"
+	AuthenticationReadAuthtypeToken                                AuthenticationReadAuthtype = "token"
+	AuthenticationReadAuthtypeUsernamePassword                     AuthenticationReadAuthtype = "username_password"
 )
 
 // Defines values for AuthenticationReadResourceType.
@@ -80,23 +107,26 @@ const (
 
 // Defines values for BulkCreatePayloadAuthenticationsAuthtype.
 const (
-	BulkCreatePayloadAuthenticationsAuthtypeAccessKeySecretKey           BulkCreatePayloadAuthenticationsAuthtype = "access_key_secret_key"
-	BulkCreatePayloadAuthenticationsAuthtypeApiTokenAccountId            BulkCreatePayloadAuthenticationsAuthtype = "api_token_account_id"
-	BulkCreatePayloadAuthenticationsAuthtypeArn                          BulkCreatePayloadAuthenticationsAuthtype = "arn"
-	BulkCreatePayloadAuthenticationsAuthtypeBitbucketAppPassword         BulkCreatePayloadAuthenticationsAuthtype = "bitbucket-app-password"
-	BulkCreatePayloadAuthenticationsAuthtypeCloudMeterArn                BulkCreatePayloadAuthenticationsAuthtype = "cloud-meter-arn"
-	BulkCreatePayloadAuthenticationsAuthtypeDockerAccessToken            BulkCreatePayloadAuthenticationsAuthtype = "docker-access-token"
-	BulkCreatePayloadAuthenticationsAuthtypeGithubPersonalAccessToken    BulkCreatePayloadAuthenticationsAuthtype = "github-personal-access-token"
-	BulkCreatePayloadAuthenticationsAuthtypeGitlabPersonalAccessToken    BulkCreatePayloadAuthenticationsAuthtype = "gitlab-personal-access-token"
-	BulkCreatePayloadAuthenticationsAuthtypeLighthouseSubscriptionId     BulkCreatePayloadAuthenticationsAuthtype = "lighthouse_subscription_id"
-	BulkCreatePayloadAuthenticationsAuthtypeMarketplaceToken             BulkCreatePayloadAuthenticationsAuthtype = "marketplace-token"
-	BulkCreatePayloadAuthenticationsAuthtypeOcid                         BulkCreatePayloadAuthenticationsAuthtype = "ocid"
-	BulkCreatePayloadAuthenticationsAuthtypeProjectIdServiceAccountJson  BulkCreatePayloadAuthenticationsAuthtype = "project_id_service_account_json"
-	BulkCreatePayloadAuthenticationsAuthtypeQuayEncryptedPassword        BulkCreatePayloadAuthenticationsAuthtype = "quay-encrypted-password"
-	BulkCreatePayloadAuthenticationsAuthtypeReceptorNode                 BulkCreatePayloadAuthenticationsAuthtype = "receptor_node"
-	BulkCreatePayloadAuthenticationsAuthtypeTenantIdClientIdClientSecret BulkCreatePayloadAuthenticationsAuthtype = "tenant_id_client_id_client_secret"
-	BulkCreatePayloadAuthenticationsAuthtypeToken                        BulkCreatePayloadAuthenticationsAuthtype = "token"
-	BulkCreatePayloadAuthenticationsAuthtypeUsernamePassword             BulkCreatePayloadAuthenticationsAuthtype = "username_password"
+	BulkCreatePayloadAuthenticationsAuthtypeAccessKeySecretKey                   BulkCreatePayloadAuthenticationsAuthtype = "access_key_secret_key"
+	BulkCreatePayloadAuthenticationsAuthtypeApiTokenAccountId                    BulkCreatePayloadAuthenticationsAuthtype = "api_token_account_id"
+	BulkCreatePayloadAuthenticationsAuthtypeArn                                  BulkCreatePayloadAuthenticationsAuthtype = "arn"
+	BulkCreatePayloadAuthenticationsAuthtypeBitbucketAppPassword                 BulkCreatePayloadAuthenticationsAuthtype = "bitbucket-app-password"
+	BulkCreatePayloadAuthenticationsAuthtypeCloudMeterArn                        BulkCreatePayloadAuthenticationsAuthtype = "cloud-meter-arn"
+	BulkCreatePayloadAuthenticationsAuthtypeDockerAccessToken                    BulkCreatePayloadAuthenticationsAuthtype = "docker-access-token"
+	BulkCreatePayloadAuthenticationsAuthtypeGithubPersonalAccessToken            BulkCreatePayloadAuthenticationsAuthtype = "github-personal-access-token"
+	BulkCreatePayloadAuthenticationsAuthtypeGitlabPersonalAccessToken            BulkCreatePayloadAuthenticationsAuthtype = "gitlab-personal-access-token"
+	BulkCreatePayloadAuthenticationsAuthtypeLighthouseSubscriptionId             BulkCreatePayloadAuthenticationsAuthtype = "lighthouse_subscription_id"
+	BulkCreatePayloadAuthenticationsAuthtypeMarketplaceToken                     BulkCreatePayloadAuthenticationsAuthtype = "marketplace-token"
+	BulkCreatePayloadAuthenticationsAuthtypeOcid                                 BulkCreatePayloadAuthenticationsAuthtype = "ocid"
+	BulkCreatePayloadAuthenticationsAuthtypeProjectIdServiceAccountJson          BulkCreatePayloadAuthenticationsAuthtype = "project_id_service_account_json"
+	BulkCreatePayloadAuthenticationsAuthtypeProvisioningArn                      BulkCreatePayloadAuthenticationsAuthtype = "provisioning-arn"
+	BulkCreatePayloadAuthenticationsAuthtypeProvisioningLighthouseSubscriptionId BulkCreatePayloadAuthenticationsAuthtype = "provisioning_lighthouse_subscription_id"
+	BulkCreatePayloadAuthenticationsAuthtypeProvisioningProjectId                BulkCreatePayloadAuthenticationsAuthtype = "provisioning_project_id"
+	BulkCreatePayloadAuthenticationsAuthtypeQuayEncryptedPassword                BulkCreatePayloadAuthenticationsAuthtype = "quay-encrypted-password"
+	BulkCreatePayloadAuthenticationsAuthtypeReceptorNode                         BulkCreatePayloadAuthenticationsAuthtype = "receptor_node"
+	BulkCreatePayloadAuthenticationsAuthtypeTenantIdClientIdClientSecret         BulkCreatePayloadAuthenticationsAuthtype = "tenant_id_client_id_client_secret"
+	BulkCreatePayloadAuthenticationsAuthtypeToken                                BulkCreatePayloadAuthenticationsAuthtype = "token"
+	BulkCreatePayloadAuthenticationsAuthtypeUsernamePassword                     BulkCreatePayloadAuthenticationsAuthtype = "username_password"
 )
 
 // Defines values for BulkCreatePayloadAuthenticationsResourceType.
@@ -325,7 +355,7 @@ type ApplicationsCollection struct {
 // Expected payload to create an Authentication
 type AuthenticationCreate struct {
 	// The type of the authentication
-	Authtype *interface{} `json:"authtype,omitempty"`
+	Authtype *AuthenticationCreateAuthtype `json:"authtype,omitempty"`
 
 	// The received error message when polling for the availability status
 	AvailabilityStatusError *string `json:"availability_status_error,omitempty"`
@@ -348,6 +378,9 @@ type AuthenticationCreate struct {
 	// The username for the authentication
 	Username *string `json:"username,omitempty"`
 }
+
+// The type of the authentication
+type AuthenticationCreateAuthtype string
 
 // The type of the resource this authentication belongs to
 type AuthenticationCreateResourceType string

--- a/mk/clients.mk
+++ b/mk/clients.mk
@@ -1,11 +1,11 @@
 ##@ HTTP Clients
 
 .PHONY: update-clients
-update-clients: ## Update HTTP client stubs from upstream git repos
+update-clients: ## Update OpenAPI specs from upstream
 	wget -O ./config/ib_api.yaml -qN https://raw.githubusercontent.com/osbuild/image-builder/main/internal/v1/api.yaml
 	wget -O ./config/sources_api.json -qN https://raw.githubusercontent.com/RedHatInsights/sources-api-go/main/public/openapi-3-v3.1.json
 
-generate-clients: internal/clients/http/image_builder/client.gen.go internal/clients/http/sources/client.gen.go
+generate-clients: internal/clients/http/image_builder/client.gen.go internal/clients/http/sources/client.gen.go ## Generate HTTP client stubs
 
 internal/clients/http/sources/client.gen.go: config/sources_config.yml config/sources_api.json
 	oapi-codegen -config ./config/sources_config.yml ./config/sources_api.json
@@ -16,4 +16,3 @@ internal/clients/http/image_builder/client.gen.go: config/ib_config.yaml config/
 .PHONY: validate-clients
 validate-clients: generate-clients ## Compare generated client code with git
 	git diff --exit-code internal/clients/*/client.gen.go
-


### PR DESCRIPTION
After the `configs` directory rename, the timestamps for `make` were not correct. This fixes it (just by running `make` once).

Also I updated clients, it now contains the change I submitted to sources (missing type, enums).

Finally, I realized that `make generate-clients` target was not documented at all.