### PR TITLE
fix: utilize clowder topic mapping

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,6 +223,7 @@ func Initialize(configFiles ...string) {
 		// kafka
 		if cfg.Kafka != nil {
 			config.Kafka.Enabled = true
+
 			config.Kafka.Brokers = make([]string, len(cfg.Kafka.Brokers))
 			for i, b := range cfg.Kafka.Brokers {
 				config.Kafka.Brokers[i] = fmt.Sprintf("%s:%d", b.Hostname, *b.Port)

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -34,6 +34,15 @@ func InProdClowder() bool {
 	return clowder.IsClowderEnabled() && strings.HasPrefix(*clowder.LoadedConfig.Metadata.EnvName, "env-stage")
 }
 
+// TopicName returns mapped topic from Clowder. When not running in Clowder mode, it returns the input topic name.
+func TopicName(topic string) string {
+	if t, ok := clowder.KafkaTopics[topic]; ok {
+		return t.Name
+	}
+
+	return topic
+}
+
 func StringToURL(urlStr string) *url.URL {
 	if urlStr == "" {
 		return nil

--- a/internal/kafka/source_result.go
+++ b/internal/kafka/source_result.go
@@ -27,5 +27,5 @@ type SourceResult struct {
 }
 
 func (sr SourceResult) GenericMessage(ctx context.Context) (GenericMessage, error) {
-	return genericMessage(ctx, sr, sr.SourceID, SendEventsToSources)
+	return genericMessage(ctx, sr, sr.SourceID, SourcesEventStreamTopic)
 }

--- a/internal/kafka/topics.go
+++ b/internal/kafka/topics.go
@@ -1,6 +1,21 @@
 package kafka
 
+import "github.com/RHEnVision/provisioning-backend/internal/config"
+
+// topic requests
 var (
-	AvailabilityStatusRequestTopic = "platform.provisioning.internal.availability-check"
-	SendEventsToSources            = "platform.sources.event-stream"
+	availabilityStatusRequestTopicReq = "platform.provisioning.internal.availability-check"
+	sendEventsToSourcesTopicReq       = "platform.sources.event-stream"
 )
+
+// topics after clowder mapping
+var (
+	AvailabilityStatusRequestTopic string
+	SourcesEventStreamTopic        string
+)
+
+// InitializeTopicRequests performs clowder mapping of topics.
+func InitializeTopicRequests() {
+	AvailabilityStatusRequestTopic = config.TopicName(availabilityStatusRequestTopicReq)
+	SourcesEventStreamTopic = config.TopicName(sendEventsToSourcesTopicReq)
+}

--- a/scripts/kafka.start.sh
+++ b/scripts/kafka.start.sh
@@ -6,9 +6,10 @@ source $BASEDIR/kafka.conf
 echo "Formatting journal..."
 $BASEDIR/kafka/bin/kafka-storage.sh format -t $UUID -c $BASEDIR/kafka/config/kraft/server.properties
 
+echo "Creating topics..."
+# Start as background shell jobs, they attempt to reconnect until it succeeds
+$BASEDIR/kafka/bin/kafka-topics.sh --create --topic platform.provisioning.internal.availability-check --bootstrap-server $KAFKA_HOST &
+$BASEDIR/kafka/bin/kafka-topics.sh --create --topic platform.sources.event-stream --bootstrap-server $KAFKA_HOST &
+
 echo "Starting Kafka..."
 $BASEDIR/kafka/bin/kafka-server-start.sh $BASEDIR/kafka/config/kraft/server.properties
-
-echo "Creating topics..."
-$BASEDIR/kafka/bin/kafka-topics.sh --create --topic platform.provisioning.internal.availability-check --bootstrap-server $KAFKA_HOST
-$BASEDIR/kafka/bin/kafka-topics.sh --create --topic platform.sources.event-stream --bootstrap-server $KAFKA_HOST


### PR DESCRIPTION
https://issues.redhat.com/browse/HMSPROV-343

We cannot use topics directly, there is some sort of "prefix" on the platform that is provided by the clowder. This should fix the stage, I am unable to test this until we deploy it on stage.

Also adds some debugging statements when adding the CA cert. It is a public key cert so it is safe to log into debug.