### PR TITLE
Typo in etag prefix and gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ TAGS
 /Containerfile
 /tern.conf
 /mk/private.mk
-/scripts/sources-*/
+/scripts/sources-api-go
 /scripts/sources.local.conf
 /scripts/rest_examples/*.local.http
 /scripts/rest_examples/*.private.env.json

--- a/internal/clients/http/ec2/types/ec2_types.go
+++ b/internal/clients/http/ec2/types/ec2_types.go
@@ -35,7 +35,7 @@ func init() {
 	}
 
 	availBuf := clients.ConcatBuffers(fsTypes, availabilityPath)
-	etag, err = middleware.GenerateETagFromBuffer("azure-types", middleware.InstanceTypeExpiration, typesBuf, availBuf)
+	etag, err = middleware.GenerateETagFromBuffer("ec2-types", middleware.InstanceTypeExpiration, typesBuf, availBuf)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Two small things I ran into today, the ec2 prefix is obvious and was spotted by @adiabramovitch 

The other commit is just a small change - I now have a symlink and it looks like git does not recognize symlinks with `something/` gitignore pattern as the slash requires it to be a directory. This fixes it.