### PR TITLE
fix(HMSPROV-392): Check if image is an original or a shared one

### DIFF
--- a/internal/clients/http/image_builder_errors.go
+++ b/internal/clients/http/image_builder_errors.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	CloneNotFoundErr        = fmt.Errorf("image clone not found: %w", clients.NotFoundErr)
 	ComposeNotFoundErr      = fmt.Errorf("image compose not found: %w", clients.NotFoundErr)
 	ImageStatusErr          = errors.New("build of requested image has not finished yet")
 	UnknownImageTypeErr     = errors.New("unknown image type")


### PR DESCRIPTION
Images can be shared to different regions in Image Builder. 
shared images are not visible under /compose endpoint in IB but under /clone.
Therefore if an image is not visible under /compose,  before erroring out we should search for the image under /clone. 
Only if the image is not preset neither under compose nor clone we should error out with the message that the image is not available. 
