### PR TITLE
build(container): Switch back to oficial go-tool build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,1 +1,1 @@
-Upstream.dockerfile
+RedHat.dockerfile

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,1 +1,0 @@
-.rhcicd/build_deploy.sh

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,1 +1,0 @@
-.rhcicd/pr_check.sh


### PR DESCRIPTION
Build by official build container as it supports go 1.18 finaly. Also remove now unused links to ci scripts.

https://issues.redhat.com/browse/HMSPROV-365