### PR TITLE
feat: welcome HTML page

### DIFF
--- a/docs/openapi/index.html
+++ b/docs/openapi/index.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <title>Provisioning API (main branch)</title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+<body>
+<redoc spec-url='https://raw.githubusercontent.com/RHEnVision/provisioning-backend/main/api/openapi.gen.json'></redoc>
+<script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"> </script>
+</body>
+</html>

--- a/internal/services/welcome_service.go
+++ b/internal/services/welcome_service.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"bytes"
+	"html/template"
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/version"
+)
+
+const welcomeTmpl = `<!DOCTYPE html>
+<html>
+	<head>
+		<title>Provisioning backend</title>
+		<meta charset="utf-8"/>
+	</head>
+	<body>
+		<h1>Provisioning backend API {{ .APIVersion }} {{ .BuildCommit }}</h1>
+		<ul>
+			<li><a href="/docs">OpenAPI documentation</a></li>
+			<li><a href="/ping">Ping service</a> (identity not needed)</li>
+			<li><a href="/api/provisioning/{{ .APIVersion }}/openapi.json">OpenAPI JSON</a></li>
+			<li><a href="/api/provisioning/{{ .APIVersion }}/ready">Ready service</a> (identity needed)</li>
+		</ul>
+		<p>Built at {{ .BuildTime }}</p>
+	</body>
+</html>
+`
+
+type Vars struct {
+	APIVersion  string
+	BuildCommit string
+	BuildTime   string
+}
+
+func WelcomeService(w http.ResponseWriter, r *http.Request) {
+	vars := Vars{
+		APIVersion:  version.APIPathVersion,
+		BuildCommit: version.BuildCommit,
+		BuildTime:   version.BuildTime,
+	}
+
+	tmpl := template.Must(template.New("welcome").Parse(welcomeTmpl))
+	buf := bytes.NewBuffer(nil)
+	_ = tmpl.Execute(buf, vars)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(buf.Bytes())
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,3 +21,13 @@ const (
 	// OpenTelemetryVersion is used for all OpenTelemetry tracing
 	OpenTelemetryVersion = "1.0.0"
 )
+
+func init() {
+	if BuildTime == "" {
+		BuildTime = "N/A"
+	}
+
+	if BuildCommit == "" {
+		BuildCommit = "HEAD"
+	}
+}


### PR DESCRIPTION
This adds a nice welcome page, this is pure HTML 3.2 how I remember it. Here is a screenshot:

![Snímek obrazovky 2022-10-13 v 16 18 51](https://user-images.githubusercontent.com/49752/195622339-d8cc5ed8-3666-4b8b-adc9-27d2884f19fb.png)

The reason was I was hitting `/docs/` instead of the correct `/docs`, I don't need to remember this anymore with this patch. Also shows current version and sha commit on the page (when compiled in).

Also cleans up routes a bit, it was a bit confusing to me.

Finally, adds an `index.html` file which should be available on through github to always show us latest and greatest OpenAPI documentation. Untested but it should work as this is exactly how Go redoc does it (I actually copy and pasted the HTML from there).