### PR TITLE
fix: Fetch tag from AWS 

### DIFF
--- a/internal/clients/ec2_types.go
+++ b/internal/clients/ec2_types.go
@@ -1,0 +1,13 @@
+package clients
+
+type EC2Tag struct {
+	Key   *string
+	Value *string
+}
+
+type EC2KeyPairInfo struct {
+	KeyPairId      *string
+	KeyName        *string
+	KeyFingerprint *string
+	Tags           []EC2Tag
+}

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -67,8 +67,8 @@ type EC2 interface {
 	// ImportPubkey imports new ssh key-pair with given tag returning its AWS ID
 	ImportPubkey(ctx context.Context, key *models.Pubkey, tag string) (string, error)
 
-	// GetPubkeyName fetches the AWS key name using given pubkey fingerprint
-	GetPubkeyName(ctx context.Context, fingerprint string) (string, error)
+	// GetKeyPairByFingerprint fetches the AWS key pair using given pubkey fingerprint
+	GetKeyPairByFingerprint(ctx context.Context, fingerprint string) (*EC2KeyPairInfo, error)
 
 	// DeleteSSHKey deletes a given ssh key-pair found by AWS ID
 	DeleteSSHKey(ctx context.Context, handle string) error

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -42,6 +42,7 @@ type PubkeyDao interface {
 	UnscopedCreateResource(ctx context.Context, pkr *models.PubkeyResource) error
 	UnscopedGetResourceBySourceAndRegion(ctx context.Context, pubkeyId int64, sourceId string, region string) (*models.PubkeyResource, error)
 	UnscopedListResourcesByPubkeyId(ctx context.Context, pkId int64) ([]*models.PubkeyResource, error)
+	UnscopedUpdateHandle(ctx context.Context, id int64, handle string) error
 	UnscopedDeleteResource(ctx context.Context, id int64) error
 }
 

--- a/internal/dao/pgx/pubkey_pgx.go
+++ b/internal/dao/pgx/pubkey_pgx.go
@@ -154,6 +154,19 @@ func (x *pubkeyDao) UnscopedGetResourceBySourceAndRegion(ctx context.Context, pu
 	return result, nil
 }
 
+func (x *pubkeyDao) UnscopedUpdateHandle(ctx context.Context, id int64, handle string) error {
+	query := `UPDATE pubkey_resources SET handle = $2 WHERE id = $1`
+
+	tag, err := db.Pool.Exec(ctx, query, id, handle)
+	if err != nil {
+		return fmt.Errorf("pgx error: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+	}
+	return nil
+}
+
 func (x *pubkeyDao) UnscopedListResourcesByPubkeyId(ctx context.Context, id int64) ([]*models.PubkeyResource, error) {
 	query := `SELECT * FROM pubkey_resources WHERE pubkey_id = $1`
 	var result []*models.PubkeyResource


### PR DESCRIPTION
Refs: HMSPROV-339

To resolve
- [ ] updating Handle will result in the key from AWS when deleted on our side, do we want that?