### PR TITLE
fix(HMSPROV-389): drop memcache count

### DIFF
--- a/internal/cache/mem_cache.go
+++ b/internal/cache/mem_cache.go
@@ -6,9 +6,6 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
-	"github.com/RHEnVision/provisioning-backend/internal/version"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type memCache struct {
@@ -26,14 +23,6 @@ func NewMemoryCache() *memCache {
 	c := memCache{
 		accountId: newMemoryCache[accountKey, *models.Account](config.Application.Cache.Memory.CleanupInterval),
 	}
-
-	_ = promauto.NewGaugeFunc(prometheus.GaugeOpts{
-		Name:        "app_cache_account_items",
-		Help:        "The total number of cache items for account ID",
-		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName},
-	}, func() float64 {
-		return float64(c.accountId.Count())
-	})
 
 	return &c
 }


### PR DESCRIPTION
Previously we used memory caching on stage, we now use Redis. It has its own statistics which we can utilize, no need to track Redis. And we only use the memory implementation to cache the app ID (single value), so this value was always zero.

This patch drops the metrics, it is not very useful now.