### PR TITLE
chore: drop jobqueue references

### DIFF
--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -101,7 +101,6 @@ The application integrates with multiple backend services:
 Worker processes (`pbworker`) are responsible for running background jobs. There must be one or more processes running in order to pick up background jobs (e.g. launch reservations). There are multiple configuration options available via `WORKER_QUEUE`:
 
 * `redis` - uses queue via Redis
-* `postgres` - uses jobqueue implementation for the queue
 * `memory` - in-memory worker (default option)
 
 The default behavior is the in-memory worker, which spawns a single goroutine within the main application which picks up all jobs sequentially. This is only meant for development setups so that no extra worker process is required when testing background jobs.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,7 +112,7 @@ var config struct {
 		TraceData bool `env:"TRACE_DATA" env-default:"true" env-description:"open telemetry HTTP context pass and trace"`
 	} `env-prefix:"REST_ENDPOINTS_"`
 	Worker struct {
-		Queue       string        `env:"QUEUE" env-default:"memory" env-description:"job worker implementation (memory, redis, sqs, postgres)"`
+		Queue       string        `env:"QUEUE" env-default:"memory" env-description:"job worker implementation (memory, redis)"`
 		Concurrency int           `env:"CONCURRENCY" env-default:"50" env-description:"number of goroutines handling jobs"`
 		Heartbeat   time.Duration `env:"HEARTBEAT" env-default:"30s" env-description:"heartbeat interval (time interval syntax)"`
 		MaxBeats    int           `env:"MAX_BEATS" env-default:"10" env-description:"maximum amount of heartbeats allowed"`

--- a/internal/db/migrations/014_drop_jobqueue.sql
+++ b/internal/db/migrations/014_drop_jobqueue.sql
@@ -1,0 +1,4 @@
+DROP VIEW ready_jobs;
+DROP TABLE heartbeats;
+DROP TABLE job_dependencies;
+DROP TABLE jobs;

--- a/internal/jobs/queue/dejq/dejq_queue.go
+++ b/internal/jobs/queue/dejq/dejq_queue.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-logr/zerologr"
 	"github.com/lzap/dejq"
 	"github.com/lzap/dejq/mem"
-	"github.com/lzap/dejq/postgres"
 	"github.com/lzap/dejq/redis"
 	"github.com/rs/zerolog"
 )
@@ -48,14 +47,8 @@ func Initialize(ctx context.Context, logger *zerolog.Logger) error {
 			config.Application.Cache.Redis.User, config.Application.Cache.Redis.Password,
 			config.Application.Cache.Redis.DB, "provisioning-job-queue",
 			5*time.Second)
-	case "postgres":
-		// TODO dejq must be refactored to use PGX too
-		dejqQueue, err = postgres.NewClient(ctx, zerologr.New(logger), nil,
-			config.Worker.Concurrency,
-			config.Worker.Heartbeat,
-			config.Worker.MaxBeats)
 	default:
-		panic("unknown WORKER_QUEUE setting, expected values: memory, redis, postgres")
+		panic("unknown WORKER_QUEUE setting, expected values: memory, redis")
 	}
 
 	if err != nil {


### PR DESCRIPTION
It turns out we do not need too complicated jobs, a simple "background job" is sufficient for our use case. Current implementation uses simple Redis queue (list) and the interface also has a second option AWS SQS. Let's drop tables from the database we will not use dbjobqueue from image-builder.