### PR TITLE
ci(HMSPROV-411): Add testing.yaml for IQE CJI

### DIFF
--- a/deploy/testing.yaml
+++ b/deploy/testing.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: provisioning-stage-test
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: provisioning-stage-test-${IMAGE_TAG}-${UID}
+    annotations:
+      "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
+      "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+  spec:
+    appName: provisioning-backend  # component for envparser
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        marker: 'smoke and api'
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"


### PR DESCRIPTION
HMSPROV-411

This will be used to execute IQE within tekton pipelines in conjunction with the service deployment

This PR will precede the app-interface contributions that define the pipeline and trigger it. The file's inclusion will not trigger any automatic execution as-is during app deployment.

**Checklist**

- [x] all commit messages follows the policy above
- [x] the change follows our security guidelines
