### PR TITLE
ci: Add rhsm-api-proxy for rhel images

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -165,6 +165,7 @@ objects:
         - sources-api
       optionalDependencies:
         - image-builder
+        - rhsm-api-proxy
 
 # possible application ENV variables are in config/api.env.example
 parameters:


### PR DESCRIPTION
Image-builder depends upon rhsm-api-proxy for creating rhel images.