### PR TITLE
fix: scope existing pubkey search by source id

### DIFF
--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -40,7 +40,7 @@ type PubkeyDao interface {
 	Delete(ctx context.Context, id int64) error
 
 	UnscopedCreateResource(ctx context.Context, pkr *models.PubkeyResource) error
-	UnscopedGetResourceByProviderType(ctx context.Context, pubkeyId int64, provider models.ProviderType) (*models.PubkeyResource, error)
+	UnscopedGetResourceBySourceAndRegion(ctx context.Context, pubkeyId int64, sourceId string, region string) (*models.PubkeyResource, error)
 	UnscopedListResourcesByPubkeyId(ctx context.Context, pkId int64) ([]*models.PubkeyResource, error)
 	UnscopedDeleteResource(ctx context.Context, id int64) error
 }

--- a/internal/dao/pgx/pubkey_pgx.go
+++ b/internal/dao/pgx/pubkey_pgx.go
@@ -129,11 +129,11 @@ func (x *pubkeyDao) UnscopedCreateResource(ctx context.Context, pkr *models.Pubk
 	return nil
 }
 
-func (x *pubkeyDao) UnscopedGetResourceByProviderType(ctx context.Context, pubkeyId int64, provider models.ProviderType) (*models.PubkeyResource, error) {
-	query := `SELECT * FROM pubkey_resources WHERE pubkey_id = $1 AND provider = $2`
+func (x *pubkeyDao) UnscopedGetResourceBySourceAndRegion(ctx context.Context, pubkeyId int64, sourceId string, region string) (*models.PubkeyResource, error) {
+	query := `SELECT * FROM pubkey_resources WHERE pubkey_id = $1 AND source_id = $2 AND region = $3`
 	result := &models.PubkeyResource{}
 
-	err := pgxscan.Get(ctx, db.Pool, result, query, pubkeyId, provider)
+	err := pgxscan.Get(ctx, db.Pool, result, query, pubkeyId, sourceId, region)
 	if err != nil {
 		return nil, fmt.Errorf("pgx error: %w", err)
 	}

--- a/internal/dao/stubs/pubkey_dao.go
+++ b/internal/dao/stubs/pubkey_dao.go
@@ -91,7 +91,7 @@ func (stub *pubkeyDaoStub) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
-func (stub *pubkeyDaoStub) UnscopedGetResourceByProviderType(ctx context.Context, pubkeyId int64, provider models.ProviderType) (*models.PubkeyResource, error) {
+func (stub *pubkeyDaoStub) UnscopedGetResourceBySourceAndRegion(ctx context.Context, pubkeyId int64, sourceId string, region string) (*models.PubkeyResource, error) {
 	return nil, nil
 }
 

--- a/internal/dao/tests/pubkey_resource_test.go
+++ b/internal/dao/tests/pubkey_resource_test.go
@@ -21,6 +21,7 @@ func newPubkeyResourceNoop() *models.PubkeyResource {
 		Tag:      "tag1",
 		PubkeyID: 1,
 		Provider: models.ProviderTypeNoop,
+		SourceID: "1",
 		Handle:   factories.GetSequenceName("handle"),
 		Region:   "us-west-1",
 	}
@@ -78,13 +79,13 @@ func TestPubkeyResourceGetByProviderType(t *testing.T) {
 		err := pubkeyDao.UnscopedCreateResource(ctx, resource)
 		require.NoError(t, err)
 
-		createdResource, err := pubkeyDao.UnscopedGetResourceByProviderType(ctx, resource.PubkeyID, resource.Provider)
+		createdResource, err := pubkeyDao.UnscopedGetResourceBySourceAndRegion(ctx, resource.PubkeyID, resource.SourceID, resource.Region)
 		require.NoError(t, err)
 		assert.Equal(t, resource, createdResource)
 	})
 
 	t.Run("no rows", func(t *testing.T) {
-		_, err := pubkeyDao.UnscopedGetResourceByProviderType(ctx, math.MaxInt64, models.ProviderTypeUnknown)
+		_, err := pubkeyDao.UnscopedGetResourceBySourceAndRegion(ctx, math.MaxInt64, "1234", "us-east-1")
 		require.ErrorIs(t, err, dao.ErrNoRows)
 	})
 }

--- a/internal/jobs/pubkey_upload_aws_job.go
+++ b/internal/jobs/pubkey_upload_aws_job.go
@@ -59,7 +59,7 @@ func handlePubkeyUploadAWS(ctx context.Context, args *PubkeyUploadAWSTaskArgs) e
 
 	// check presence first
 	skip := true
-	pkrCheck, errDao := pkDao.UnscopedGetResourceByProviderType(ctx, args.PubkeyID, models.ProviderTypeAWS)
+	pkrCheck, errDao := pkDao.UnscopedGetResourceBySourceAndRegion(ctx, args.PubkeyID, args.SourceID, args.Region)
 	if errDao != nil {
 		if errors.Is(errDao, dao.ErrNoRows) {
 			skip = false


### PR DESCRIPTION
For AWS the key needs to be available in a region we Launch in.
This fixes the search so we verify pubkey for given account and region.

Fixes: HMSPROV-366