### PR TITLE
fix(HMSPROV-416): simple launch statistics

### DIFF
--- a/cmd/pbapi/main.go
+++ b/cmd/pbapi/main.go
@@ -74,6 +74,7 @@ func main() {
 	tel := telemetry.Initialize(&log.Logger)
 	defer tel.Close(ctx)
 	metrics.RegisterApiMetrics()
+	metrics.RegisterApiStatistics()
 
 	// initialize the rest
 	err = db.Initialize(ctx, "public")

--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -320,6 +320,7 @@ func main() {
 	}()
 
 	metrics.RegisterStatuserMetrics()
+	metrics.RegisterStatuserStatistics()
 
 	// start processing goroutines
 	processingWG.Add(3)

--- a/cmd/typesctl/providers/gcp_types.go
+++ b/cmd/typesctl/providers/gcp_types.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
-	"github.com/RHEnVision/provisioning-backend/internal/clients/http/ec2/types"
+	"github.com/RHEnVision/provisioning-backend/internal/clients/http/gcp/types"
 )
 
 func init() {

--- a/internal/clients/http/gcp/types/gcp_types.go
+++ b/internal/clients/http/gcp/types/gcp_types.go
@@ -61,3 +61,7 @@ func InstanceTypesForZone(region, zone string, supported *bool) ([]*clients.Inst
 	}
 	return result, nil
 }
+
+func FindInstanceType(name clients.InstanceTypeName) *clients.InstanceType {
+	return typeInfo.RegisteredTypes.Get(name)
+}

--- a/internal/metrics/statistics.go
+++ b/internal/metrics/statistics.go
@@ -1,0 +1,82 @@
+package metrics
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/version"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	StatisticsLaunchUsageName = "statistics_launch_usage"
+	StatisticsLaunchCountName = "statistics_launch_count"
+)
+
+var StatisticsLaunchUsage = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name:        StatisticsLaunchUsageName,
+		Help:        "statistics: launch usage",
+		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName, "component": "api", "statistics": "true"},
+	},
+	[]string{"type", "provider"},
+)
+
+var StatisticsLaunchCount = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:        StatisticsLaunchCountName,
+		Help:        "statistics: number of instances launched at once",
+		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName, "component": "api", "statistics": "true"},
+		// maximum Value in the wizard is 45
+		Buckets: []float64{0.5, 1.5, 2.5, 4.5, 8.5, 16.5, 32.5},
+	},
+	[]string{"type", "provider"},
+)
+
+type KVPair struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type LogRecord struct {
+	Name  string   `json:"name"`
+	Value []KVPair `json:"pairs"`
+}
+
+func statsLogger(ctx context.Context, rec LogRecord) {
+	ctxval.Logger(ctx).Info().Interface("statistics", rec).Msgf("Statistics: %+v", rec)
+}
+
+func LaunchUsageStats(ctx context.Context, it clients.InstanceTypeName, pt models.ProviderType, count int) {
+	StatisticsLaunchUsage.WithLabelValues(it.String(), pt.String()).Inc()
+	StatisticsLaunchCount.WithLabelValues(it.String(), pt.String()).Observe(float64(count))
+	stats := LogRecord{
+		Name: StatisticsLaunchUsageName,
+		Value: []KVPair{
+			{
+				Key:   "type",
+				Value: it.String(),
+			},
+			{
+				Key:   "provider",
+				Value: pt.String(),
+			},
+			{
+				Key:   "count",
+				Value: strconv.Itoa(count),
+			},
+		},
+	}
+	statsLogger(ctx, stats)
+}
+
+func RegisterStatuserStatistics() {
+	// no statistics yet
+}
+
+func RegisterApiStatistics() {
+	prometheus.MustRegister(StatisticsLaunchUsage, StatisticsLaunchCount)
+}

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/jobs"
 	"github.com/RHEnVision/provisioning-backend/internal/jobs/queue"
+	"github.com/RHEnVision/provisioning-backend/internal/metrics"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/render"
@@ -162,6 +163,9 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 		renderError(w, r, payloads.NewEnqueueTaskError(r.Context(), "job enqueue error", err))
 		return
 	}
+
+	// Statistics
+	metrics.LaunchUsageStats(r.Context(), it.Name, models.ProviderTypeAWS, int(payload.Amount))
 
 	// Return response payload
 	unused := make([]*models.ReservationInstance, 0, 0)


### PR DESCRIPTION
We need to explore launch statistics, this is currently in the design phase, but I wanted to take a look how statistics implemented as prometheus or logs (or both in this case) would look like.

We can only do dumb "counting" that will give us just a number of uses. However, it would make sense to collect also account numbers and then we could filter out red hat or testing accounts as a post processing step (in PowerBI or Excel). That would require more capacity.

So I think we have several options:

* Store data into Prometheus, good for short term graphing or export. Retention policy might be quite small (days), however, for counter-only approach this is good enough as counters are monotonic.
* Store data in logs, good exporting possibilities via Kibana (e.g. Excel), retention policy is still small (weeks). We could export data every month into Excel and this could be a way to get very detailed statistics for a whole year. Chances are it could be automated.
* Create our own table and track statistics there. I do not like this approach as it is the most complex and data are locked down for engineering in stage/prod environments.

I propose a combination of both A and B.

We need to gather info about instance types and other parameters form the main wizard (count perhaps). Monitoring can give us counters or histograms of usage. Additionally, creating INFO level logs with field "statistics" allows us to export data from Kibana before retention (which appears to be a week).

This implementation will be quite simple, if we encounter any issues with these stats we can do proper implementation of statistics via a database table or external system.

* https://issues.redhat.com/browse/HMSPROV-416
* https://issues.redhat.com/browse/HMSPROV-385

Consider this a draft, tho, if this gets accepted I would encourage to test this both with AWS and GCP, thanks.