### PR TITLE
fix(HMSPROV-352): error out jobs early

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -229,6 +229,12 @@
             "format": "int32",
             "type": "integer"
           },
+          "step_titles": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "steps": {
             "format": "int32",
             "type": "integer"
@@ -244,7 +250,9 @@
           "build_time": {
             "type": "string"
           },
-          "error": {},
+          "error": {
+            "type": "string"
+          },
           "msg": {
             "type": "string"
           },

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -464,6 +464,10 @@ components:
         step:
           format: int32
           type: integer
+        step_titles:
+          items:
+            type: string
+          type: array
         steps:
           format: int32
           type: integer
@@ -474,7 +478,8 @@ components:
       properties:
         build_time:
           type: string
-        error: {}
+        error:
+          type: string
         msg:
           type: string
         trace_id:

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/jackc/pgx/v5 v5.0.4
 	github.com/jackc/tern/v2 v2.0.0-beta.3
 	github.com/lzap/cloudwatchwriter2 v1.0.0
-	github.com/lzap/dejq v1.1.0
+	github.com/lzap/dejq v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.1
 	github.com/redhatinsights/app-common-go v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -478,6 +478,8 @@ github.com/lzap/cloudwatchwriter2 v1.0.0 h1:10galxReSfwfDyLZQzW6t5iX/YVehOJfYynY
 github.com/lzap/cloudwatchwriter2 v1.0.0/go.mod h1:5G2xdbsdTbMcC21C8KV6gvdGB8yAHiCS2+CxTMkQx1o=
 github.com/lzap/dejq v1.1.0 h1:fWVUONhESSjxA/NiY/biF8qUwlxMDXWmqIureIFpqYo=
 github.com/lzap/dejq v1.1.0/go.mod h1:CsPywwlI1sFzZq/1y9iF6qZ6qydjNtaiaX4po3/5f+8=
+github.com/lzap/dejq v1.2.0 h1:rrM75v5a128TDM+eZl4POsDFBCbOKM7DHFIycogyDcE=
+github.com/lzap/dejq v1.2.0/go.mod h1:CsPywwlI1sFzZq/1y9iF6qZ6qydjNtaiaX4po3/5f+8=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=

--- a/internal/config/override_integration.go
+++ b/internal/config/override_integration.go
@@ -12,4 +12,5 @@ func init() {
 	os.Setenv("APP_CACHE_ACCOUNT", "false")
 	os.Setenv("FEATURE_FLAGS_ENVIRONMENT", "test")
 	os.Setenv("TEST_ENVIRONMENT", "integration")
+	os.Setenv("WORKER_QUEUE", "memory")
 }

--- a/internal/dao/tests/noop_job_test.go
+++ b/internal/dao/tests/noop_job_test.go
@@ -1,0 +1,221 @@
+//go:build integration
+// +build integration
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/jobs"
+	"github.com/RHEnVision/provisioning-backend/internal/jobs/queue"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/lzap/dejq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReservationNoopOneSuccess(t *testing.T) {
+	reservationDao, ctx := setupReservation(t)
+	defer teardownReservation(t)
+
+	type test struct {
+		name   string
+		action func() *models.NoopReservation
+		checks func(*models.Reservation)
+	}
+
+	tests := []test{
+		{
+			name: "SingleStepNoError",
+			action: func() *models.NoopReservation {
+				// create new reservation
+				res := &models.NoopReservation{
+					Reservation: models.Reservation{
+						AccountID:  1,
+						Steps:      1,
+						StepTitles: []string{"Test step"},
+						Provider:   models.ProviderTypeNoop,
+						Status:     "Created",
+					},
+				}
+				err := reservationDao.CreateNoop(ctx, res)
+				require.NoError(t, err)
+				require.NotZero(t, res.ID)
+
+				// create new job
+				successJob := dejq.PendingJob{
+					Type: queue.TypeNoop,
+					Body: &jobs.NoopJobArgs{
+						AccountID:     1,
+						ReservationID: res.ID,
+						Fail:          false,
+					},
+				}
+
+				err = queue.GetEnqueuer().Enqueue(context.Background(), successJob)
+				require.NoError(t, err)
+
+				return res
+			},
+			checks: func(updatedRes *models.Reservation) {
+				require.True(t, updatedRes.Success.Bool)
+				require.Empty(t, updatedRes.Error)
+				require.Equal(t, int32(1), updatedRes.Step)
+				require.Equal(t, int32(1), updatedRes.Steps)
+				require.Equal(t, "No operation finished", updatedRes.Status)
+			},
+		},
+		{
+			name: "SingleStepError",
+			action: func() *models.NoopReservation {
+				// create new reservation
+				res := &models.NoopReservation{
+					Reservation: models.Reservation{
+						AccountID:  1,
+						Steps:      1,
+						StepTitles: []string{"Test step"},
+						Provider:   models.ProviderTypeNoop,
+						Status:     "Created",
+					},
+				}
+				err := reservationDao.CreateNoop(ctx, res)
+				require.NoError(t, err)
+				require.NotZero(t, res.ID)
+
+				// create new job
+				successJob := dejq.PendingJob{
+					Type: queue.TypeNoop,
+					Body: &jobs.NoopJobArgs{
+						AccountID:     1,
+						ReservationID: res.ID,
+						Fail:          true,
+					},
+				}
+
+				err = queue.GetEnqueuer().Enqueue(context.Background(), successJob)
+				require.NoError(t, err)
+
+				return res
+			},
+			checks: func(updatedRes *models.Reservation) {
+				require.False(t, updatedRes.Success.Bool)
+				require.Equal(t, "job failed on request", updatedRes.Error)
+				require.Equal(t, int32(1), updatedRes.Step)
+				require.Equal(t, int32(1), updatedRes.Steps)
+				require.Equal(t, "No operation finished", updatedRes.Status)
+			},
+		},
+		{
+			name: "ThreeStepsNoError",
+			action: func() *models.NoopReservation {
+				// create new reservation
+				res := &models.NoopReservation{
+					Reservation: models.Reservation{
+						AccountID:  1,
+						Steps:      3,
+						StepTitles: []string{"Step one", "Step two", "Step three"},
+						Provider:   models.ProviderTypeNoop,
+						Status:     "Created",
+					},
+				}
+				err := reservationDao.CreateNoop(ctx, res)
+				require.NoError(t, err)
+				require.NotZero(t, res.ID)
+
+				// create new job
+				successJob := dejq.PendingJob{
+					Type: queue.TypeNoop,
+					Body: &jobs.NoopJobArgs{
+						AccountID:     1,
+						ReservationID: res.ID,
+						Fail:          false,
+					},
+				}
+				err = queue.GetEnqueuer().Enqueue(context.Background(), successJob, successJob, successJob)
+				require.NoError(t, err)
+
+				return res
+			},
+			checks: func(updatedRes *models.Reservation) {
+				require.True(t, updatedRes.Success.Bool)
+				require.Empty(t, updatedRes.Error)
+				require.Equal(t, int32(3), updatedRes.Step)
+				require.Equal(t, int32(3), updatedRes.Steps)
+				require.Equal(t, "No operation finished", updatedRes.Status)
+			},
+		},
+		{
+			name: "ThreeStepsFirstFails",
+			action: func() *models.NoopReservation {
+				// create new reservation
+				res := &models.NoopReservation{
+					Reservation: models.Reservation{
+						AccountID:  1,
+						Steps:      3,
+						StepTitles: []string{"Step one", "Step two", "Step three"},
+						Provider:   models.ProviderTypeNoop,
+						Status:     "Created",
+					},
+				}
+				err := reservationDao.CreateNoop(ctx, res)
+				require.NoError(t, err)
+				require.NotZero(t, res.ID)
+
+				// create new job
+				successJob := dejq.PendingJob{
+					Type: queue.TypeNoop,
+					Body: &jobs.NoopJobArgs{
+						AccountID:     1,
+						ReservationID: res.ID,
+						Fail:          false,
+					},
+				}
+				failureJob := dejq.PendingJob{
+					Type: queue.TypeNoop,
+					Body: &jobs.NoopJobArgs{
+						AccountID:     1,
+						ReservationID: res.ID,
+						Fail:          true,
+					},
+				}
+				err = queue.GetEnqueuer().Enqueue(context.Background(), failureJob, successJob, successJob)
+				require.NoError(t, err)
+
+				return res
+			},
+			checks: func(updatedRes *models.Reservation) {
+				require.False(t, updatedRes.Success.Bool)
+				require.Equal(t, "step skipped: step skipped: job failed on request", updatedRes.Error)
+				require.Equal(t, int32(3), updatedRes.Step)
+				require.Equal(t, int32(3), updatedRes.Steps)
+				require.Equal(t, "No operation finished", updatedRes.Status)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// create reservation and enqueue job(s)
+			res := test.action()
+
+			// read reservation until it is finished (max. 2 seconds)
+			var updatedRes *models.Reservation
+			var err error
+			for i := 0; i < 20; i++ {
+				time.Sleep(100 * time.Millisecond)
+				updatedRes, err = reservationDao.GetById(ctx, res.ID)
+				require.NoError(t, err)
+				assert.Equal(t, res.ID, updatedRes.ID)
+
+				if updatedRes.Success.Valid {
+					break
+				}
+			}
+
+			// perform checks
+			test.checks(updatedRes)
+		})
+	}
+}

--- a/internal/dao/tests/reservation_test.go
+++ b/internal/dao/tests/reservation_test.go
@@ -19,10 +19,12 @@ import (
 func newNoopReservation() *models.NoopReservation {
 	return &models.NoopReservation{
 		Reservation: models.Reservation{
-			ID:        10,
-			Provider:  models.ProviderTypeNoop,
-			AccountID: 1,
-			Status:    "Created",
+			ID:         10,
+			Steps:      1,
+			StepTitles: []string{"Test step"},
+			Provider:   models.ProviderTypeNoop,
+			AccountID:  1,
+			Status:     "Created",
 		},
 	}
 }

--- a/internal/db/migrations/012_reservation_errors.sql
+++ b/internal/db/migrations/012_reservation_errors.sql
@@ -1,0 +1,1 @@
+ALTER TABLE reservations ADD COLUMN step_titles text[];

--- a/internal/jobs/ensure_pubkey_on_aws_job.go
+++ b/internal/jobs/ensure_pubkey_on_aws_job.go
@@ -44,6 +44,12 @@ func handleEnsurePubkeyOnAWS(ctx context.Context, args *EnsurePubkeyOnAWSTaskArg
 	ctxLogger := ctxval.Logger(ctx)
 	ctxLogger.Debug().Msg("Started pubkey upload AWS job")
 
+	// skip job if reservation already contains errors
+	err := checkExistingError(ctx, args.ReservationID)
+	if err != nil {
+		return fmt.Errorf("step skipped: %w", err)
+	}
+
 	ctx = ctxval.WithAccountId(ctx, args.AccountID)
 	logger := ctxLogger.With().Int64("reservation", args.ReservationID).Logger()
 	logger.Info().Interface("args", args).Msg("Processing pubkey upload AWS job")

--- a/internal/jobs/noop_job.go
+++ b/internal/jobs/noop_job.go
@@ -2,15 +2,23 @@ package jobs
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/lzap/dejq"
 )
 
 type NoopJobArgs struct {
 	AccountID     int64 `json:"account_id"`
 	ReservationID int64 `json:"reservation_id"`
+
+	// Indicates that the test should fail, used only in tests.
+	Fail bool `json:"fail"`
 }
+
+var NoOperationFailure = errors.New("job failed on request")
 
 // Unmarshall arguments and handle error
 func HandleNoop(ctx context.Context, job dejq.Job) error {
@@ -29,12 +37,25 @@ func HandleNoop(ctx context.Context, job dejq.Job) error {
 
 // Job logic, when error is returned the job status is updated accordingly
 func handleNoop(ctx context.Context, args *NoopJobArgs) error {
+	logger := ctxval.Logger(ctx)
+
 	// status updates before and after the code logic
 	updateStatusBefore(ctx, args.ReservationID, "No operation started")
 	defer updateStatusAfter(ctx, args.ReservationID, "No operation finished", 1)
 
-	// do nothing and return no error
-	time.Sleep(5 * time.Second)
+	// skip job if reservation already contains errors
+	err := checkExistingError(ctx, args.ReservationID)
+	if err != nil {
+		return fmt.Errorf("step skipped: %w", err)
+	}
+
+	// do nothing
+	time.Sleep(10 * time.Millisecond)
+	logger.Info().Msg("No operation finished")
+
+	if args.Fail {
+		return NoOperationFailure
+	}
 
 	return nil
 }

--- a/internal/jobs/queue/stub/memory_queue.go
+++ b/internal/jobs/queue/stub/memory_queue.go
@@ -1,15 +1,16 @@
 // Import this package in all Go tests which need to enqueue a job. The implementation
-// is to silently handle all incoming jobs without any effects.
+// is to silently enqueue all incoming jobs without any effects. No jobs will be actually
+// executed. Tests for job execution must use the dejq package (memory driver).
 package stub
 
 import (
 	"context"
 
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/jobs/queue"
 	"github.com/go-logr/zerologr"
 	"github.com/lzap/dejq"
 	"github.com/lzap/dejq/mem"
-	"github.com/rs/zerolog/log"
 )
 
 // memQueue is the main job stub memQueue
@@ -20,14 +21,15 @@ func getEnqueuer() queue.Enqueuer {
 }
 
 func init() {
-	InitializeStub()
+	InitializeStub(context.Background())
 	queue.GetEnqueuer = getEnqueuer
 }
 
-func InitializeStub() {
+func InitializeStub(ctx context.Context) {
 	var err error
-	ctx := context.Background()
-	memQueue, err = mem.NewClient(ctx, zerologr.New(&log.Logger))
+
+	logger := ctxval.Logger(ctx)
+	memQueue, err = mem.NewClient(ctx, zerologr.New(logger))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -24,6 +24,9 @@ type Reservation struct {
 	// Total number of job steps for this reservation.
 	Steps int32 `db:"steps" json:"steps"`
 
+	// User-facing step descriptions for each step. Length of StepTitles must be equal to Steps.
+	StepTitles []string `db:"step_titles" json:"step_titles"`
+
 	// Active job step for this reservation. See Status for more details.
 	Step int32 `db:"step" json:"step"`
 
@@ -31,7 +34,9 @@ type Reservation struct {
 	// it should not contain error details. See Error field for more details.
 	Status string `db:"status" json:"status"`
 
-	// Error message when reservation was not successful. Only set when Success if false.
+	// Error contains error message from the last step. When a job returns an error, execution of
+	// reservation should stop, Success flag should be set to false and Error will contain the error
+	// message.
 	Error string `db:"error" json:"error,omitempty"`
 
 	// Time when reservation was finished or nil when it's still processing.

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -25,7 +25,7 @@ type ResponseError struct {
 	TraceId string `json:"trace_id,omitempty"`
 
 	// full root cause
-	Error error `json:"error"`
+	Error string `json:"error"`
 
 	// build commit
 	Version string `json:"version"`
@@ -48,7 +48,7 @@ func NewInvalidRequestError(ctx context.Context, message string, err error) *Res
 		HTTPStatusCode: 400,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -75,7 +75,7 @@ func PubkeyDuplicateError(ctx context.Context, message string, err error) *Respo
 		HTTPStatusCode: 422,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -134,7 +134,7 @@ func Response(ctx context.Context, status int, message string, err error) *Respo
 		HTTPStatusCode: status,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -165,7 +165,7 @@ func NewNotFoundError(ctx context.Context, message string, err error) *ResponseE
 		HTTPStatusCode: 404,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -179,7 +179,7 @@ func NewEnqueueTaskError(ctx context.Context, message string, err error) *Respon
 		HTTPStatusCode: 500,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -194,7 +194,7 @@ func NewDAOError(ctx context.Context, message string, err error) *ResponseError 
 		HTTPStatusCode: 500,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -208,7 +208,7 @@ func NewRenderError(ctx context.Context, message string, err error) *ResponseErr
 		HTTPStatusCode: 500,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -222,7 +222,7 @@ func NewURLParsingError(ctx context.Context, message string, err error) *Respons
 		HTTPStatusCode: 400,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -236,7 +236,7 @@ func NewStatusError(ctx context.Context, message string, err error) *ResponseErr
 		HTTPStatusCode: 500,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -250,7 +250,7 @@ func NewAWSError(ctx context.Context, message string, err error) *ResponseError 
 		HTTPStatusCode: 500,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -264,7 +264,7 @@ func NewAzureError(ctx context.Context, message string, err error) *ResponseErro
 		HTTPStatusCode: 500,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}
@@ -278,7 +278,7 @@ func NewGCPError(ctx context.Context, message string, err error) *ResponseError 
 		HTTPStatusCode: 500,
 		Message:        message,
 		TraceId:        ctxval.TraceId(ctx),
-		Error:          err,
+		Error:          err.Error(),
 		Version:        version.BuildCommit,
 		BuildTime:      version.BuildTime,
 	}

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -21,16 +21,19 @@ type GenericReservationResponsePayload struct {
 	CreatedAt time.Time `json:"created_at"`
 
 	// Total number of job steps for this reservation.
-	Steps int32 `db:"steps" json:"steps"`
+	Steps int32 `json:"steps"`
+
+	// User-facing step descriptions for each step. Length of StepTitles must be equal to Steps.
+	StepTitles []string `json:"step_titles"`
 
 	// Active job step for this reservation. See Status for more details.
-	Step int32 `db:"step" json:"step"`
+	Step int32 `json:"step"`
 
 	// Textual status of the reservation or error when there was a failure
 	Status string `json:"status"`
 
 	// Error message when reservation was not successful. Only set when Success if false.
-	Error string `db:"error" json:"error,omitempty"`
+	Error string `json:"error"`
 
 	// Time when reservation was finished or nil when it's still processing.
 	FinishedAt *time.Time `json:"finished_at"`
@@ -253,6 +256,7 @@ func reservationResponseMapper(reservation *models.Reservation) *GenericReservat
 		Success:    success,
 		Steps:      reservation.Steps,
 		Step:       reservation.Step,
+		StepTitles: reservation.StepTitles,
 		Error:      reservation.Error,
 	}
 }

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -48,6 +48,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	reservation.Status = "Created"
 	reservation.Provider = models.ProviderTypeAWS
 	reservation.Steps = 2
+	reservation.StepTitles = []string{"Upload public key", "Launch instance(s)"}
 	newName := config.Application.InstancePrefix + payload.Name
 	reservation.Detail.Name = &newName
 

--- a/internal/services/noop_reservation_service.go
+++ b/internal/services/noop_reservation_service.go
@@ -22,10 +22,11 @@ func CreateNoopReservation(w http.ResponseWriter, r *http.Request) {
 	rDao := dao.GetReservationDao(r.Context())
 	reservation := &models.NoopReservation{
 		Reservation: models.Reservation{
-			Provider:  models.ProviderTypeNoop,
-			AccountID: accountId,
-			Status:    "Created",
-			Steps:     1,
+			Provider:   models.ProviderTypeNoop,
+			AccountID:  accountId,
+			Status:     "Created",
+			Steps:      1,
+			StepTitles: []string{"A test step"},
 		},
 	}
 

--- a/internal/services/noop_reservation_service_test.go
+++ b/internal/services/noop_reservation_service_test.go
@@ -1,29 +1,10 @@
 package services_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/RHEnVision/provisioning-backend/internal/jobs/queue"
 	_ "github.com/RHEnVision/provisioning-backend/internal/testing/initialization"
-
-	"github.com/RHEnVision/provisioning-backend/internal/jobs"
-	"github.com/lzap/dejq"
 )
-
-func TestEnqueueNoopJob(t *testing.T) {
-	pj := dejq.PendingJob{
-		Type: queue.TypeNoop,
-		Body: &jobs.NoopJobArgs{
-			AccountID:     1,
-			ReservationID: 0,
-		},
-	}
-	err := queue.GetEnqueuer().Enqueue(context.Background(), pj)
-	if err != nil {
-		panic(err)
-	}
-}
 
 func TestCreateNoopReservationHandler(t *testing.T) {
 	// TODO full service test


### PR DESCRIPTION
Because the job queue implementation is generic, there is no support for cancelling dependant jobs when some fail.

For this reason, jobs must explicitly check associated Reservation field Error for non-empty value using checkExistingError helper function. If it returns an error, the job MUST immediately exit prepending "step skipped: " to the error message.

This way, the actual error message will be prefixed by N prefixes for all remaining jobs in the queue. For example, for 3 jobs when the first fails it is: "step skipped: step skipped: actual error text".

The job code currently always finishes all dependant jobs, so 3 out of 3 jobs will be done. In other words, no matter if queue of dependant jobs will succeed or fail, the counter will be equal to number of steps.

The patch also adds a new array of strings which hold a title that can be presented in a nice way in the UI. We currently do not show full list of all steps involved.
