### PR TITLE
feat: better Kafka logging

### DIFF
--- a/cmd/pbapi/main.go
+++ b/cmd/pbapi/main.go
@@ -87,7 +87,7 @@ func main() {
 
 	// initialize platform kafka
 	if config.Kafka.Enabled {
-		err = kafka.InitializeKafkaBroker()
+		err = kafka.InitializeKafkaBroker(ctx)
 		if err != nil {
 			logger.Fatal().Err(err).Msg("Unable to initialize the platform kafka")
 		}

--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -75,7 +75,7 @@ func main() {
 
 	// initialize platform kafka
 	logger.Info().Msg("Initializing platform kafka")
-	err = kafka.InitializeKafkaBroker()
+	err = kafka.InitializeKafkaBroker(ctx)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Unable to initialize the platform kafka")
 	}

--- a/internal/background/availability_queue.go
+++ b/internal/background/availability_queue.go
@@ -39,7 +39,7 @@ func sendAvailabilityRequestMessages(ctx context.Context, batchSize int, tickDur
 			length := len(messageBuffer)
 
 			if length >= batchSize {
-				logger.Trace().Int("messages", length).Msgf("Sent %d availability request messages (full buffer)", length)
+				logger.Trace().Int("messages", length).Msgf("Sending %d availability request messages (full buffer)", length)
 				send(ctx, messageBuffer...)
 				messageBuffer = messageBuffer[:0]
 			}
@@ -47,7 +47,7 @@ func sendAvailabilityRequestMessages(ctx context.Context, batchSize int, tickDur
 			length := len(messageBuffer)
 
 			if length > 0 {
-				logger.Trace().Int("messages", length).Msgf("Sent %d availability request messages (tick)", length)
+				logger.Trace().Int("messages", length).Msgf("Sending %d availability request messages (tick)", length)
 				send(ctx, messageBuffer...)
 				messageBuffer = messageBuffer[:0]
 			}
@@ -56,7 +56,7 @@ func sendAvailabilityRequestMessages(ctx context.Context, batchSize int, tickDur
 			length := len(messageBuffer)
 
 			if length > 0 {
-				logger.Trace().Int("messages", length).Msgf("Sent %d availability request messages (cancel)", length)
+				logger.Trace().Int("messages", length).Msgf("Sending %d availability request messages (cancel)", length)
 				send(ctx, messageBuffer...)
 			}
 

--- a/internal/kafka/noop.go
+++ b/internal/kafka/noop.go
@@ -2,6 +2,8 @@ package kafka
 
 import (
 	"context"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 )
 
 // Broker that does nothing
@@ -10,8 +12,13 @@ type noopBroker struct{}
 var _ Broker = &noopBroker{}
 
 func (s *noopBroker) Consume(ctx context.Context, topic string, handler func(ctx context.Context, message *GenericMessage)) {
+	logger := ctxval.Logger(ctx)
+	logger.Warn().Msg("Consume loop not started (Kafka not configured)")
 }
 
-func (s *noopBroker) Send(_ context.Context, messages ...*GenericMessage) error {
+func (s *noopBroker) Send(ctx context.Context, messages ...*GenericMessage) error {
+	logger := ctxval.Logger(ctx)
+	logger.Warn().Msgf("Throwing away %d messages (Kafka not configured)", len(messages))
+
 	return nil
 }


### PR DESCRIPTION
Just to see little bit more from Kafka:

* list of hosts
* when a message is really sent
* increases to trace for ephemeral

The trace is a bit dirty but I am not sure how can I set options for clowder. It has some CLI arguments but it's cryptic without examples. If I knew how to use its `-p component/parameter=value` then we could ask QE folks to increase verbosity for PR checks.