### PR TITLE
fix: image builder clowder config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -272,8 +272,8 @@ func Initialize(configFiles ...string) {
 		if endpoint, ok := clowder.DependencyEndpoints["sources-api"]["svc"]; ok {
 			config.RestEndpoints.Sources.URL = fmt.Sprintf("http://%s:%d/api/sources/v3.1", endpoint.Hostname, endpoint.Port)
 		}
-		if endpoint, ok := clowder.DependencyEndpoints["image-builder"]["svc"]; ok {
-			config.RestEndpoints.Sources.URL = fmt.Sprintf("http://%s:%d/api/image-builder/v1", endpoint.Hostname, endpoint.Port)
+		if endpoint, ok := clowder.DependencyEndpoints["image-builder"]["service"]; ok {
+			config.RestEndpoints.ImageBuilder.URL = fmt.Sprintf("http://%s:%d/api/image-builder/v1", endpoint.Hostname, endpoint.Port)
 		}
 	}
 


### PR DESCRIPTION
Image builder defines it's backend container as service not svc. This is fixing the typo for picking up that config.

Fixes HMSPROV-421