### PR TITLE
fix(HMSPROV-407): enable cloudwatch in clowder

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -255,7 +255,7 @@ func Initialize(configFiles ...string) {
 
 		// cloudwatch (is blank in ephemeral)
 		cw := cfg.Logging.Cloudwatch
-		if notBlank(cw.Region, cw.AccessKeyId, cw.SecretAccessKey, cw.LogGroup) {
+		if !blank(cw.Region, cw.AccessKeyId, cw.SecretAccessKey, cw.LogGroup) {
 			config.Cloudwatch.Enabled = true
 			config.Cloudwatch.Key = cw.AccessKeyId
 			config.Cloudwatch.Secret = cw.SecretAccessKey

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
@@ -64,7 +65,7 @@ var config struct {
 		} `env-prefix:"LOGGER_"`
 	} `env-prefix:"TELEMETRY_"`
 	Cloudwatch struct {
-		Enabled bool   `env:"ENABLED" env-default:"false" env-description:"cloudwatch logging exporter"`
+		Enabled bool   `env:"ENABLED" env-default:"false" env-description:"cloudwatch logging exporter (enabled in clowder)"`
 		Region  string `env:"REGION" env-default:"" env-description:"cloudwatch logging AWS region"`
 		Key     string `env:"KEY" env-default:"" env-description:"cloudwatch logging key"`
 		Secret  string `env:"SECRET" env-default:"" env-description:"cloudwatch logging secret"`
@@ -250,6 +251,17 @@ func Initialize(configFiles ...string) {
 					}
 				}
 			}
+		}
+
+		// cloudwatch (is blank in ephemeral)
+		cw := cfg.Logging.Cloudwatch
+		if notBlank(cw.Region, cw.AccessKeyId, cw.SecretAccessKey, cw.LogGroup) {
+			config.Cloudwatch.Enabled = true
+			config.Cloudwatch.Key = cw.AccessKeyId
+			config.Cloudwatch.Secret = cw.SecretAccessKey
+			config.Cloudwatch.Region = cw.Region
+			config.Cloudwatch.Group = cw.LogGroup
+			config.Cloudwatch.Stream = path.Base(os.Args[0])
 		}
 
 		// HTTP proxies are not allowed in clowder environment

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-func notBlank(args ...string) bool {
+func blank(args ...string) bool {
 	for _, arg := range args {
 		if arg == "" {
 			return true
@@ -17,10 +17,10 @@ func notBlank(args ...string) bool {
 
 func validate() error {
 	if Cloudwatch.Enabled {
-		if notBlank(Cloudwatch.Region, Cloudwatch.Key, Cloudwatch.Secret) {
+		if !blank(Cloudwatch.Region, Cloudwatch.Key, Cloudwatch.Secret) {
 			return validateMissingSecretError
 		}
-		if notBlank(Cloudwatch.Group, Cloudwatch.Stream) {
+		if !blank(Cloudwatch.Group, Cloudwatch.Stream) {
 			return validateGroupStreamError
 		}
 	}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -6,12 +6,21 @@ import (
 	"fmt"
 )
 
+func notBlank(args ...string) bool {
+	for _, arg := range args {
+		if arg == "" {
+			return true
+		}
+	}
+	return true
+}
+
 func validate() error {
 	if Cloudwatch.Enabled {
-		if Cloudwatch.Region == "" || Cloudwatch.Key == "" || Cloudwatch.Secret == "" {
+		if notBlank(Cloudwatch.Region, Cloudwatch.Key, Cloudwatch.Secret) {
 			return validateMissingSecretError
 		}
-		if Cloudwatch.Group == "" || Cloudwatch.Stream == "" {
+		if notBlank(Cloudwatch.Group, Cloudwatch.Stream) {
 			return validateGroupStreamError
 		}
 	}


### PR DESCRIPTION
Looks like everything is ready to enable cloudwatch API on stage, this is the only change that is needed to export logs via the API.

To get access to ELK/CW on AWS open the [HMSPROV-407](https://issues.redhat.com/browse/HMSPROV-407) ticket and follow the instructions to setup permissions for you account. You will need a GPG public key for a password to be emailed to you.

Testing: Not sure how to test this in ephemeral, but ideally let us merge this sometime in the morning hours so we can check stage. I am still waiting for my permissions to be approved.