### PR TITLE
Multiple Kafka concurrency fixes

### DIFF
--- a/internal/background/availability_queue.go
+++ b/internal/background/availability_queue.go
@@ -58,8 +58,9 @@ func sendAvailabilityRequestMessages(ctx context.Context, batchSize int, tickDur
 			if length > 0 {
 				logger.Trace().Int("messages", length).Msgf("Sent %d availability request messages (cancel)", length)
 				send(ctx, messageBuffer...)
-				messageBuffer = messageBuffer[:0]
 			}
+
+			return
 		}
 	}
 }

--- a/internal/clients/http/platform_client.go
+++ b/internal/clients/http/platform_client.go
@@ -9,13 +9,14 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
+// Shared HTTP transport for all platform clients to utilize connection caching
+var transport = &http.Transport{}
+
 // NewPlatformClient returns new HTTP client (doer) with W3C Trace Context, logging tracing
 // and/or HTTP proxy (non-clowder environment only) according to application configuration.
 // Use this function to create HTTP clients for communication with all platform services.
 func NewPlatformClient(ctx context.Context, proxy string) HttpRequestDoer {
-	var rt http.RoundTripper
-	transport := &http.Transport{}
-	rt = transport
+	var rt http.RoundTripper = transport
 
 	if proxy != "" {
 		if config.InClowder() {

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -167,6 +167,8 @@ func (b *kafkaBroker) Consume(ctx context.Context, topic string, handler func(ct
 		msg, err := r.ReadMessage(ctx)
 		if err != nil && errors.Is(err, io.EOF) {
 			break
+		} else if err != nil && errors.Is(err, context.Canceled) {
+			break
 		} else if err != nil {
 			logger.Warn().Err(err).Msgf("Error when reading message: %s", err.Error())
 		} else {


### PR DESCRIPTION
When I was working with Adi on Kafka producer, I noticed few bugs in my code.

FIrst, the consumer did not break on context cancel correctly which has no effect any other than if you use some method to wait until goroutine is finished e.g.:

```go
	ctx := context.Background()
	ctx, cancel := context.WithCancel(ctx)

	receiverWG.Add(1)
	go func() {
		defer receiverWG.Done()
		// suppose this is kafka.Consume(ctx, ...)
		receiveFromKafka(ctx, "a message")
	}()

	// wait until term signal and then

	// stop kafka receiver (can take up to 10 seconds) and wait until it returns
	cancel()
	receiverWG.Wait()
```

The `Wait` call would never end. The first commit fixes it.

Second, we use a custom HTTP client doer for Sources and IB, however, it creates a new transport for each and every client. This is wasting of resources since http.Transport can and should be shared according to Go documentation. This allows reusing of connections or connection caching/pooling which is built in. The second patch fixes this, this should lead to better performance for sources/ib clients.

Finally, similar issue to the first one we have in the availability queuer where look is not broken on the context cancel leading to active goroutine when shutting down gracefully. Again, no practical consequences other than program exiting with a goroutine still looping (waiting) in the background, but it's good to fix it too. That's the third commit.