### PR TITLE
feat: add account identity endpoint

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -108,6 +108,19 @@
         },
         "type": "object"
       },
+      "v1.AccountIDTypeResponse": {
+        "properties": {
+          "aws": {
+            "properties": {
+              "account_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
       "v1.AvailabilityStatusRequest": {
         "properties": {
           "source_id": {
@@ -657,6 +670,40 @@
               }
             },
             "description": "Returned on success."
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/sources/{ID}/account_identity": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Source ID from Sources Database",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AccountIDTypeResponse"
+                }
+              }
+            },
+            "description": "Return on success."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
           },
           "500": {
             "$ref": "#/components/responses/InternalError"

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -112,6 +112,30 @@ paths:
                   $ref: '#/components/schemas/v1.SourceResponse'
         '500':
           $ref: "#/components/responses/InternalError"
+  /sources/{ID}/account_identity:
+    get:
+        description: >
+          Return details needed to identify a hyperscaler account associated with a certain
+          source. The image builder service uses this to share an image with a specific source.
+        parameters:
+        - in: path
+          name: ID
+          schema:
+            type: integer
+            format: int64
+          required: true
+          description: 'Source ID from Sources Database'
+        responses:
+          '200':
+            description: Return on success.
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/v1.AccountIDTypeResponse'
+          '404':
+            $ref: "#/components/responses/NotFound"
+          '500':
+            $ref: "#/components/responses/InternalError"
   /sources/{ID}/instance_types:
       get:
         description: 'Return a list of instance types (DEPRECATED: use /instance_types)'
@@ -380,6 +404,14 @@ components:
           type: integer
         source_id:
           type: string
+      type: object
+    v1.AccountIDTypeResponse:
+      properties:
+        aws:
+          properties:
+            account_id:
+              type: string
+          type: object
       type: object
     v1.AvailabilityStatusRequest:
       properties:

--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -58,6 +58,7 @@ func main() {
 	gen.addSchema("v1.AWSReservationRequest", &payloads.AWSReservationRequestPayload{})
 	gen.addSchema("v1.AWSReservationResponse", &payloads.AWSReservationResponsePayload{})
 	gen.addSchema("v1.AvailabilityStatusRequest", &payloads.AvailabilityStatusRequest{})
+	gen.addSchema("v1.AccountIDTypeResponse", &payloads.AccountIdentityResponse{})
 
 	// error payloads
 	gen.addSchema("v1.ResponseError", &payloads.ResponseError{})

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -112,6 +112,27 @@ paths:
                   $ref: '#/components/schemas/v1.SourceResponse'
         '500':
           $ref: "#/components/responses/InternalError"
+  /sources/{ID}/account_identity:
+    get:
+        parameters:
+        - in: path
+          name: ID
+          schema:
+            type: integer
+            format: int64
+          required: true
+          description: 'Source ID from Sources Database'
+        responses:
+          '200':
+            description: Return on success.
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/v1.AccountIDTypeResponse'
+          '404':
+            $ref: "#/components/responses/NotFound"
+          '500':
+            $ref: "#/components/responses/InternalError"
   /sources/{ID}/instance_types:
       get:
         description: 'Return a list of instance types (DEPRECATED: use /instance_types)'

--- a/internal/clients/account_identity.go
+++ b/internal/clients/account_identity.go
@@ -1,0 +1,9 @@
+package clients
+
+type AccountIdentity struct {
+	AWSDetails *AccountDetailsAWS `json:"aws,omitempty" yaml:"aws"`
+}
+
+type AccountDetailsAWS struct {
+	AccountID string `json:"account_id" yaml:"account_id"`
+}

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -77,6 +77,8 @@ type EC2 interface {
 
 	// RunInstances launches one or more instances
 	RunInstances(ctx context.Context, name *string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error)
+
+	GetAccountId(ctx context.Context) (string, error)
 }
 
 // GetAzureClient returns an Azure client with customer's subscription ID.

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -147,3 +147,7 @@ func (mock *EC2ClientStub) ListInstanceTypesWithPaginator(ctx context.Context) (
 func (mock *EC2ClientStub) RunInstances(ctx context.Context, name *string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error) {
 	return nil, nil, nil
 }
+
+func (mock *EC2ClientStub) GetAccountId(ctx context.Context) (string, error) {
+	return "", nil
+}

--- a/internal/payloads/account_identity.go
+++ b/internal/payloads/account_identity.go
@@ -1,0 +1,26 @@
+package payloads
+
+import (
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/go-chi/render"
+)
+
+type AccountIdentityResponse struct {
+	*clients.AccountIdentity
+}
+
+func NewAccountIdentityResponse(awsAccountId string) render.Renderer {
+	return &AccountIdentityResponse{
+		&clients.AccountIdentity{
+			AWSDetails: &clients.AccountDetailsAWS{
+				AccountID: awsAccountId,
+			},
+		},
+	}
+}
+
+func (s *AccountIdentityResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
+	return nil
+}

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -61,6 +61,8 @@ func MountAPI(r *chi.Mux) {
 
 				// TODO move this to outside of /sources (see below)
 				r.Get("/instance_types", s.ListInstanceTypes)
+
+				r.Get("/account_identity", s.GetAccountIdentity)
 			})
 		})
 

--- a/internal/services/account_identity.go
+++ b/internal/services/account_identity.go
@@ -1,0 +1,43 @@
+package services
+
+import (
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+func GetAccountIdentity(w http.ResponseWriter, r *http.Request) {
+	sourceId := chi.URLParam(r, "ID")
+
+	sourcesClient, err := clients.GetSourcesClient(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	authentication, err := sourcesClient.GetAuthentication(r.Context(), sourceId)
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	ec2Client, err := clients.GetEC2Client(r.Context(), authentication, "")
+	if err != nil {
+		renderError(w, r, payloads.NewAWSError(r.Context(), "unable to get AWS EC2 client", err))
+		return
+	}
+
+	accountId, err := ec2Client.GetAccountId(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewAWSError(r.Context(), "unable to get account id", err))
+		return
+	}
+
+	if err := render.Render(w, r, payloads.NewAccountIdentityResponse(accountId)); err != nil {
+		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render account id", err))
+		return
+	}
+}


### PR DESCRIPTION
I'm unsure if this is the right approach, but opened the PR anyway to discuss.

---

Currently it's very easy for a mismatch between user hyperscaler accounts. Users need to make sure they shared the image with the same account they configured provisioning for.  To avoid this mismatch, image builder should offer to share the image with a source rather than asking for an account number, guaranteeing  that the image was shared with the correct account.