### PR TITLE
test: add unit test for Authentication failure

### DIFF
--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -31,7 +31,13 @@ func logger(ctx context.Context) zerolog.Logger {
 }
 
 func newSourcesClient(ctx context.Context) (clients.Sources, error) {
-	c, err := NewClientWithResponses(config.Sources.URL, func(c *Client) error {
+	return NewSourcesClientWithUrl(ctx, config.Sources.URL)
+}
+
+// NewSourcesClientWithUrl allows customization of the URL for the underlying client.
+// It is meant for testing only, for production please use clients.GetSourcesClient.
+func NewSourcesClientWithUrl(ctx context.Context, url string) (clients.Sources, error) {
+	c, err := NewClientWithResponses(url, func(c *Client) error {
 		c.Client = http.NewPlatformClient(ctx, config.Sources.Proxy.URL)
 		return nil
 	})

--- a/internal/clients/http/sources/sources_client_test.go
+++ b/internal/clients/http/sources/sources_client_test.go
@@ -1,0 +1,32 @@
+package sources_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients/http/sources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourcesClient_GetAuthentication(t *testing.T) {
+	t.Run("source with missing Provisioning auth", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err := io.WriteString(w, `{"data":[{"id":"256144","authtype":"provisioning-arn","username":"arn:aws:asdfasdfsdfsdafsdf","availability_status":"in_progress","resource_type":"Source","resource_id":"304935"}],"meta":{"count":1,"limit":100,"offset":0},"links":{"first":"/api/sources/v3.1/sources/304935/authentications?limit=100\u0026offset=0","last":"/api/sources/v3.1/sources/304935/authentications?limit=100\u0026offset=100"}}`)
+			require.NoError(t, err, "failed to write http body for stubbed server")
+		}))
+		defer ts.Close()
+
+		ctx := context.Background()
+		client, err := sources.NewSourcesClientWithUrl(ctx, ts.URL)
+		require.NoError(t, err, "failed to initialize sources client with test server")
+
+		_, err = client.GetAuthentication(ctx, "256144")
+		assert.Error(t, err, "Authentication should not succeed with missing link to Provisioning service")
+	})
+}


### PR DESCRIPTION
Adds test that uses [`httptest.Server`](https://pkg.go.dev/net/http/httptest#Server) to mock the outbound connection and stub its response.
I believe this is the best way to test the clients as it tests the client implementation together with the generated client and stubs on the HTTP layer.