### PR TITLE
fix(HMSPROV-390): calculate AWS fingerprint

### DIFF
--- a/internal/jobs/ensure_pubkey_on_aws_job_test.go
+++ b/internal/jobs/ensure_pubkey_on_aws_job_test.go
@@ -10,8 +10,10 @@ import (
 	daoStubs "github.com/RHEnVision/provisioning-backend/internal/dao/stubs"
 	"github.com/RHEnVision/provisioning-backend/internal/jobs"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/factories"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,53 +68,72 @@ func prepareReservation(t *testing.T, ctx context.Context, pk *models.Pubkey) *m
 }
 
 func TestHandleEnsurePubkeyOnAWS(t *testing.T) {
-	t.Run("KeyPair exists on AWS", func(t *testing.T) {
-		ctx := prepareContext(t)
+	keys := []struct {
+		KeyType        string
+		Body           string
+		AwsFingerprint string
+	}{
+		{
+			"rsa",
+			"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDABkLdmd4mnZTOKcZpi0cu+YWbnVbbJSjHW5FDc4p9AgeVZA2WKx2f2x4YPOdB9NtAuVuFUpDAvBiV96Coy0747I2RXrR5abzVWbW+bIJOJXqCCBLHlUEj13CduIs40pHwVXGRdlwLZk4rChWKzg+C6sNBq5lXxtBLfKmf5S2LbhWKTfZje7OI2We2pZXiRZg58IVIA2mpvNr3MxaoMlEK92VwiVzlwOaCKbG4Ere5M1ug/5RRSXXLQjPBc6ePqg1PiVHrx2DP2jDJsGETQGj13zzqI4nvXbcu7EM/TiCJpreHZIxDgn97AtYj2IJbscz+6/aWyBlZG0be8oaLLlYN",
+			"93:fb:9e:04:da:6e:5d:37:5d:2e:f4:0b:39:ef:6a:08",
+		},
+		{
+			"ed25519",
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEhnn80ZywmjeBFFOGm+cm+5HUwm62qTVnjKlOdYFLHN lzap",
+			"gL/y6MvNmJ8jDXtsL/oMmK8jUuIefN39BBuvYw/Rndk=",
+		},
+	}
 
-		pk := &models.Pubkey{
-			Name: "provisioningName",
-			Body: factories.GenerateRSAPubKey(t),
-		}
-		err := daoStubs.AddPubkey(ctx, pk)
-		require.NoError(t, err, "failed to add stubbed key")
+	for _, testKey := range keys {
+		t.Run("KeyPair exists on AWS", func(t *testing.T) {
+			ctx := prepareContext(t)
 
-		authentication := clients.Authentication{ProviderType: models.ProviderTypeAWS, Payload: "arn:aws:123123123123"}
+			// using a static key for which we know it's real AWS fingerprint
+			pk := &models.Pubkey{
+				Name: "provisioningName",
+				Body: testKey.Body,
+			}
+			err := daoStubs.AddPubkey(ctx, pk)
+			require.NoError(t, err, "failed to add stubbed key")
 
-		ec2Client, err := clients.GetEC2Client(ctx, &authentication, "us-east-1")
-		require.NoError(t, err, "failed to get stubbed EC2 client")
-		pk.Name = "awsName" // change the name to get imported in the stub under
-		_, err = ec2Client.ImportPubkey(ctx, pk, "some-tag")
-		require.NoError(t, err, "failed to ImportPubkey to the stub")
-		pk.Name = "provisioningName" // change the name back
+			err = clientStubs.AddStubbedEC2KeyPair(ctx, &types.KeyPairInfo{
+				KeyName:        ptr.To("awsName"),
+				KeyFingerprint: &testKey.AwsFingerprint,
+				KeyType:        types.KeyType(testKey.KeyType),
+				PublicKey:      &pk.Body,
+			})
+			require.NoError(t, err, "failed to add stubbed key to ec2 stub")
 
-		reservation := prepareReservation(t, ctx, pk)
-		rDao := dao.GetReservationDao(ctx)
-		err = rDao.CreateAWS(ctx, reservation)
-		require.NoError(t, err, "failed to add stubbed reservation")
+			reservation := prepareReservation(t, ctx, pk)
+			rDao := dao.GetReservationDao(ctx)
+			err = rDao.CreateAWS(ctx, reservation)
+			require.NoError(t, err, "failed to add stubbed reservation")
 
-		stubbedEnsureJob := stubAWSJob{
-			body: &jobs.EnsurePubkeyOnAWSTaskArgs{
-				AccountID:     1,
-				ReservationID: reservation.ID,
-				Region:        reservation.Detail.Region,
-				PubkeyID:      pk.ID,
-				SourceID:      reservation.SourceID,
-				ARN:           &authentication,
-			},
-		}
+			stubbedEnsureJob := stubAWSJob{
+				body: &jobs.EnsurePubkeyOnAWSTaskArgs{
+					AccountID:     1,
+					ReservationID: reservation.ID,
+					Region:        reservation.Detail.Region,
+					PubkeyID:      pk.ID,
+					SourceID:      reservation.SourceID,
+					ARN:           &clients.Authentication{ProviderType: models.ProviderTypeAWS, Payload: "arn:aws:123123123123"},
+				},
+			}
 
-		err = jobs.HandleEnsurePubkeyOnAWS(ctx, stubbedEnsureJob)
-		require.NoError(t, err, "the ensure pubkey job failed to run")
+			err = jobs.HandleEnsurePubkeyOnAWS(ctx, stubbedEnsureJob)
+			require.NoError(t, err, "the ensure pubkey job failed to run")
 
-		resAfter, err := rDao.GetAWSById(ctx, reservation.ID)
-		require.NoError(t, err, "failed to add stubbed reservation")
-		assert.Equal(t, "awsName", resAfter.Detail.PubkeyName)
+			resAfter, err := rDao.GetAWSById(ctx, reservation.ID)
+			require.NoError(t, err, "failed to add stubbed reservation")
+			assert.Equal(t, "awsName", resAfter.Detail.PubkeyName)
 
-		pkDao := dao.GetPubkeyDao(ctx)
-		pkrList, err := pkDao.UnscopedListResourcesByPubkeyId(ctx, pk.ID)
-		require.NoError(t, err)
-		assert.Equal(t, 1, len(pkrList))
-	})
+			pkDao := dao.GetPubkeyDao(ctx)
+			pkrList, err := pkDao.UnscopedListResourcesByPubkeyId(ctx, pk.ID)
+			require.NoError(t, err)
+			assert.Equal(t, 1, len(pkrList))
+		})
+	}
 
 	t.Run("pubkey not on AWS", func(t *testing.T) {
 		ctx := prepareContext(t)

--- a/internal/models/pubkey_model.go
+++ b/internal/models/pubkey_model.go
@@ -1,5 +1,16 @@
 package models
 
+import (
+	"crypto/md5" //#nosec
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
 // Pubkey represents SSH public key that can be deployed to clients.
 type Pubkey struct {
 	// Required auto-generated PK.
@@ -16,4 +27,40 @@ type Pubkey struct {
 
 	// Public key SHA256 fingerprint. Generated (read-only).
 	Fingerprint string `db:"fingerprint" json:"fingerprint"`
+}
+
+// FingerprintAWS calculates fingerprint used by AWS.
+// AWS calculates MD5 sums differently then all the other tools and use format DER as the base for the sub.
+// see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/verify-keys.html for more details.
+func (pk *Pubkey) FingerprintAWS() (string, error) {
+	pkey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(pk.Body))
+	if err != nil {
+		return "", fmt.Errorf("failed to calculate fingerprint for %s: %w", pk.Name, err)
+	}
+	// when rsa key
+	if pkey.Type() == "ssh-rsa" {
+		return fingerprintRsaAWS(pkey)
+	}
+	// when ed25519 key
+	// this is the same as what we store, but better be sure here
+	return strings.TrimLeft(ssh.FingerprintSHA256(pkey), "SHA256:") + "=", nil
+}
+
+// fingerprintRsaAWS calculates fingerprint for rsa keys
+func fingerprintRsaAWS(key ssh.PublicKey) (string, error) {
+	parsedCryptoKey := key.(ssh.CryptoPublicKey)
+
+	// Finally, we can convert back to an *rsa.PublicKey
+	pub := parsedCryptoKey.CryptoPublicKey().(*rsa.PublicKey)
+
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", fmt.Errorf("failed to calculate rsa key fingerprint: %w", err)
+	}
+	md5sum := md5.Sum(der) //#nosec
+	hexarray := make([]string, len(md5sum))
+	for i, c := range md5sum {
+		hexarray[i] = hex.EncodeToString([]byte{c})
+	}
+	return strings.Join(hexarray, ":"), nil
 }


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_KeyPairInfo.html talks about what to expect as fingerprint format, which is different then what we store in some cases.