### PR TITLE
feat: introduce availability status endpoint

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -108,6 +108,14 @@
         },
         "type": "object"
       },
+      "v1.AvailabilityStatusRequest": {
+        "properties": {
+          "source_id": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "v1.InstanceTypeResponse": {
         "properties": {
           "architecture": {
@@ -278,6 +286,31 @@
   },
   "openapi": "3.0.0",
   "paths": {
+    "/availability_status/sources": {
+      "post": {
+        "description": "Schedules a background operation of Sources availability check. These checks are are performed in separate process at it's own pace. Results are sent via Kafka to Sources. There is no output from this REST operation available, no tracking of jobs is possible.\n",
+        "operationId": "availabilityStatus",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AvailabilityStatusRequest"
+              }
+            }
+          },
+          "description": "availability status request with source id",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Returned on success, empty response."
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/instance_types/{PROVIDER}": {
       "get": {
         "description": "Return a list of instance types for particular provider. A region must be provided. A zone must be provided for Azure.\n",

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -289,6 +289,26 @@ paths:
                 $ref: '#/components/schemas/v1.NoopReservationResponse'
         "500":
           $ref: '#/components/responses/InternalError'
+  /availability_status/sources:
+    post:
+      operationId: availabilityStatus
+      description: >
+        Schedules a background operation of Sources availability check. These checks are
+        are performed in separate process at it's own pace. Results are sent via Kafka
+        to Sources. There is no output from this REST operation available, no tracking
+        of jobs is possible.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/v1.AvailabilityStatusRequest'
+        description: availability status request with source id
+        required: true
+      responses:
+        '200':
+          description: 'Returned on success, empty response.'
+        "500":
+          $ref: '#/components/responses/InternalError'
 components:
   responses:
     BadRequest:
@@ -358,6 +378,11 @@ components:
         reservation_id:
           format: int64
           type: integer
+        source_id:
+          type: string
+      type: object
+    v1.AvailabilityStatusRequest:
+      properties:
         source_id:
           type: string
       type: object

--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -57,6 +57,7 @@ func main() {
 	gen.addSchema("v1.NoopReservationResponse", &payloads.NoopReservationResponsePayload{})
 	gen.addSchema("v1.AWSReservationRequest", &payloads.AWSReservationRequestPayload{})
 	gen.addSchema("v1.AWSReservationResponse", &payloads.AWSReservationResponsePayload{})
+	gen.addSchema("v1.AvailabilityStatusRequest", &payloads.AvailabilityStatusRequest{})
 
 	// error payloads
 	gen.addSchema("v1.ResponseError", &payloads.ResponseError{})

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -289,3 +289,23 @@ paths:
                 $ref: '#/components/schemas/v1.NoopReservationResponse'
         "500":
           $ref: '#/components/responses/InternalError'
+  /availability_status/sources:
+    post:
+      operationId: availabilityStatus
+      description: >
+        Schedules a background operation of Sources availability check. These checks are
+        are performed in separate process at it's own pace. Results are sent via Kafka
+        to Sources. There is no output from this REST operation available, no tracking
+        of jobs is possible.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/v1.AvailabilityStatusRequest'
+        description: availability status request with source id
+        required: true
+      responses:
+        '200':
+          description: 'Returned on success, empty response.'
+        "500":
+          $ref: '#/components/responses/InternalError'

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -86,7 +86,9 @@ func MountAPI(r *chi.Mux) {
 		})
 
 		r.Route("/availability_status", func(r chi.Router) {
-			r.Post("/", s.AvailabilityStatus)
+			r.Route("/sources", func(r chi.Router) {
+				r.Post("/", s.AvailabilityStatus)
+			})
 		})
 
 		// Unsupported routes are not published through OpenAPI, they are documented

--- a/scripts/rest_examples/availability-status.http
+++ b/scripts/rest_examples/availability-status.http
@@ -1,5 +1,5 @@
 // @no-log
-POST http://{{hostname}}:{{port}}/{{prefix}}/availability_status HTTP/1.1
+POST http://{{hostname}}:{{port}}/{{prefix}}/availability_status/sources HTTP/1.1
 Content-Type: application/json
 X-Rh-Identity: {{identity}}
 


### PR DESCRIPTION
We can start testing in ephemeral where Kafka does work already. For stage, we are still working on a clowder mapping of topics, there is an open PR for that. This one will be a challenge to test:

* Hit the endpoint with an existing source ID that has a AWS account associated.
* Listen for the `platform.sources.event-stream` Kafka event that contains the source ID and result.
* Results can be cached in stage/prod, however, in ephemeral we should not be doing any caching so the event should be sent always (with a small delay of approx. 10 seconds).

Let's try if our checker likes URLs too:

https://issues.redhat.com/browse/HMSPROV-337

