### PR TITLE
chore: run migrations for statuser

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -80,6 +80,12 @@ objects:
             image: ${IMAGE}:${IMAGE_TAG}
             command:
               - /pbstatuser
+            initContainers:
+              - name: run-migrations
+                image: "${IMAGE}:${IMAGE_TAG}"
+                command:
+                  - /pbmigrate
+                inheritEnv: true
             env:
               - name: LOGGING_LEVEL
                 value: ${LOGGING_LEVEL}


### PR DESCRIPTION
We run migrations when api and worker pods start up, but not when statuser pod starts up. This should fix this.

It looks like during todays redeplyoment, k8s started redeployment with statuser first leading to booting up our app with old database.