### PR TITLE
fix: ensure pubkey is always present on AWS

### DIFF
--- a/internal/clients/http/ec2_errors.go
+++ b/internal/clients/http/ec2_errors.go
@@ -3,6 +3,7 @@ package http
 import "errors"
 
 var (
-	DuplicatePubkeyErr                    = errors.New("pubkey already exists in the target account")
+	DuplicatePubkeyErr                    = errors.New("public key already exists in target cloud provider account and region")
+	PubkeyNotFoundErr                     = errors.New("pubkey not found in AWS account")
 	ServiceAccountUnsupportedOperationErr = errors.New("unsupported operation on service account")
 )

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -67,6 +67,9 @@ type EC2 interface {
 	// ImportPubkey imports new ssh key-pair with given tag returning its AWS ID
 	ImportPubkey(ctx context.Context, key *models.Pubkey, tag string) (string, error)
 
+	// GetPubkeyName fetches the AWS key name using given pubkey fingerprint
+	GetPubkeyName(ctx context.Context, fingerprint string) (string, error)
+
 	// DeleteSSHKey deletes a given ssh key-pair found by AWS ID
 	DeleteSSHKey(ctx context.Context, handle string) error
 

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/clients/http"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
@@ -12,7 +13,9 @@ type ec2CtxKeyType string
 
 var ec2CtxKey ec2CtxKeyType = "ec2-interface"
 
-type EC2ClientStub struct{}
+type EC2ClientStub struct {
+	Imported []*models.Pubkey
+}
 
 func init() {
 	clients.GetEC2Client = newEC2CustomerClientStubWithRegion
@@ -41,7 +44,15 @@ func (mock *EC2ClientStub) Status(ctx context.Context) error {
 }
 
 func (mock *EC2ClientStub) ImportPubkey(ctx context.Context, key *models.Pubkey, tag string) (string, error) {
-	return "", nil
+	mock.Imported = append(mock.Imported, key)
+	return "key-12345678912345678", nil
+}
+
+func (mock *EC2ClientStub) GetPubkeyName(ctx context.Context, fingerprint string) (string, error) {
+	if fingerprint == "existing" {
+		return "awsKeyPairName", nil
+	}
+	return "", http.PubkeyNotFoundErr
 }
 
 func (mock *EC2ClientStub) DeleteSSHKey(ctx context.Context, handle string) error {

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -79,6 +79,9 @@ type ReservationDao interface {
 	// UpdateStatus sets status field and increment step counter by addSteps. UNSCOPED.
 	UpdateStatus(ctx context.Context, id int64, status string, addSteps int32) error
 
+	// UnscopedUpdateAWSDetail updates details of the AWS reservation. UNSCOPED.
+	UnscopedUpdateAWSDetail(ctx context.Context, id int64, awsDetail *models.AWSDetail) error
+
 	// UpdateReservationIDForAWS updates AWS reservation id field. UNSCOPED.
 	UpdateReservationIDForAWS(ctx context.Context, id int64, awsReservationId string) error
 

--- a/internal/dao/pgx/reservation_pgx.go
+++ b/internal/dao/pgx/reservation_pgx.go
@@ -210,6 +210,19 @@ func (x *reservationDao) UpdateStatus(ctx context.Context, id int64, status stri
 	return nil
 }
 
+func (x *reservationDao) UnscopedUpdateAWSDetail(ctx context.Context, id int64, awsDetail *models.AWSDetail) error {
+	query := `UPDATE aws_reservation_details SET detail = $2 WHERE reservation_id = $1`
+
+	tag, err := db.Pool.Exec(ctx, query, id, awsDetail)
+	if err != nil {
+		return fmt.Errorf("pgx error: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+	}
+	return nil
+}
+
 func (x *reservationDao) UpdateReservationIDForAWS(ctx context.Context, id int64, awsReservationId string) error {
 	query := `UPDATE aws_reservation_details SET aws_reservation_id = $2 WHERE reservation_id = $1`
 

--- a/internal/dao/stubs/context_getters.go
+++ b/internal/dao/stubs/context_getters.go
@@ -43,7 +43,7 @@ func WithReservationDao(parent context.Context) context.Context {
 		panic(dao.ErrStubContextAlreadySet)
 	}
 
-	ctx := context.WithValue(parent, reservationCtxKey, &reservationDaoStub{lastId: 0, store: []*models.AWSReservation{}})
+	ctx := context.WithValue(parent, reservationCtxKey, &reservationDaoStub{lastId: 0, storeAWS: []*models.AWSReservation{}})
 	return ctx
 }
 

--- a/internal/dao/stubs/pubkey_dao.go
+++ b/internal/dao/stubs/pubkey_dao.go
@@ -8,8 +8,9 @@ import (
 )
 
 type pubkeyDaoStub struct {
-	lastId int64
-	store  []*models.Pubkey
+	lastId        int64
+	store         []*models.Pubkey
+	resourceStore []*models.PubkeyResource
 }
 
 func init() {
@@ -92,10 +93,17 @@ func (stub *pubkeyDaoStub) Delete(ctx context.Context, id int64) error {
 }
 
 func (stub *pubkeyDaoStub) UnscopedGetResourceBySourceAndRegion(ctx context.Context, pubkeyId int64, sourceId string, region string) (*models.PubkeyResource, error) {
-	return nil, nil
+	for _, pkr := range stub.resourceStore {
+		if pkr.PubkeyID == pubkeyId && pkr.SourceID == sourceId && pkr.Region == region {
+			return pkr, nil
+		}
+	}
+	return nil, dao.ErrNoRows
 }
 
 func (stub *pubkeyDaoStub) UnscopedCreateResource(ctx context.Context, pkr *models.PubkeyResource) error {
+	pkr.ID = int64(len(stub.resourceStore)) + 1
+	stub.resourceStore = append(stub.resourceStore, pkr)
 	return nil
 }
 
@@ -104,5 +112,11 @@ func (stub *pubkeyDaoStub) UnscopedDeleteResource(ctx context.Context, id int64)
 }
 
 func (stub *pubkeyDaoStub) UnscopedListResourcesByPubkeyId(ctx context.Context, pkId int64) ([]*models.PubkeyResource, error) {
-	return nil, nil
+	var result []*models.PubkeyResource
+	for _, pkr := range stub.resourceStore {
+		if pkr.PubkeyID == pkId {
+			result = append(result, pkr)
+		}
+	}
+	return result, nil
 }

--- a/internal/dao/stubs/reservation_dao.go
+++ b/internal/dao/stubs/reservation_dao.go
@@ -2,14 +2,15 @@ package stubs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 )
 
 type reservationDaoStub struct {
-	lastId int64
-	store  []*models.AWSReservation
+	lastId   int64
+	storeAWS []*models.AWSReservation
 }
 
 func init() {
@@ -18,7 +19,7 @@ func init() {
 
 func ReservationStubCount(ctx context.Context) int {
 	pkdao := getReservationDaoStub(ctx)
-	return len(pkdao.store)
+	return len(pkdao.storeAWS)
 }
 
 func getReservationDao(ctx context.Context) dao.ReservationDao {
@@ -27,7 +28,7 @@ func getReservationDao(ctx context.Context) dao.ReservationDao {
 
 func (stub *reservationDaoStub) CreateAWS(ctx context.Context, reservation *models.AWSReservation) error {
 	reservation.ID = stub.lastId + 1
-	stub.store = append(stub.store, reservation)
+	stub.storeAWS = append(stub.storeAWS, reservation)
 	stub.lastId++
 	return nil
 }
@@ -45,7 +46,7 @@ func (stub *reservationDaoStub) CreateInstance(ctx context.Context, reservation 
 }
 
 func (stub *reservationDaoStub) GetById(ctx context.Context, id int64) (*models.Reservation, error) {
-	for _, awsReservation := range stub.store {
+	for _, awsReservation := range stub.storeAWS {
 		if awsReservation.AccountID == ctxAccountId(ctx) && awsReservation.ID == id {
 			return &awsReservation.Reservation, nil
 		}
@@ -54,7 +55,7 @@ func (stub *reservationDaoStub) GetById(ctx context.Context, id int64) (*models.
 }
 
 func (stub *reservationDaoStub) GetAWSById(ctx context.Context, id int64) (*models.AWSReservation, error) {
-	for _, awsReservation := range stub.store {
+	for _, awsReservation := range stub.storeAWS {
 		if awsReservation.AccountID == ctxAccountId(ctx) && awsReservation.ID == id {
 			return awsReservation, nil
 		}
@@ -71,6 +72,15 @@ func (stub *reservationDaoStub) ListInstances(ctx context.Context, reservationId
 }
 
 func (stub *reservationDaoStub) UpdateStatus(ctx context.Context, id int64, status string, addSteps int32) error {
+	return nil
+}
+
+func (stub *reservationDaoStub) UnscopedUpdateAWSDetail(ctx context.Context, id int64, awsDetail *models.AWSDetail) error {
+	res, err := stub.GetAWSById(ctx, id)
+	if err != nil {
+		return fmt.Errorf("stubbed lookup of AWS reservation failed: %w", err)
+	}
+	res.Detail = awsDetail
 	return nil
 }
 

--- a/internal/dao/tests/reservation_test.go
+++ b/internal/dao/tests/reservation_test.go
@@ -175,6 +175,32 @@ func TestReservationList(t *testing.T) {
 	})
 }
 
+func TestUnscopedUpdateAWSDetail(t *testing.T) {
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
+
+	t.Run("updates detail field", func(t *testing.T) {
+		reservation := newAWSReservation()
+		reservation.Detail = &models.AWSDetail{
+			Region: "us-east-1",
+			Amount: 1,
+		}
+		err := reservationDao.CreateAWS(ctx, reservation)
+		require.NoError(t, err)
+		newDetail := &models.AWSDetail{
+			Region:     "us-east-1",
+			Amount:     1,
+			PubkeyName: "AWS name",
+		}
+		err = reservationDao.UnscopedUpdateAWSDetail(ctx, reservation.ID, newDetail)
+		require.NoError(t, err, "failed to update reservation")
+
+		reservationAfter, err := reservationDao.GetAWSById(ctx, reservation.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "AWS name", reservationAfter.Detail.PubkeyName)
+	})
+}
+
 func TestReservationUpdateIDForAWS(t *testing.T) {
 	reservationDao, ctx := setupReservation(t)
 	defer teardownReservation(t)

--- a/internal/jobs/common.go
+++ b/internal/jobs/common.go
@@ -10,7 +10,7 @@ import (
 )
 
 func decodeJob(ctx context.Context, job dejq.Job, argInterface interface{}) error {
-	err := job.Decode(&argInterface)
+	err := job.Decode(argInterface)
 	if err != nil {
 		ctxval.Logger(ctx).Error().Err(err).Msgf("Unable to decode arguments for job '%s'", job.Type())
 		return fmt.Errorf("decode error: %w", err)

--- a/internal/jobs/ensure_pubkey_on_aws_job_test.go
+++ b/internal/jobs/ensure_pubkey_on_aws_job_test.go
@@ -1,0 +1,147 @@
+package jobs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	clientStubs "github.com/RHEnVision/provisioning-backend/internal/clients/stubs"
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	daoStubs "github.com/RHEnVision/provisioning-backend/internal/dao/stubs"
+	"github.com/RHEnVision/provisioning-backend/internal/jobs"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/testing/factories"
+	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubAWSJob struct {
+	body *jobs.EnsurePubkeyOnAWSTaskArgs
+}
+
+func (s stubAWSJob) Type() string { return "stub AWS pubkey job" }
+func (s stubAWSJob) Decode(out interface{}) error {
+	typed := out.(*jobs.EnsurePubkeyOnAWSTaskArgs)
+	typed.ARN = s.body.ARN
+	typed.AccountID = s.body.AccountID
+	typed.ReservationID = s.body.ReservationID
+	typed.SourceID = s.body.SourceID
+	typed.PubkeyID = s.body.PubkeyID
+	typed.Region = s.body.Region
+	return nil
+}
+
+func prepareContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx := daoStubs.WithAccountDaoOne(context.Background())
+	ctx = identity.WithTenant(t, ctx)
+	ctx = clientStubs.WithEC2Client(ctx)
+	ctx = daoStubs.WithReservationDao(ctx)
+	ctx = daoStubs.WithPubkeyDao(ctx)
+
+	return ctx
+}
+
+func prepareReservation(t *testing.T, ctx context.Context, pk *models.Pubkey) *models.AWSReservation {
+	t.Helper()
+	detail := &models.AWSDetail{
+		Region:       "us-east-1",
+		InstanceType: "t1.micro",
+		Amount:       1,
+		PowerOff:     false,
+	}
+	reservation := &models.AWSReservation{
+		PubkeyID: pk.ID,
+		SourceID: "irrelevant",
+		ImageID:  "irrelevant",
+		Detail:   detail,
+	}
+	reservation.AccountID = 1
+	reservation.Status = "Created"
+	reservation.Provider = models.ProviderTypeAWS
+	reservation.Steps = 2
+	return reservation
+}
+
+func TestHandleEnsurePubkeyOnAWS(t *testing.T) {
+	t.Run("KeyPair exists on AWS", func(t *testing.T) {
+		ctx := prepareContext(t)
+
+		pk := &models.Pubkey{
+			Name: factories.GetSequenceName("pubkey"),
+			Body: factories.GenerateRSAPubKey(t),
+		}
+		err := daoStubs.AddPubkey(ctx, pk)
+		pk.Fingerprint = "existing"
+		require.NoError(t, err, "failed to add stubbed key")
+
+		reservation := prepareReservation(t, ctx, pk)
+		rDao := dao.GetReservationDao(ctx)
+		err = rDao.CreateAWS(ctx, reservation)
+		require.NoError(t, err, "failed to add stubbed reservation")
+
+		stubbedEnsureJob := stubAWSJob{
+			body: &jobs.EnsurePubkeyOnAWSTaskArgs{
+				AccountID:     1,
+				ReservationID: reservation.ID,
+				Region:        reservation.Detail.Region,
+				PubkeyID:      pk.ID,
+				SourceID:      reservation.SourceID,
+				ARN:           &clients.Authentication{ProviderType: models.ProviderTypeAWS, Payload: "arn:aws:123123123123"},
+			},
+		}
+
+		err = jobs.HandleEnsurePubkeyOnAWS(ctx, stubbedEnsureJob)
+		require.NoError(t, err, "the ensure pubkey job failed to run")
+
+		resAfter, err := rDao.GetAWSById(ctx, reservation.ID)
+		require.NoError(t, err, "failed to add stubbed reservation")
+		assert.Equal(t, "awsKeyPairName", resAfter.Detail.PubkeyName)
+
+		pkDao := dao.GetPubkeyDao(ctx)
+		pkrList, err := pkDao.UnscopedListResourcesByPubkeyId(ctx, pk.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(pkrList))
+	})
+
+	t.Run("pubkey not on AWS", func(t *testing.T) {
+		ctx := prepareContext(t)
+
+		pk := &models.Pubkey{
+			Name: factories.GetSequenceName("pubkey"),
+			Body: factories.GenerateRSAPubKey(t),
+		}
+		err := daoStubs.AddPubkey(ctx, pk)
+		require.NoError(t, err, "failed to add stubbed key")
+
+		reservation := prepareReservation(t, ctx, pk)
+		rDao := dao.GetReservationDao(ctx)
+		err = rDao.CreateAWS(ctx, reservation)
+		require.NoError(t, err, "failed to add stubbed reservation")
+
+		stubbedEnsureJob := stubAWSJob{
+			body: &jobs.EnsurePubkeyOnAWSTaskArgs{
+				AccountID:     1,
+				ReservationID: reservation.ID,
+				Region:        reservation.Detail.Region,
+				PubkeyID:      pk.ID,
+				SourceID:      reservation.SourceID,
+				ARN:           &clients.Authentication{ProviderType: models.ProviderTypeAWS, Payload: "arn:aws:123123123123"},
+			},
+		}
+
+		err = jobs.HandleEnsurePubkeyOnAWS(ctx, stubbedEnsureJob)
+		require.NoError(t, err, "the ensure pubkey job failed to run")
+
+		resAfter, err := rDao.GetAWSById(ctx, reservation.ID)
+		require.NoError(t, err)
+		assert.Equal(t, pk.Name, resAfter.Detail.PubkeyName)
+
+		pkDao := dao.GetPubkeyDao(ctx)
+		pkrList, err := pkDao.UnscopedListResourcesByPubkeyId(ctx, pk.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(pkrList))
+	})
+}

--- a/internal/jobs/queue/dejq/dejq_queue.go
+++ b/internal/jobs/queue/dejq/dejq_queue.go
@@ -30,7 +30,7 @@ func init() {
 func RegisterJobs(logger *zerolog.Logger) {
 	logger.Debug().Msg("Registering job queue handlers")
 	dejqQueue.RegisterHandler(queue.TypeNoop, jobs.HandleNoop)
-	dejqQueue.RegisterHandler(queue.TypePubkeyUploadAws, jobs.HandlePubkeyUploadAWS)
+	dejqQueue.RegisterHandler(queue.TypeEnsurePubkeyOnAws, jobs.HandleEnsurePubkeyOnAWS)
 	dejqQueue.RegisterHandler(queue.TypeLaunchInstanceAws, jobs.HandleLaunchInstanceAWS)
 	dejqQueue.RegisterHandler(queue.TypeLaunchInstanceGcp, jobs.HandleLaunchInstanceGCP)
 }

--- a/internal/jobs/queue/queue_types.go
+++ b/internal/jobs/queue/queue_types.go
@@ -2,7 +2,7 @@ package queue
 
 const (
 	TypeNoop              = "no_operation"
-	TypePubkeyUploadAws   = "pubkey_upload_aws"
+	TypeEnsurePubkeyOnAws = "ensure_pubkey_on_aws"
 	TypeLaunchInstanceAws = "launch_instances_aws"
 	TypeLaunchInstanceGcp = "launch_instances_gcp"
 )

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -59,6 +59,9 @@ type AWSDetail struct {
 
 	// Immediately power off the system after initialization
 	PowerOff bool `json:"poweroff"`
+
+	// PubkeyName on AWS in given region. Found by the EnsurePubkey job.
+	PubkeyName string `json:"pubkey_name"`
 }
 
 type AWSReservation struct {

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -91,8 +91,8 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	// Prepare jobs
 	logger.Debug().Msgf("Enqueuing upload key job for pubkey %d", pk.ID)
 	uploadPubkeyJob := dejq.PendingJob{
-		Type: queue.TypePubkeyUploadAws,
-		Body: &jobs.PubkeyUploadAWSTaskArgs{
+		Type: queue.TypeEnsurePubkeyOnAws,
+		Body: &jobs.EnsurePubkeyOnAWSTaskArgs{
 			AccountID:     accountId,
 			ReservationID: reservation.ID,
 			Region:        reservation.Detail.Region,
@@ -131,6 +131,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 			ReservationID: reservation.ID,
 			Region:        reservation.Detail.Region,
 			PubkeyID:      pk.ID,
+			SourceID:      reservation.SourceID,
 			Detail:        reservation.Detail,
 			AMI:           ami,
 			ARN:           authentication,


### PR DESCRIPTION
Ensure pubkey is on AWS and save its name to ASWDetails.

Fixes: HMSPROV-339 HMSPROV-332

Refactors the pubkey job to Ensure the pubkey exists on AWS.
First it tries to look for the key on AWS, if it exits, it gets its name.
If it doesn't exist, it imports the key with the name we have in our DB.

This name gets saved to AWS details so next job can fetch it and pass the correct name to AWS `RunInstances`.
Adds tests for the refactored job.