### PR TITLE
fix: missing cache type variable for api

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -148,6 +148,8 @@ objects:
                     optional: false
               - name: APP_INSTANCE_PREFIX
                 value: ${APP_INSTANCE_PREFIX}
+              - name: APP_CACHE_TYPE
+                value: ${APP_CACHE_TYPE}
               - name: WORKER_QUEUE
                 value: ${WORKER_QUEUE}
             resources:


### PR DESCRIPTION
I noticed that cache is actually not configured for the API pod on ephemeral:

```
7:36AM TRC Registered unleash client: {AppName:provisioning InstanceID:1001900000-provisioning-backend-api-7d85475bc4-f9mbp SDKVersion:unleash-client-go:3.7.0 Strategies:[default applicationHostname gradualRolloutRandom gradualRolloutSessionId gradualRolloutUserId remoteAddress userWithId flexibleRollout] Started:2022-11-21 07:36:51.163013346 +0000 UTC m=+0.577366699 Interval:60} hostname=provisioning-backend-api-7d85475bc4-f9mbp unleash=true version=eb5e353
7:36AM INF No application cache in use hostname=provisioning-backend-api-7d85475bc4-f9mbp version=eb5e353
7:36AM DBG Initializing 'redis' job queue hostname=provisioning-backend-api-7d85475bc4-f9mbp version=eb5e353
7:36AM DBG Starting dequeue loop hostname=provisioning-backend-api-7d85475bc4-f9mbp queue_type=redis version=eb5e353
7:36AM TRC Calculated 'json-spec' etag 'ede4eb7b56370b0e' in 0ms hostname=provisioning-backend-api-7d85475bc4-f9mbp version=eb5e353
7:36AM TRC Calculated 'azure-types' etag '3d70c0ffe874d276' in 0ms hostname=provisioning-backend-api-7d85475bc4-f9mbp version=eb5e353
7:36AM TRC Calculated 'ec2-types' etag '64a1f8c83ae3fed4' in 0ms hostname=provisioning-backend-api-7d85475bc4-f9mbp version=eb5e353
7:36AM TRC Calculated 'gcp-types' etag 'ac19c0054941f338' in 0ms hostname=provisioning-backend-api-7d85475bc4-f9mbp version=eb5e353
7:36AM INF Starting new instance on port 8000 with prometheus on 9000 hostname=provisioning-backend-api-7d85475bc4-f9mbp version=eb5e353
```

The message I am looking at is `No application cache`. This should fix this.