### PR TITLE
fix: kafka port is a pointer

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,7 +224,7 @@ func Initialize(configFiles ...string) {
 		if cfg.Kafka != nil {
 			config.Kafka.Brokers = make([]string, len(cfg.Kafka.Brokers))
 			for i, b := range cfg.Kafka.Brokers {
-				config.Kafka.Brokers[i] = fmt.Sprintf("%s:%d", b.Hostname, b.Port)
+				config.Kafka.Brokers[i] = fmt.Sprintf("%s:%d", b.Hostname, *b.Port)
 
 				// assumption: TLS/SASL credentials are always the same for all nodes in a cluster
 				if b.Authtype != nil && *b.Authtype != "" {


### PR DESCRIPTION
Clowder types are a mess, some values are pointers (port) others are not (hostname).

People sometimes use pointers to be able to use `nil` and it's bad practice, zero values are also valid options, specifically for port it is definitely a not valid port number.