### PR TITLE
feat(refactor): Add required true post aws in apispec

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -479,7 +479,9 @@
                 "$ref": "#/components/schemas/v1.AWSReservationRequest"
               }
             }
-          }
+          },
+          "description": "aws request body",
+          "required": true
         },
         "responses": {
           "200": {

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -239,6 +239,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/v1.AWSReservationRequest'
+        description: aws request body
+        required: true
       responses:
         '200':
           description: 'Returned on success.'

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -239,6 +239,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/v1.AWSReservationRequest'
+        description: aws request body
+        required: true
       responses:
         '200':
           description: 'Returned on success.'


### PR DESCRIPTION
This helps IQE to pass the parameters into **kwargs instead of an positional arg.
The same is already done with POST /pubkeys