### PR TITLE
fix(HMSPROV-387): set consumer group for statuser

### DIFF
--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -316,7 +316,7 @@ func main() {
 	cancelCtx, consumerCancelFunc := context.WithCancel(ctx)
 	go func() {
 		defer receiverWG.Done()
-		kafka.Consume(cancelCtx, kafka.AvailabilityStatusRequestTopic, processMessage)
+		kafka.Consume(cancelCtx, kafka.AvailabilityStatusRequestTopic, "statuser", processMessage)
 	}()
 
 	metrics.RegisterStatuserMetrics()

--- a/internal/background/availability_queue_test.go
+++ b/internal/background/availability_queue_test.go
@@ -25,7 +25,7 @@ func TestQueueNormalSend(t *testing.T) {
 	cct, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go sendAvailabilityRequestMessages(cct, 8, 10*time.Millisecond)
-	go kafka.Consume(cct, kafka.AvailabilityStatusRequestTopic, func(ctx context.Context, msg *kafka.GenericMessage) {
+	go kafka.Consume(cct, kafka.AvailabilityStatusRequestTopic, "", func(ctx context.Context, msg *kafka.GenericMessage) {
 		asm, _ := kafka.NewAvailabilityStatusMessage(msg)
 		require.EqualValues(t, "1", asm.SourceID)
 		wg.Done()
@@ -48,7 +48,7 @@ func TestFullQueueSend(t *testing.T) {
 	senderCtx, senderCancel := context.WithCancel(ctx)
 	defer consumeCancel()
 	go sendAvailabilityRequestMessages(senderCtx, 2, time.Second)
-	go kafka.Consume(consumeCtx, kafka.AvailabilityStatusRequestTopic, func(ctx context.Context, msg *kafka.GenericMessage) {
+	go kafka.Consume(consumeCtx, kafka.AvailabilityStatusRequestTopic, "", func(ctx context.Context, msg *kafka.GenericMessage) {
 		asm, _ := kafka.NewAvailabilityStatusMessage(msg)
 		require.EqualValues(t, "1", asm.SourceID)
 		wg.Done()
@@ -82,7 +82,7 @@ func TestQueueCancelSend(t *testing.T) {
 
 	consumeCtx, consumeCancel := context.WithCancel(ctx)
 	defer consumeCancel()
-	go kafka.Consume(consumeCtx, kafka.AvailabilityStatusRequestTopic, func(ctx context.Context, msg *kafka.GenericMessage) {
+	go kafka.Consume(consumeCtx, kafka.AvailabilityStatusRequestTopic, "", func(ctx context.Context, msg *kafka.GenericMessage) {
 		asm, _ := kafka.NewAvailabilityStatusMessage(msg)
 		require.EqualValues(t, "1", asm.SourceID)
 		wg.Done()

--- a/internal/kafka/interface.go
+++ b/internal/kafka/interface.go
@@ -9,7 +9,7 @@ type Broker interface {
 	Send(ctx context.Context, messages ...*GenericMessage) error
 
 	// Consume messages of a single topic in a loop. Blocking call, use context cancellation to stop.
-	Consume(ctx context.Context, topic string, handler func(ctx context.Context, message *GenericMessage))
+	Consume(ctx context.Context, topic string, group string, handler func(ctx context.Context, message *GenericMessage))
 }
 
 var broker Broker = &noopBroker{}
@@ -19,6 +19,6 @@ func Send(ctx context.Context, messages ...*GenericMessage) error {
 	return broker.Send(ctx, messages...)
 }
 
-func Consume(ctx context.Context, topic string, handler func(ctx context.Context, message *GenericMessage)) {
-	broker.Consume(ctx, topic, handler)
+func Consume(ctx context.Context, topic string, group string, handler func(ctx context.Context, message *GenericMessage)) {
+	broker.Consume(ctx, topic, group, handler)
 }

--- a/internal/kafka/interface_test.go
+++ b/internal/kafka/interface_test.go
@@ -28,7 +28,7 @@ func TestSendAndConsume(t *testing.T) {
 	cct, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go bus.Consume(cct, "topic", func(ctx context.Context, msg *GenericMessage) {
+	go bus.Consume(cct, "topic", "", func(ctx context.Context, msg *GenericMessage) {
 		require.EqualValues(t, "key", msg.Key)
 		require.EqualValues(t, "value", msg.Value)
 		wg.Done()
@@ -47,13 +47,13 @@ func TestMultipleTopics(t *testing.T) {
 	cct, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go bus.Consume(cct, "topic1", func(ctx context.Context, msg *GenericMessage) {
+	go bus.Consume(cct, "topic1", "", func(ctx context.Context, msg *GenericMessage) {
 		require.EqualValues(t, "key1", msg.Key)
 		require.EqualValues(t, "value", msg.Value)
 		wg.Done()
 	})
 
-	go bus.Consume(cct, "topic2", func(ctx context.Context, msg *GenericMessage) {
+	go bus.Consume(cct, "topic2", "", func(ctx context.Context, msg *GenericMessage) {
 		require.EqualValues(t, "key2", msg.Key)
 		require.EqualValues(t, "value", msg.Value)
 		wg.Done()

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -138,11 +138,12 @@ func newContextErrLogger(ctx context.Context) func(msg string, a ...interface{})
 }
 
 // NewReader creates a reader. Use Close() function to close the reader.
-func (b *kafkaBroker) NewReader(ctx context.Context, topic string) *kafka.Reader {
+func (b *kafkaBroker) NewReader(ctx context.Context, topic, group string) *kafka.Reader {
 	return kafka.NewReader(kafka.ReaderConfig{
 		Brokers:     config.Kafka.Brokers,
 		Dialer:      b.dialer,
 		Topic:       topic,
+		GroupID:     group,
 		StartOffset: kafka.LastOffset,
 		Logger:      kafka.LoggerFunc(newContextLogger(ctx)),
 		ErrorLogger: kafka.LoggerFunc(newContextErrLogger(ctx)),
@@ -162,9 +163,9 @@ func (b *kafkaBroker) NewWriter(ctx context.Context) *kafka.Writer {
 
 // Consume reads messages in batches up to 1 MB with up to 10 seconds delay. It blocks, therefore
 // it should be called from a separate goroutine. Use context cancellation to stop the loop.
-func (b *kafkaBroker) Consume(ctx context.Context, topic string, handler func(ctx context.Context, message *GenericMessage)) {
+func (b *kafkaBroker) Consume(ctx context.Context, topic string, group string, handler func(ctx context.Context, message *GenericMessage)) {
 	logger := ctxval.Logger(ctx)
-	r := b.NewReader(ctx, topic)
+	r := b.NewReader(ctx, topic, group)
 	defer r.Close()
 
 	for {
@@ -176,7 +177,8 @@ func (b *kafkaBroker) Consume(ctx context.Context, topic string, handler func(ct
 		} else if err != nil {
 			logger.Warn().Err(err).Msgf("Error when reading message: %s", err.Error())
 		} else {
-			logger.Trace().Bytes("payload", msg.Value).Msgf("Received message with key: %s", msg.Key)
+			logger.Trace().Bytes("payload", msg.Value).Msgf("Received message with key: %s, topic: %s, offset: %d, partition: %d",
+				msg.Key, msg.Topic, msg.Offset, msg.Partition)
 			ctx, err = ctxval.WithIdentityFrom64(ctx, header("x-rh-identity", msg.Headers))
 			if err != nil {
 				logger.Trace().Msgf("Could not extract identity from context to Kafka message: %s", err)

--- a/internal/kafka/noop.go
+++ b/internal/kafka/noop.go
@@ -11,7 +11,7 @@ type noopBroker struct{}
 
 var _ Broker = &noopBroker{}
 
-func (s *noopBroker) Consume(ctx context.Context, topic string, handler func(ctx context.Context, message *GenericMessage)) {
+func (s *noopBroker) Consume(ctx context.Context, topic string, group string, handler func(ctx context.Context, message *GenericMessage)) {
 	logger := ctxval.Logger(ctx)
 	logger.Warn().Msg("Consume loop not started (Kafka not configured)")
 }

--- a/internal/kafka/stub.go
+++ b/internal/kafka/stub.go
@@ -40,7 +40,7 @@ func (s *stubBroker) find(topic string) chan *GenericMessage {
 	}
 }
 
-func (s *stubBroker) Consume(ctx context.Context, topic string, handler func(ctx context.Context, message *GenericMessage)) {
+func (s *stubBroker) Consume(ctx context.Context, topic string, group string, handler func(ctx context.Context, message *GenericMessage)) {
 	ch := s.find(topic)
 
 	for {


### PR DESCRIPTION
Previously, if you started statuser it would start from offset 0 and process all the messages in the queue regardless of the offset start setting in the reader client.

Turns out that in Kafka, you have to set group name in order for the platform to "remember" the offset.

To test this, send some availability checks and then start statuser, it should NOT process any messages. Only when it is running it should be processing them.