### PR TITLE
chore: simplify replica config and set all back to 1

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -24,7 +24,7 @@ objects:
         iqePlugin: provisioning
       deployments:
         - name: worker
-          minReplicas: ${{WORKER_MIN_REPLICAS}}
+          replicas: 1
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command:
@@ -82,8 +82,8 @@ objects:
                 cpu: ${CPU_REQUESTS}
                 memory: ${MEMORY_REQUESTS}
         - name: statuser
-          minReplicas: ${{STATUSER_REPLICAS}}
-          maxReplicas: ${{STATUSER_REPLICAS}}
+          # statuser pod must have exactly one replicas
+          replicas: 1
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command:
@@ -127,7 +127,7 @@ objects:
                 cpu: ${CPU_REQUESTS}
                 memory: ${MEMORY_REQUESTS}
         - name: api
-          minReplicas: ${{MIN_REPLICAS}}
+          replicas: 1
           webServices:
             public:
               enabled: true
@@ -234,12 +234,6 @@ parameters:
   - description: memory request increment
     name: MEMORY_REQUESTS
     value: 100Mi
-  - name: MIN_REPLICAS
-    value: "1"
-  - name: WORKER_MIN_REPLICAS
-    value: "2"
-  - name: STATUSER_REPLICAS
-    value: "1"
   - description: Image tag
     name: IMAGE_TAG
     required: true


### PR DESCRIPTION
According to docs, minReplicas was deprecated, we should only use replicas field. Also there is no need to create ENV variables for these. The patch simplifies this.

Since I have tested that multiple backend workers work fine via Redis on stage, I am bringing the number back to 1 for everything. Looking up logs with multiple pods is a bad experience, we can increase this once we setup CloudWatch which is my priority for this sprint.