### PR TITLE
chore: use one API worker

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -235,7 +235,7 @@ parameters:
     name: MEMORY_REQUESTS
     value: 100Mi
   - name: MIN_REPLICAS
-    value: "2"
+    value: "1"
   - name: WORKER_MIN_REPLICAS
     value: "2"
   - name: STATUSER_REPLICAS


### PR DESCRIPTION
The recent patch increased number of API and backend workers to 2. It is fine to test multiple workers, but for API workers it is inconvenient to have multiple workers on stage environment as you need to switch between k8s log consoles constantly.

This brings the number back to 1 but it keeps 2 workers.

@mshriver you mentioned some Splunk URL, do we have some Stage log monitoring database? I would love to have access to that.