### PR TITLE
fix: null for aws_reservation_id when pending

### DIFF
--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -70,8 +70,8 @@ type AWSReservation struct {
 	// Source ID.
 	SourceID string `db:"source_id" json:"source_id"`
 
-	// The ID of the aws reservation which was created.
-	AWSReservationID string `db:"aws_reservation_id" json:"aws_reservation_id"`
+	// The ID of the aws reservation which was created or nil when reservation was not yet created.
+	AWSReservationID *string `db:"aws_reservation_id" json:"aws_reservation_id"`
 
 	// The ID of the image from which the instance is created. AMI's must be prefixed with 'ami-'.
 	ImageID string `db:"image_id" json:"image_id"`

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -60,8 +60,8 @@ type AWSReservationResponsePayload struct {
 	// The ID of the image from which the instance is created.
 	ImageID string `json:"image_id"`
 
-	// The ID of the aws reservation which was created.
-	AWSReservationID string `json:"aws_reservation_id"`
+	// The ID of the aws reservation which was created, or missing if not created yet.
+	AWSReservationID string `json:"aws_reservation_id,omitempty"`
 
 	// Optional name of the instance(s).
 	Name *string `json:"name"`
@@ -189,17 +189,19 @@ func NewAWSReservationResponse(reservation *models.AWSReservation, instances []*
 	}
 
 	response := AWSReservationResponsePayload{
-		PubkeyID:         reservation.PubkeyID,
-		ImageID:          reservation.ImageID,
-		SourceID:         reservation.SourceID,
-		Region:           reservation.Detail.Region,
-		Amount:           reservation.Detail.Amount,
-		InstanceType:     reservation.Detail.InstanceType,
-		AWSReservationID: reservation.AWSReservationID,
-		ID:               reservation.ID,
-		Name:             reservation.Detail.Name,
-		PowerOff:         reservation.Detail.PowerOff,
-		Instances:        instanceIds,
+		PubkeyID:     reservation.PubkeyID,
+		ImageID:      reservation.ImageID,
+		SourceID:     reservation.SourceID,
+		Region:       reservation.Detail.Region,
+		Amount:       reservation.Detail.Amount,
+		InstanceType: reservation.Detail.InstanceType,
+		ID:           reservation.ID,
+		Name:         reservation.Detail.Name,
+		PowerOff:     reservation.Detail.PowerOff,
+		Instances:    instanceIds,
+	}
+	if reservation.AWSReservationID != nil {
+		response.AWSReservationID = *reservation.AWSReservationID
 	}
 	return &response
 }


### PR DESCRIPTION
When reservation is created and it is still not fulfilled, the AWS reservation id was NULL in the database, but the struct field was string and not pointer to string. This caused scany library not to be able to scan the `nil` value. This fixes it.

OpenAPI clients must be aware that the field can be `null` in case the reservation is not yet finished.