### PR TITLE
fix(HMSPROV-407): fix blank logic in cw initialization

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -255,7 +255,7 @@ func Initialize(configFiles ...string) {
 
 		// cloudwatch (is blank in ephemeral)
 		cw := cfg.Logging.Cloudwatch
-		if !blank(cw.Region, cw.AccessKeyId, cw.SecretAccessKey, cw.LogGroup) {
+		if present(cw.Region, cw.AccessKeyId, cw.SecretAccessKey, cw.LogGroup) {
 			config.Cloudwatch.Enabled = true
 			config.Cloudwatch.Key = cw.AccessKeyId
 			config.Cloudwatch.Secret = cw.SecretAccessKey

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlank1(t *testing.T) {
+	require.False(t, present(""))
+}
+
+func TestBlank2(t *testing.T) {
+	require.False(t, present("", ""))
+}
+
+func TestBlankNon1(t *testing.T) {
+	require.True(t, present("x"))
+}
+
+func TestBlankNon2(t *testing.T) {
+	require.True(t, present("x", "x"))
+}

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
-	"path"
 	"strings"
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
@@ -30,12 +28,12 @@ func RedisHostAndPort() string {
 
 // InStageClowder returns true, when the app is running in stage clowder environment.
 func InStageClowder() bool {
-	return clowder.IsClowderEnabled() && strings.HasPrefix(*clowder.LoadedConfig.Metadata.EnvName, "env-stage")
+	return clowder.IsClowderEnabled() && strings.HasPrefix(*clowder.LoadedConfig.Metadata.EnvName, "stage")
 }
 
 // InProdClowder returns true, when the app is running in production clowder environment.
 func InProdClowder() bool {
-	return clowder.IsClowderEnabled() && strings.HasPrefix(*clowder.LoadedConfig.Metadata.EnvName, "env-prod")
+	return clowder.IsClowderEnabled() && strings.HasPrefix(*clowder.LoadedConfig.Metadata.EnvName, "prod")
 }
 
 // TopicName returns mapped topic from Clowder. When not running in Clowder mode, it returns the input topic name.
@@ -99,5 +97,5 @@ func DumpConfig(logger zerolog.Logger) {
 	configCopy.Azure.ClientSecret = replacement
 	configCopy.GCP.JSON = replacement
 	configCopy.Unleash.Token = replacement
-	logger.Info().Str("binary", path.Base(os.Args[0])).Msgf("Configuration: %+v", configCopy)
+	logger.Info().Msgf("Configuration: %+v", configCopy)
 }

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 )
 
-func blank(args ...string) bool {
+// present checks if all arguments are not blank
+func present(args ...string) bool {
 	for _, arg := range args {
 		if arg == "" {
-			return true
+			return false
 		}
 	}
 	return true
@@ -17,10 +18,10 @@ func blank(args ...string) bool {
 
 func validate() error {
 	if Cloudwatch.Enabled {
-		if !blank(Cloudwatch.Region, Cloudwatch.Key, Cloudwatch.Secret) {
+		if present(Cloudwatch.Region, Cloudwatch.Key, Cloudwatch.Secret) {
 			return validateMissingSecretError
 		}
-		if !blank(Cloudwatch.Group, Cloudwatch.Stream) {
+		if present(Cloudwatch.Group, Cloudwatch.Stream) {
 			return validateGroupStreamError
 		}
 	}

--- a/internal/logging/zerolog.go
+++ b/internal/logging/zerolog.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"fmt"
 	"os"
+	"path"
 	"time"
 	"unicode/utf8"
 
@@ -68,7 +69,7 @@ func InitializeStdout() {
 		FormatFieldValue: func(i interface{}) string {
 			return truncateText(fmt.Sprintf("%s", i), config.Logging.MaxField)
 		},
-	}))
+	})).With().Str("binary", path.Base(os.Args[0])).Logger()
 }
 
 func InitializeCloudwatch(logger zerolog.Logger) (zerolog.Logger, func(), error) {


### PR DESCRIPTION
Turns out logic algebra can still bite. Also, I confirmed that the "cloudwatch type" clowder field is suppoed to be set to "app-interface" but it is actually blank. It's a known issue.

This patch should finally grab CW configuration from clowder and finally start logging. You cannot test this in ephemeral, this must be merged.