### PR TITLE
fix(config): unleash token as bearer header

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,7 +204,7 @@ func Initialize(configFiles ...string) {
 		url := fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
 		config.Unleash.URL = url
 		if cfg.FeatureFlags.ClientAccessToken != nil {
-			config.Unleash.Token = *cfg.FeatureFlags.ClientAccessToken
+			config.Unleash.Token = fmt.Sprintf("Bearer %s", *cfg.FeatureFlags.ClientAccessToken)
 		}
 
 		// HTTP proxies are not allowed in clowder environment

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const unleashProjectName = "default"
+
 // FeatureEnabled returns a user-specific or global feature flag. When such flag is not found,
 // true is returned.
 func FeatureEnabled(ctx context.Context, name string) bool {
@@ -45,8 +47,9 @@ func InitializeFeatureFlags(ctx context.Context) error {
 	}
 	err := unleash.Initialize(
 		unleash.WithListener(&listener),
-		unleash.WithAppName(version.UnleashAppName),
 		unleash.WithUrl(config.Unleash.URL),
+		unleash.WithProjectName(unleashProjectName),
+		unleash.WithAppName(version.UnleashAppName),
 		unleash.WithEnvironment(config.Unleash.Environment),
 		unleash.WithCustomHeaders(http.Header{"Authorization": {config.Unleash.Token}}),
 	)


### PR DESCRIPTION
From others I'm guessing that this should fix unleash connection when token is required.
Also uses unleash project.