### PR TITLE
test: use path to the main config dir

### DIFF
--- a/internal/dao/tests/main_test.go
+++ b/internal/dao/tests/main_test.go
@@ -27,7 +27,7 @@ func teardown() {
 }
 
 func initEnvironment() {
-	config.Initialize("config/test.env")
+	config.Initialize("../../../config/test.env")
 
 	err := db.Initialize(context.Background(), "integration")
 	if err != nil {


### PR DESCRIPTION
This was the only way for me to run `make integration-tests` with the config in the main `config/` folder.
Happy to discuss better options, but if I run the make from root folder, it needs to respect configs from the main config folder, otherwise it is very weird for devs.

Taken out from other PR after a bit of discussion: https://github.com/RHEnVision/provisioning-backend/pull/315/files#r1038972780