### PR TITLE
fix(HMSPROV-387): use time-based offset for statuser

### DIFF
--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -316,7 +316,7 @@ func main() {
 	cancelCtx, consumerCancelFunc := context.WithCancel(ctx)
 	go func() {
 		defer receiverWG.Done()
-		kafka.Consume(cancelCtx, kafka.AvailabilityStatusRequestTopic, "statuser", processMessage)
+		kafka.Consume(cancelCtx, kafka.AvailabilityStatusRequestTopic, time.Now(), processMessage)
 	}()
 
 	metrics.RegisterStatuserMetrics()

--- a/internal/background/availability_queue_test.go
+++ b/internal/background/availability_queue_test.go
@@ -25,7 +25,7 @@ func TestQueueNormalSend(t *testing.T) {
 	cct, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go sendAvailabilityRequestMessages(cct, 8, 10*time.Millisecond)
-	go kafka.Consume(cct, kafka.AvailabilityStatusRequestTopic, "", func(ctx context.Context, msg *kafka.GenericMessage) {
+	go kafka.Consume(cct, kafka.AvailabilityStatusRequestTopic, time.Now(), func(ctx context.Context, msg *kafka.GenericMessage) {
 		asm, _ := kafka.NewAvailabilityStatusMessage(msg)
 		require.EqualValues(t, "1", asm.SourceID)
 		wg.Done()
@@ -48,7 +48,7 @@ func TestFullQueueSend(t *testing.T) {
 	senderCtx, senderCancel := context.WithCancel(ctx)
 	defer consumeCancel()
 	go sendAvailabilityRequestMessages(senderCtx, 2, time.Second)
-	go kafka.Consume(consumeCtx, kafka.AvailabilityStatusRequestTopic, "", func(ctx context.Context, msg *kafka.GenericMessage) {
+	go kafka.Consume(consumeCtx, kafka.AvailabilityStatusRequestTopic, time.Now(), func(ctx context.Context, msg *kafka.GenericMessage) {
 		asm, _ := kafka.NewAvailabilityStatusMessage(msg)
 		require.EqualValues(t, "1", asm.SourceID)
 		wg.Done()
@@ -82,7 +82,7 @@ func TestQueueCancelSend(t *testing.T) {
 
 	consumeCtx, consumeCancel := context.WithCancel(ctx)
 	defer consumeCancel()
-	go kafka.Consume(consumeCtx, kafka.AvailabilityStatusRequestTopic, "", func(ctx context.Context, msg *kafka.GenericMessage) {
+	go kafka.Consume(consumeCtx, kafka.AvailabilityStatusRequestTopic, time.Now(), func(ctx context.Context, msg *kafka.GenericMessage) {
 		asm, _ := kafka.NewAvailabilityStatusMessage(msg)
 		require.EqualValues(t, "1", asm.SourceID)
 		wg.Done()

--- a/internal/kafka/interface.go
+++ b/internal/kafka/interface.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+	"time"
 )
 
 type Broker interface {
@@ -9,7 +10,7 @@ type Broker interface {
 	Send(ctx context.Context, messages ...*GenericMessage) error
 
 	// Consume messages of a single topic in a loop. Blocking call, use context cancellation to stop.
-	Consume(ctx context.Context, topic string, group string, handler func(ctx context.Context, message *GenericMessage))
+	Consume(ctx context.Context, topic string, since time.Time, handler func(ctx context.Context, message *GenericMessage))
 }
 
 var broker Broker = &noopBroker{}
@@ -19,6 +20,6 @@ func Send(ctx context.Context, messages ...*GenericMessage) error {
 	return broker.Send(ctx, messages...)
 }
 
-func Consume(ctx context.Context, topic string, group string, handler func(ctx context.Context, message *GenericMessage)) {
-	broker.Consume(ctx, topic, group, handler)
+func Consume(ctx context.Context, topic string, since time.Time, handler func(ctx context.Context, message *GenericMessage)) {
+	broker.Consume(ctx, topic, since, handler)
 }

--- a/internal/kafka/interface_test.go
+++ b/internal/kafka/interface_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	_ "github.com/RHEnVision/provisioning-backend/internal/testing/initialization"
 
@@ -28,7 +29,7 @@ func TestSendAndConsume(t *testing.T) {
 	cct, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go bus.Consume(cct, "topic", "", func(ctx context.Context, msg *GenericMessage) {
+	go bus.Consume(cct, "topic", time.Now(), func(ctx context.Context, msg *GenericMessage) {
 		require.EqualValues(t, "key", msg.Key)
 		require.EqualValues(t, "value", msg.Value)
 		wg.Done()
@@ -47,13 +48,13 @@ func TestMultipleTopics(t *testing.T) {
 	cct, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go bus.Consume(cct, "topic1", "", func(ctx context.Context, msg *GenericMessage) {
+	go bus.Consume(cct, "topic1", time.Now(), func(ctx context.Context, msg *GenericMessage) {
 		require.EqualValues(t, "key1", msg.Key)
 		require.EqualValues(t, "value", msg.Value)
 		wg.Done()
 	})
 
-	go bus.Consume(cct, "topic2", "", func(ctx context.Context, msg *GenericMessage) {
+	go bus.Consume(cct, "topic2", time.Now(), func(ctx context.Context, msg *GenericMessage) {
 		require.EqualValues(t, "key2", msg.Key)
 		require.EqualValues(t, "value", msg.Value)
 		wg.Done()

--- a/internal/kafka/noop.go
+++ b/internal/kafka/noop.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"context"
+	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 )
@@ -11,7 +12,7 @@ type noopBroker struct{}
 
 var _ Broker = &noopBroker{}
 
-func (s *noopBroker) Consume(ctx context.Context, topic string, group string, handler func(ctx context.Context, message *GenericMessage)) {
+func (s *noopBroker) Consume(ctx context.Context, topic string, since time.Time, handler func(ctx context.Context, message *GenericMessage)) {
 	logger := ctxval.Logger(ctx)
 	logger.Warn().Msg("Consume loop not started (Kafka not configured)")
 }

--- a/internal/kafka/stub.go
+++ b/internal/kafka/stub.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // In-memory broker
@@ -40,7 +41,7 @@ func (s *stubBroker) find(topic string) chan *GenericMessage {
 	}
 }
 
-func (s *stubBroker) Consume(ctx context.Context, topic string, group string, handler func(ctx context.Context, message *GenericMessage)) {
+func (s *stubBroker) Consume(ctx context.Context, topic string, since time.Time, handler func(ctx context.Context, message *GenericMessage)) {
 	ch := s.find(topic)
 
 	for {


### PR DESCRIPTION
Last week, I enabled a Kafka consumer group which solved the problem of tracking offsets. While this worked fine locally, it does not on stage. I am not sure what is wrong, however, I figured out a different solution.

Statuser is only one instance at the moment, however, turns out that offsets can be also set based on time. When statuser is restarted, only newly created messages can be read. This patch does exactly that.