### PR TITLE
fix: Kafka headers are slice now

### DIFF
--- a/internal/kafka/avail_status_msg.go
+++ b/internal/kafka/avail_status_msg.go
@@ -40,12 +40,12 @@ func genericMessage(ctx context.Context, m any, key string, topic string) (Gener
 		Key:   []byte(key),
 		Value: payload,
 		// Keep headers written in lowercase to match sources comparison.
-		Headers: map[string]string{
-			"content-type":                "application/json",
-			"x-rh-identity":               identity.GetIdentityHeader(ctx),
-			"x-rh-sources-org-id":         id.Identity.OrgID,
-			"x-rh-sources-account-number": id.Identity.AccountNumber,
-			"event_type":                  "availability_status",
-		},
+		Headers: GenericHeaders(
+			"content-type", "application/json",
+			"x-rh-identity", identity.GetIdentityHeader(ctx),
+			"x-rh-sources-org-id", id.Identity.OrgID,
+			"x-rh-sources-account-number", id.Identity.AccountNumber,
+			"event_type", "availability_status",
+		),
 	}, nil
 }

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -177,7 +177,7 @@ func (b *kafkaBroker) Consume(ctx context.Context, topic string, handler func(ct
 			logger.Warn().Err(err).Msgf("Error when reading message: %s", err.Error())
 		} else {
 			logger.Trace().Bytes("payload", msg.Value).Msgf("Received message with key: %s", msg.Key)
-			ctx, err = ctxval.WithIdentityFrom64(ctx, LookupKafkaHeader(ctx, msg.Headers))
+			ctx, err = ctxval.WithIdentityFrom64(ctx, header("x-rh-identity", msg.Headers))
 			if err != nil {
 				logger.Trace().Msgf("Could not extract identity from context to Kafka message: %s", err)
 			}
@@ -186,9 +186,9 @@ func (b *kafkaBroker) Consume(ctx context.Context, topic string, handler func(ct
 	}
 }
 
-func LookupKafkaHeader(ctx context.Context, headers []protocol.Header) string {
+func header(name string, headers []protocol.Header) string {
 	for _, h := range headers {
-		if strings.EqualFold(h.Key, "X-RH-Identity") {
+		if strings.EqualFold(h.Key, name) {
 			return string(h.Value)
 		}
 	}

--- a/internal/kafka/message_test.go
+++ b/internal/kafka/message_test.go
@@ -1,0 +1,41 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateHeadersEmpty(t *testing.T) {
+	h := GenericHeaders()
+	require.Empty(t, h)
+}
+
+func TestGenerateHeadersOne(t *testing.T) {
+	h := GenericHeaders("a", "b")
+	require.Len(t, h, 1)
+	require.Equal(t, GenericHeader{
+		Key:   "a",
+		Value: "b",
+	}, h[0])
+}
+
+func TestGenerateHeadersTwo(t *testing.T) {
+	h := GenericHeaders("a", "b", "c", "d")
+	require.Len(t, h, 2)
+	require.Equal(t, GenericHeader{
+		Key:   "a",
+		Value: "b",
+	}, h[0])
+	require.Equal(t, GenericHeader{
+		Key:   "c",
+		Value: "d",
+	}, h[1])
+}
+
+// nolint:staticcheck
+func TestGenerateHeadersOdd(t *testing.T) {
+	require.Panicsf(t, func() {
+		_ = GenericHeaders("")
+	}, "generic headers: odd amount of arguments")
+}

--- a/mk/code.mk
+++ b/mk/code.mk
@@ -28,5 +28,8 @@ check-commits: ## Check commit format
 	python -m rhenvision_changelog commit-check
 
 .PHONY: fmt ## Alias to perform all code formatting and linting
-fmt: check-commits check-migrations format imports lint
+fmt: format imports lint
+
+.PHONY: check ## Alias to perform all checking (commits, migrations)
+check: check-commits check-migrations
 


### PR DESCRIPTION
Kafka headers are slices instead of map, this is how Kafka does it, we should follow what the library does.

https://issues.redhat.com/browse/HMSPROV-337
