### PR TITLE
fix(HMSPROV-433): change resource type to application

### DIFF
--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -39,7 +39,7 @@ const ChannelBuffer = 32
 type SourceInfo struct {
 	Authentication clients.Authentication
 
-	SourceID string
+	SourceApplictionID string
 
 	Identity identity.XRHID
 }
@@ -85,9 +85,9 @@ func processMessage(ctx context.Context, message *kafka.GenericMessage) {
 	}
 
 	s := SourceInfo{
-		Authentication: *authentication,
-		SourceID:       sourceId,
-		Identity:       ctxval.Identity(ctx),
+		Authentication:     *authentication,
+		SourceApplictionID: authentication.SourceApplictionID,
+		Identity:           ctxval.Identity(ctx),
 	}
 
 	switch authentication.ProviderType {
@@ -110,9 +110,9 @@ func checkSourceAvailabilityAzure(ctx context.Context) {
 		metrics.ObserveAvailablilityCheckReqsDuration(models.ProviderTypeAzure, func() error {
 			var err error
 			sr := kafka.SourceResult{
-				SourceID:     s.SourceID,
+				ResourceID:   s.SourceApplictionID,
 				Identity:     s.Identity,
-				ResourceType: "Source",
+				ResourceType: "Application",
 			}
 			// TODO: check if source is avavliable - WIP
 			sr.Status = kafka.StatusAvaliable
@@ -132,9 +132,9 @@ func checkSourceAvailabilityAWS(ctx context.Context) {
 		metrics.ObserveAvailablilityCheckReqsDuration(models.ProviderTypeAWS, func() error {
 			var err error
 			sr := kafka.SourceResult{
-				SourceID:     s.SourceID,
+				ResourceID:   s.SourceApplictionID,
 				Identity:     s.Identity,
-				ResourceType: "Source",
+				ResourceType: "Application",
 			}
 			_, err = clients.GetEC2Client(ctx, &s.Authentication, "")
 			if err != nil {
@@ -160,9 +160,9 @@ func checkSourceAvailabilityGCP(ctx context.Context) {
 		metrics.ObserveAvailablilityCheckReqsDuration(models.ProviderTypeGCP, func() error {
 			var err error
 			sr := kafka.SourceResult{
-				SourceID:     s.SourceID,
+				ResourceID:   s.SourceApplictionID,
 				Identity:     s.Identity,
-				ResourceType: "Source",
+				ResourceType: "Application",
 			}
 			gcpClient, err := clients.GetGCPClient(ctx, &s.Authentication)
 			if err != nil {

--- a/internal/clients/authentication.go
+++ b/internal/clients/authentication.go
@@ -9,8 +9,9 @@ import (
 )
 
 type Authentication struct {
-	ProviderType models.ProviderType `json:"type"`
-	Payload      string              `json:"payload"`
+	SourceApplictionID string              `json:"source_application_id"`
+	ProviderType       models.ProviderType `json:"type"`
+	Payload            string              `json:"payload"`
 }
 
 func NewAuthentication(str string, provType models.ProviderType) *Authentication {
@@ -21,8 +22,8 @@ func NewAuthentication(str string, provType models.ProviderType) *Authentication
 	return &a
 }
 
-func NewAuthenticationFromSourceAuthType(ctx context.Context, str, authType string) *Authentication {
-	a := Authentication{Payload: str}
+func NewAuthenticationFromSourceAuthType(ctx context.Context, str, authType, appID string) *Authentication {
+	a := Authentication{Payload: str, SourceApplictionID: appID}
 	switch authType {
 	case "provisioning-arn":
 		a.ProviderType = models.ProviderTypeAWS

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -139,7 +139,7 @@ func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId clients.
 		return nil, err
 	}
 
-	authentication := clients.NewAuthenticationFromSourceAuthType(ctx, *auth.Username, string(*auth.Authtype))
+	authentication := clients.NewAuthenticationFromSourceAuthType(ctx, *auth.Username, string(*auth.Authtype), *auth.ResourceId)
 	return authentication, nil
 }
 

--- a/internal/kafka/source_result.go
+++ b/internal/kafka/source_result.go
@@ -14,7 +14,7 @@ const (
 )
 
 type SourceResult struct {
-	SourceID string `json:"resource_id"`
+	ResourceID string `json:"resource_id"`
 
 	// Resource type of the source
 	ResourceType string `json:"resource_type"`
@@ -27,5 +27,5 @@ type SourceResult struct {
 }
 
 func (sr SourceResult) GenericMessage(ctx context.Context) (GenericMessage, error) {
-	return genericMessage(ctx, sr, sr.SourceID, SourcesStatusTopic)
+	return genericMessage(ctx, sr, sr.ResourceID, SourcesStatusTopic)
 }


### PR DESCRIPTION
The source's status is not being updated to "Available" or  "Unavailable" 
According to sources [integrate with us](https://consoledot.pages.redhat.com/docs/dev/services/sources/integration.html#_work_on_our_side) documentation the resource type is supposed to be "Application" 