### PR TITLE
feat: AWS file credentials support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ TAGS
 /scripts/rest_examples/*.local.http
 /scripts/rest_examples/*.private.env.json
 /dao_tests.test
+/internal/db/seeds/*.local.sql

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,11 @@ var config struct {
 		Session       string `env:"SESSION" env-default:"" env-description:"AWS service account session"`
 		DefaultRegion string `env:"DEFAULT_REGION" env-default:"us-east-1" env-description:"AWS region when not provided"`
 		Logging       bool   `env:"LOGGING" env-default:"false" env-description:"AWS service account logging (verbose)"`
+		// Alternative credentials through our aws-saml.py script which creates ~/.aws/credentials
+		// Only use this for development setups
+		FileCredentials bool   `env:"FILE_CREDENTIALS" env-default:"false" env-description:"read credentials from ~/.aws/credentials (dev only alternative)"`
+		FileProfile     string `env:"FILE_PROFILE" env-default:"" env-description:"credential file profile (dev only)"`
+		NoAssumeRole    bool   `env:"NO_ASSUME_ROLE" env-default:"false" env-description:"disable AssumeRole call and use service account directly (dev only)"`
 	} `env-prefix:"AWS_"`
 	Azure struct {
 		TenantID       string `env:"TENANT_ID" env-default:"" env-description:"Azure service account tenant id"`

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -58,7 +59,8 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	pk, err := pkDao.GetById(r.Context(), reservation.PubkeyID)
 	if err != nil {
 		if errors.Is(err, dao.ErrNoRows) {
-			renderError(w, r, payloads.NewNotFoundError(r.Context(), err))
+			notFoundErr := fmt.Errorf("pubkey id %d not found for this account: %w", reservation.PubkeyID, err)
+			renderError(w, r, payloads.NewNotFoundError(r.Context(), notFoundErr))
 		} else {
 			renderError(w, r, payloads.NewDAOError(r.Context(), "get pubkey by id", err))
 		}


### PR DESCRIPTION
Since we still don't have AWS team account for development and my free credits has expired already, I need to use our SAML-enabled account via the `saml-aws.py` script. It is possible only if we add a special configuration for this.

This patch adds exactly that, however, I would very much rather prefer getting a proper service/customer account for the whole team instead of this.