### PR TITLE
fix(HMSPROV-421): fix image-builder-service url

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -255,7 +255,7 @@ parameters:
   - description: ImageBuilder service URL
     name: IMAGEBUILDER_URL
     required: false
-    value: "http://image-builder:8080"
+    value: "http://image-builder-service:8080"
   - description: Instance prefix adds string to all instance names, leave blank for production
     name: APP_INSTANCE_PREFIX
     value: ""


### PR DESCRIPTION
In the ephemeral environment, API calls to image-builder-service are failing because the value of the image builder service url is incorrect. The service url should be `http://image-builder-service:8080`.

***DO NOT MERGE***
I am issuing this PR so that a container will be built and I can test this fix manually on the ephemeral environment. I will mark this PR ready for review once I have confirmed that this fix works.