### PR TITLE
fix(sources): handle source without application type correctly

### DIFF
--- a/internal/clients/http/sources_errors.go
+++ b/internal/clients/http/sources_errors.go
@@ -8,10 +8,10 @@ import (
 )
 
 var (
-	MoreThanOneAuthenticationForSourceErr = errors.New("more than one authentication")
-	AuthenticationForSourcesNotFoundErr   = fmt.Errorf("authentications for source weren't found in sources app: %w", clients.NotFoundErr)
-	ApplicationNotFoundErr                = fmt.Errorf("application not found is sources app: %w", clients.NotFoundErr)
-	ApplicationTypeNotFoundErr            = fmt.Errorf("application type 'provisioning' not found: %w", clients.NotFoundErr)
-	SourceNotFoundErr                     = fmt.Errorf("source not found: %w", clients.NotFoundErr)
-	AuthenticationSourceAssociationErr    = errors.New("authentication associated to source id not found")
+	AuthenticationForSourcesNotFoundErr = fmt.Errorf("authentications for source weren't found in sources app: %w", clients.NotFoundErr)
+	ApplicationNotFoundErr              = fmt.Errorf("application not found in sources app: %w", clients.NotFoundErr)
+	ApplicationReadErr                  = fmt.Errorf("application read returned no application type in sources: %w", clients.NotFoundErr)
+	ApplicationTypeNotFoundErr          = fmt.Errorf("application type 'provisioning' not found: %w", clients.NotFoundErr)
+	SourceNotFoundErr                   = fmt.Errorf("source not found: %w", clients.NotFoundErr)
+	AuthenticationSourceAssociationErr  = errors.New("authentication associated to source id not found")
 )


### PR DESCRIPTION
In accounts list we allow to select source that does not contain ARN for provisioning.

When selected and sent to reservation creation with such source following panic ocurs:

```
3:35PM ERR Unhandled panic: runtime error: invalid memory address or nil pointer dereference
goroutine 2312 [running]:
runtime/debug.Stack()
    /usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/RHEnVision/provisioning-backend/internal/middleware.LoggerMiddleware.func1.1.1()
    /build/internal/middleware/logger.go:46 +0x392
panic({0x21580c0, 0x39ab360})
    /usr/local/go/src/runtime/panic.go:838 +0x207
github.com/RHEnVision/provisioning-backend/internal/clients/http/sources.(*sourcesClient).GetAuthentication(0xc000546280, {0x29824b8, 0xc001063a10}, {0xc000ad90d0, 0x6})
    /build/internal/clients/http/sources/sources_client.go:138 +0x4d2
github.com/RHEnVision/provisioning-backend/internal/services.CreateAWSReservation({0x297e370, 0xc00065eeb0}, 0xc000cb6500)
    /build/internal/services/aws_reservation_service.go:81 +0x7de
github.com/RHEnVision/provisioning-backend/internal/services.CreateReservation({0x297e370, 0xc00065eeb0}, 0xc000cb6500)
    /build/internal/services/reservations_service.go:33 +0x29b
net/http.HandlerFunc.ServeHTTP(0x2111500?, {0x297e370?, 0xc00065eeb0?}, 0x29478f4?)
    /usr/local/go/src/net/http/server.go:2084 +0x2f
github.com/go-chi/chi/v5.(*Mux).routeHTTP(0xc00013b800, {0x297e370, 0xc00065eeb0}, 0xc000cb6500)
```

I haven't reproduced, but very likely what is happening is that the filter function creates a slice and if there are no Application records, it puts nothing into it and then returns `slice[0]` which is `nil` which is immediately dereferenced on the line 138 and panics.

This patch simplifies this, we are not really interested in sources with multiple Applications, we just take the first. Also no need to pass pointer to slice. Finally, the error is only thrown when the Application is missing.

https://issues.redhat.com/browse/HMSPROV-347