### PR TITLE
feat: minimal PoC Azure implementation

### DIFF
--- a/internal/clients/http/azure/azure_client.go
+++ b/internal/clients/http/azure/azure_client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
@@ -34,12 +35,20 @@ func newAzureClient(ctx context.Context, auth *clients.Authentication) (clients.
 	}, nil
 }
 
-func (c *client) newResourcesClient(ctx context.Context) (*armresources.Client, error) {
-	client, err := armresources.NewClient(c.subscriptionID, c.credential, nil)
+func (c *client) newResourceGroupsClient(ctx context.Context) (*armresources.ResourceGroupsClient, error) {
+	client, err := armresources.NewResourceGroupsClient(c.subscriptionID, c.credential, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create resources Azure client: %w", err)
 	}
 	return client, nil
+}
+
+func (c *client) newVirtualMachinesClient(ctx context.Context) (*armcompute.VirtualMachinesClient, error) {
+	vmClient, err := armcompute.NewVirtualMachinesClient(c.subscriptionID, c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create VM Azure client: %w", err)
+	}
+	return vmClient, nil
 }
 
 func (c *client) newSubscriptionsClient(ctx context.Context) (*armsubscriptions.Client, error) {
@@ -56,6 +65,46 @@ func (c *client) newSshKeysClient(ctx context.Context) (*armcompute.SSHPublicKey
 		return nil, fmt.Errorf("unable to create SSH keys Azure client: %w", err)
 	}
 	return client, nil
+}
+
+func (c *client) newVirtualNetworksClient(ctx context.Context) (*armnetwork.VirtualNetworksClient, error) {
+	vnetClient, err := armnetwork.NewVirtualNetworksClient(c.subscriptionID, c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create Virtual networks Azure client: %w", err)
+	}
+	return vnetClient, nil
+}
+
+func (c *client) newSubnetsClient(ctx context.Context) (*armnetwork.SubnetsClient, error) {
+	subnetClient, err := armnetwork.NewSubnetsClient(c.subscriptionID, c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create SSH keys Azure client: %w", err)
+	}
+	return subnetClient, nil
+}
+
+func (c *client) newPublicIPAddressesClient(ctx context.Context) (*armnetwork.PublicIPAddressesClient, error) {
+	publicIPAddressClient, err := armnetwork.NewPublicIPAddressesClient(c.subscriptionID, c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create public IP addresses Azure client: %w", err)
+	}
+	return publicIPAddressClient, nil
+}
+
+func (c *client) newSecurityGroupsClient(ctx context.Context) (*armnetwork.SecurityGroupsClient, error) {
+	nsgClient, err := armnetwork.NewSecurityGroupsClient(c.subscriptionID, c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create security groups Azure client: %w", err)
+	}
+	return nsgClient, nil
+}
+
+func (c *client) newInterfacesClient(ctx context.Context) (*armnetwork.InterfacesClient, error) {
+	nicClient, err := armnetwork.NewInterfacesClient(c.subscriptionID, c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create interfaces Azure client: %w", err)
+	}
+	return nicClient, nil
 }
 
 func (c *client) Status(ctx context.Context) error {

--- a/internal/clients/http/azure/create_vm.go
+++ b/internal/clients/http/azure/create_vm.go
@@ -1,0 +1,433 @@
+// strongly inspired by https://github.com/Azure-Samples/azure-sdk-for-go-samples/tree/main/sdk/resourcemanager/compute/create_vm
+// from commit 2ea51d9744d5d4680b4983b2e292a7b1d0085ff4
+
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+)
+
+var subscriptionId string
+
+const TraceName = "github.com/RHEnVision/provisioning-backend/internal/clients/http/azure"
+
+const (
+	resourceGroupName = "redhat-deployed"
+	vmName            = "redhat-vm"
+	vnetName          = "redhat-vnet"
+	subnetName        = "redhat-subnet"
+	nsgName           = "redhat-nsg"
+	nicName           = "redhat-nic"
+	diskName          = "redhat-disk"
+	publicIPName      = "redhat-public-ip"
+	location          = "eastus"
+	adminUsername     = "azureuser"
+	vpnIPAddress      = "172.22.0.0/16"
+)
+
+func (c *client) CreateVM(ctx context.Context, imageID string, pubkey *models.Pubkey, instanceType clients.InstanceTypeName) (*string, error) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "CreateVM")
+	defer span.End()
+
+	logger := logger(ctx)
+	logger.Debug().Msg("Creating Azure VM instance")
+
+	resourceGroup, err := c.getOrCreateResourceGroup(ctx, resourceGroupName, location)
+	if err != nil {
+		span.SetStatus(codes.Error, "cannot create resource group")
+		logger.Error().Err(err).Msgf("cannot create resource group")
+		return nil, err
+	}
+	logger.Trace().Msgf("Using resource group id=%s", *resourceGroup.ID)
+
+	virtualNetwork, err := c.createVirtualNetwork(ctx, resourceGroupName, vnetName)
+	if err != nil {
+		span.SetStatus(codes.Error, "cannot create virtual network")
+		logger.Error().Err(err).Msgf("cannot create virtual network")
+		return nil, err
+	}
+	logger.Trace().Msgf("Using virtual network id=%s", *virtualNetwork.ID)
+
+	subnet, err := c.createSubnets(ctx, resourceGroupName, vnetName, subnetName)
+	if err != nil {
+		span.SetStatus(codes.Error, "cannot create subnet")
+		logger.Error().Err(err).Msgf("cannot create subnet")
+		return nil, err
+	}
+	logger.Trace().Msgf("Using subnet id=%s", *subnet.ID)
+
+	publicIP, err := c.createPublicIP(ctx, location, resourceGroupName, publicIPName)
+	if err != nil {
+		span.SetStatus(codes.Error, "cannot create public IP address")
+		logger.Error().Err(err).Msgf("cannot create public IP address")
+		return nil, err
+	}
+	logger.Trace().Msgf("Using public IP address id=%s", *publicIP.ID)
+
+	// network security group
+	nsg, err := c.createNetworkSecurityGroup(ctx, location, resourceGroupName, nsgName)
+	if err != nil {
+		span.SetStatus(codes.Error, "cannot create network security group")
+		logger.Error().Err(err).Msgf("cannot create network security group")
+		return nil, err
+	}
+	logger.Trace().Msgf("Using network security group id=%s", *nsg.ID)
+
+	networkInterface, err := c.createNetworkInterface(ctx, location, resourceGroupName, subnet, publicIP, nsg, nicName)
+	if err != nil {
+		span.SetStatus(codes.Error, "cannot create network interface")
+		logger.Error().Err(err).Msgf("cannot create network interface")
+		return nil, err
+	}
+	logger.Trace().Msgf("Using network interface id=%s", *networkInterface.ID)
+
+	vmParams := c.prepareVirtualMachineParameters(location, armcompute.VirtualMachineSizeTypes(instanceType), networkInterface, imageID, pubkey.Body, diskName)
+	virtualMachine, err := c.createVirtualMachine(ctx, resourceGroupName, vmName, vmParams)
+	if err != nil {
+		span.SetStatus(codes.Error, "cannot create virtual machine")
+		logger.Error().Err(err).Msgf("cannot create virtual machine")
+		return nil, err
+	}
+	logger.Debug().Msgf("Created virtual machine id=%s", *virtualMachine.ID)
+
+	return virtualMachine.ID, nil
+}
+
+func (c *client) getOrCreateResourceGroup(ctx context.Context, name string, location string) (*armresources.ResourceGroup, error) {
+	resourceGroupClient, err := c.newResourceGroupsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := logger(ctx)
+	getResp, err := resourceGroupClient.Get(ctx, name, nil)
+	if err == nil {
+		return &getResp.ResourceGroup, nil
+	}
+	if err != nil {
+		var azErr *azcore.ResponseError
+		if errors.As(err, &azErr) && azErr.StatusCode == http.StatusNotFound {
+			logger.Debug().Msgf("resource group %s not found, creating", name)
+			// 404 is expected, continue
+		} else {
+			return nil, fmt.Errorf("failed to fetch resource group: %w", err)
+		}
+	}
+
+	parameters := armresources.ResourceGroup{
+		Location: ptr.To(location),
+		// TODO tag the resource group by some RH identifier
+		// Tags:     map[string]*string{"sample-rs-tag": ptr.To("sample-tag")}, // resource group update tags
+	}
+
+	resp, err := resourceGroupClient.CreateOrUpdate(ctx, name, parameters, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create resource group: %w", err)
+	}
+
+	return &resp.ResourceGroup, nil
+}
+
+func (c *client) createVirtualNetwork(ctx context.Context, resourceGroupName string, name string) (*armnetwork.VirtualNetwork, error) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "createVirtualNetwork")
+	defer span.End()
+
+	vnetClient, err := c.newVirtualNetworksClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := logger(ctx)
+	getResp, err := vnetClient.Get(ctx, resourceGroupName, name, nil)
+	if err == nil {
+		return &getResp.VirtualNetwork, nil
+	}
+	if err != nil {
+		var azErr *azcore.ResponseError
+		if errors.As(err, &azErr) && azErr.StatusCode == http.StatusNotFound {
+			logger.Debug().Msgf("virtual network %s not found, creating", name)
+			// 404 is expected, continue
+		} else {
+			return nil, fmt.Errorf("failed to fetch virtual network: %w", err)
+		}
+	}
+
+	parameters := armnetwork.VirtualNetwork{
+		Location: to.Ptr(location),
+		Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+			AddressSpace: &armnetwork.AddressSpace{
+				AddressPrefixes: []*string{
+					to.Ptr(vpnIPAddress),
+				},
+			},
+			//Subnets: []*armnetwork.Subnet{
+			//	{
+			//		Name: to.Ptr(subnetName+"3"),
+			//		Properties: &armnetwork.SubnetPropertiesFormat{
+			//			AddressPrefix: to.Ptr("10.1.0.0/24"),
+			//		},
+			//	},
+			//},
+		},
+	}
+
+	pollerResponse, err := vnetClient.BeginCreateOrUpdate(ctx, resourceGroupName, name, parameters, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create of virtual network failed to start: %w", err)
+	}
+
+	resp, err := pollerResponse.PollUntilDone(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll for create virtual network result: %w", err)
+	}
+
+	return &resp.VirtualNetwork, nil
+}
+
+func (c *client) createSubnets(ctx context.Context, resourceGroupName string, vnetName string, name string) (*armnetwork.Subnet, error) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "createSubnets")
+	defer span.End()
+
+	subnetClient, err := c.newSubnetsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	parameters := armnetwork.Subnet{
+		Properties: &armnetwork.SubnetPropertiesFormat{
+			// the subnet takes the full vpn address scope
+			AddressPrefix: to.Ptr(vpnIPAddress),
+		},
+	}
+
+	pollerResponse, err := subnetClient.BeginCreateOrUpdate(ctx, resourceGroupName, vnetName, name, parameters, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create of subnet failed to start: %w", err)
+	}
+
+	resp, err := pollerResponse.PollUntilDone(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll for create subnet result: %w", err)
+	}
+
+	return &resp.Subnet, nil
+}
+
+func (c *client) createPublicIP(ctx context.Context, location string, resourceGroupName string, name string) (*armnetwork.PublicIPAddress, error) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "createPublicIP")
+	defer span.End()
+
+	publicIPAddressClient, err := c.newPublicIPAddressesClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	parameters := armnetwork.PublicIPAddress{
+		Location: to.Ptr(location),
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic), // Static or Dynamic
+		},
+	}
+
+	pollerResponse, err := publicIPAddressClient.BeginCreateOrUpdate(ctx, resourceGroupName, name, parameters, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create of public IP address failed to start: %w", err)
+	}
+
+	resp, err := pollerResponse.PollUntilDone(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll for create public IP address result: %w", err)
+	}
+	return &resp.PublicIPAddress, nil
+}
+
+func (c *client) createNetworkSecurityGroup(ctx context.Context, location string, resourceGroupName string, name string) (*armnetwork.SecurityGroup, error) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "createNetworkSecurityGroup")
+	defer span.End()
+
+	nsgClient, err := c.newSecurityGroupsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	parameters := armnetwork.SecurityGroup{
+		Location: to.Ptr(location),
+		Properties: &armnetwork.SecurityGroupPropertiesFormat{
+			SecurityRules: []*armnetwork.SecurityRule{
+				// inbound
+				{
+					Name: to.Ptr("inbound_22"), //
+					Properties: &armnetwork.SecurityRulePropertiesFormat{
+						SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
+						SourcePortRange:          to.Ptr("*"),
+						DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
+						DestinationPortRange:     to.Ptr("22"),
+						Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+						Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+						Priority:                 to.Ptr[int32](100),
+						Description:              to.Ptr("network security group inbound port 22"),
+						Direction:                to.Ptr(armnetwork.SecurityRuleDirectionInbound),
+					},
+				},
+				// outbound
+				{
+					Name: to.Ptr("outbound_22"), //
+					Properties: &armnetwork.SecurityRulePropertiesFormat{
+						SourceAddressPrefix:      to.Ptr("0.0.0.0/0"),
+						SourcePortRange:          to.Ptr("*"),
+						DestinationAddressPrefix: to.Ptr("0.0.0.0/0"),
+						DestinationPortRange:     to.Ptr("22"),
+						Protocol:                 to.Ptr(armnetwork.SecurityRuleProtocolTCP),
+						Access:                   to.Ptr(armnetwork.SecurityRuleAccessAllow),
+						Priority:                 to.Ptr[int32](100),
+						Description:              to.Ptr("network security group outbound port 22"),
+						Direction:                to.Ptr(armnetwork.SecurityRuleDirectionOutbound),
+					},
+				},
+			},
+		},
+	}
+
+	pollerResponse, err := nsgClient.BeginCreateOrUpdate(ctx, resourceGroupName, name, parameters, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create of network security group failed to start: %w", err)
+	}
+
+	resp, err := pollerResponse.PollUntilDone(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll for create network security group result: %w", err)
+	}
+	return &resp.SecurityGroup, nil
+}
+
+func (c *client) createNetworkInterface(ctx context.Context, location string, resourceGroupName string, subnet *armnetwork.Subnet, publicIP *armnetwork.PublicIPAddress, nsg *armnetwork.SecurityGroup, name string) (*armnetwork.Interface, error) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "createNetworkInterface")
+	defer span.End()
+
+	nicClient, err := c.newInterfacesClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	parameters := armnetwork.Interface{
+		Location: to.Ptr(location),
+		Properties: &armnetwork.InterfacePropertiesFormat{
+			IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+				{
+					Name: to.Ptr("ipConfig"),
+					Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+						PrivateIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
+						Subnet: &armnetwork.Subnet{
+							ID: subnet.ID,
+						},
+						PublicIPAddress: &armnetwork.PublicIPAddress{
+							ID: publicIP.ID,
+						},
+					},
+				},
+			},
+			NetworkSecurityGroup: &armnetwork.SecurityGroup{
+				ID: nsg.ID,
+			},
+		},
+	}
+
+	pollerResponse, err := nicClient.BeginCreateOrUpdate(ctx, resourceGroupName, name, parameters, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create of network interface failed to start: %w", err)
+	}
+
+	resp, err := pollerResponse.PollUntilDone(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll for create network interface result: %w", err)
+	}
+
+	return &resp.Interface, nil
+}
+
+func (c *client) prepareVirtualMachineParameters(location string, instanceType armcompute.VirtualMachineSizeTypes, networkInterface *armnetwork.Interface, imageID string, sshKeyBody string, diskName string) *armcompute.VirtualMachine {
+	return &armcompute.VirtualMachine{
+		Location: to.Ptr(location),
+		Identity: &armcompute.VirtualMachineIdentity{
+			Type: to.Ptr(armcompute.ResourceIdentityTypeNone),
+		},
+		Properties: &armcompute.VirtualMachineProperties{
+			StorageProfile: &armcompute.StorageProfile{
+				ImageReference: &armcompute.ImageReference{
+					ID: ptr.To(imageID),
+				},
+				OSDisk: &armcompute.OSDisk{
+					Name:         to.Ptr(diskName),
+					CreateOption: to.Ptr(armcompute.DiskCreateOptionTypesFromImage),
+					Caching:      to.Ptr(armcompute.CachingTypesReadWrite),
+					ManagedDisk: &armcompute.ManagedDiskParameters{
+						StorageAccountType: to.Ptr(armcompute.StorageAccountTypesStandardLRS), // OSDisk type Standard/Premium HDD/SSD
+					},
+					// DiskSizeGB: to.Ptr[int32](100), // default 127G
+				},
+			},
+			HardwareProfile: &armcompute.HardwareProfile{
+				VMSize: to.Ptr(instanceType), // VM size include vCPUs,RAM,Data Disks,Temp storage.
+			},
+			OSProfile: &armcompute.OSProfile{ //
+				ComputerName:  to.Ptr(vmName),
+				AdminUsername: to.Ptr(adminUsername),
+				// require ssh key for authentication
+				LinuxConfiguration: &armcompute.LinuxConfiguration{
+					DisablePasswordAuthentication: to.Ptr(true),
+					SSH: &armcompute.SSHConfiguration{
+						PublicKeys: []*armcompute.SSHPublicKey{
+							{
+								Path:    to.Ptr(fmt.Sprintf("/home/%s/.ssh/authorized_keys", adminUsername)),
+								KeyData: to.Ptr(sshKeyBody),
+							},
+						},
+					},
+				},
+			},
+			NetworkProfile: &armcompute.NetworkProfile{
+				NetworkInterfaces: []*armcompute.NetworkInterfaceReference{
+					{
+						ID: networkInterface.ID,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (c *client) createVirtualMachine(ctx context.Context, resourceGroupName string, vmName string, parameters *armcompute.VirtualMachine) (*armcompute.VirtualMachine, error) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "createVirtualMachine")
+	defer span.End()
+
+	vmClient, err := c.newVirtualMachinesClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pollerResponse, err := vmClient.BeginCreateOrUpdate(ctx, resourceGroupName, vmName, *parameters, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create of virtual machine failed to start: %w", err)
+	}
+
+	resp, err := pollerResponse.PollUntilDone(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to poll for create virtual machine status: %w", err)
+	}
+
+	return &resp.VirtualMachine, nil
+}

--- a/internal/clients/http/azure/types/azure_types.go
+++ b/internal/clients/http/azure/types/azure_types.go
@@ -61,3 +61,7 @@ func InstanceTypesForZone(region, zone string, supported *bool) ([]*clients.Inst
 	}
 	return result, nil
 }
+
+func FindInstanceSize(name clients.InstanceTypeName) *clients.InstanceType {
+	return typeInfo.RegisteredTypes.Get(name)
+}

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -89,6 +89,12 @@ var GetServiceAzureClient func(ctx context.Context) (ServiceAzure, error)
 
 type Azure interface {
 	ClientStatuser
+
+	// CreateVM creates Azure virtual machine.
+	// Most of the parameters are constant for now.
+	// imageID is expected in format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageID}
+	// sshKeyBody should be full public key body
+	CreateVM(ctx context.Context, imageID string, pubkey *models.Pubkey, instanceType InstanceTypeName) (*string, error)
 }
 
 type ServiceAzure interface {

--- a/internal/clients/stubs/errors.go
+++ b/internal/clients/stubs/errors.go
@@ -4,5 +4,7 @@ import (
 	"errors"
 )
 
-var NotImplementedErr = errors.New("stub not yet implemented")
-var SourceAuthenticationNotFound = errors.New("stubbed authentication for source not found")
+var (
+	NotImplementedErr            = errors.New("stub not yet implemented")
+	SourceAuthenticationNotFound = errors.New("stubbed authentication for source not found")
+)

--- a/internal/clients/stubs/errors.go
+++ b/internal/clients/stubs/errors.go
@@ -1,5 +1,8 @@
 package stubs
 
-import "errors"
+import (
+	"errors"
+)
 
 var NotImplementedErr = errors.New("stub not yet implemented")
+var SourceAuthenticationNotFound = errors.New("stubbed authentication for source not found")

--- a/internal/clients/stubs/sources_stub.go
+++ b/internal/clients/stubs/sources_stub.go
@@ -87,10 +87,12 @@ func (stub *SourcesClientStub) GetAuthentication(ctx context.Context, sourceId s
 	if sourceId == "1" {
 		return clients.NewAuthentication("arn:aws:iam::230214684733:role/Test", models.ProviderTypeAWS), nil
 	}
-	if auth, ok := stub.auths[sourceId]; ok {
-		return auth, nil
+
+	auth, ok := stub.auths[sourceId]
+	if !ok {
+		return nil, SourceAuthenticationNotFound
 	}
-	return nil, SourceAuthenticationNotFound
+	return auth, nil
 }
 
 func (mock *SourcesClientStub) GetProvisioningTypeId(ctx context.Context) (string, error) {

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -57,6 +57,9 @@ type ReservationDao interface {
 	// CreateAWS creates AWS reservation with details in a single transaction.
 	CreateAWS(ctx context.Context, reservation *models.AWSReservation) error
 
+	// CreateAzure creates Azure reservation with details in a single transaction.
+	CreateAzure(ctx context.Context, reservation *models.AzureReservation) error
+
 	// CreateGCP creates GCP reservation with details in a single transaction.
 	CreateGCP(ctx context.Context, reservation *models.GCPReservation) error
 
@@ -68,6 +71,9 @@ type ReservationDao interface {
 
 	// GetAWSById returns reservation for a particular account.
 	GetAWSById(ctx context.Context, id int64) (*models.AWSReservation, error)
+
+	// GetAzureById returns Azure reservation for a given id.
+	GetAzureById(ctx context.Context, id int64) (*models.AzureReservation, error)
 
 	// List returns reservation for a particular account.
 	List(ctx context.Context, limit, offset int64) ([]*models.Reservation, error)

--- a/internal/dao/stubs/context_getters.go
+++ b/internal/dao/stubs/context_getters.go
@@ -43,7 +43,7 @@ func WithReservationDao(parent context.Context) context.Context {
 		panic(dao.ErrStubContextAlreadySet)
 	}
 
-	ctx := context.WithValue(parent, reservationCtxKey, &reservationDaoStub{lastId: 0, storeAWS: []*models.AWSReservation{}})
+	ctx := context.WithValue(parent, reservationCtxKey, &reservationDaoStub{})
 	return ctx
 }
 

--- a/internal/dao/stubs/reservation_dao.go
+++ b/internal/dao/stubs/reservation_dao.go
@@ -9,17 +9,22 @@ import (
 )
 
 type reservationDaoStub struct {
-	lastId   int64
-	storeAWS []*models.AWSReservation
+	storeAWS   []*models.AWSReservation
+	storeAzure []*models.AzureReservation
 }
 
 func init() {
 	dao.GetReservationDao = getReservationDao
 }
 
-func ReservationStubCount(ctx context.Context) int {
-	pkdao := getReservationDaoStub(ctx)
-	return len(pkdao.storeAWS)
+func AWSReservationStubCount(ctx context.Context) int {
+	resDao := getReservationDaoStub(ctx)
+	return len(resDao.storeAWS)
+}
+
+func AzureReservationStubCount(ctx context.Context) int {
+	resDao := getReservationDaoStub(ctx)
+	return len(resDao.storeAzure)
 }
 
 func getReservationDao(ctx context.Context) dao.ReservationDao {
@@ -27,9 +32,14 @@ func getReservationDao(ctx context.Context) dao.ReservationDao {
 }
 
 func (stub *reservationDaoStub) CreateAWS(ctx context.Context, reservation *models.AWSReservation) error {
-	reservation.ID = stub.lastId + 1
+	reservation.ID = int64(len(stub.storeAWS)) + 1
 	stub.storeAWS = append(stub.storeAWS, reservation)
-	stub.lastId++
+	return nil
+}
+
+func (stub *reservationDaoStub) CreateAzure(ctx context.Context, reservation *models.AzureReservation) error {
+	reservation.ID = int64(len(stub.storeAzure)) + 1
+	stub.storeAzure = append(stub.storeAzure, reservation)
 	return nil
 }
 
@@ -58,6 +68,15 @@ func (stub *reservationDaoStub) GetAWSById(ctx context.Context, id int64) (*mode
 	for _, awsReservation := range stub.storeAWS {
 		if awsReservation.AccountID == ctxAccountId(ctx) && awsReservation.ID == id {
 			return awsReservation, nil
+		}
+	}
+	return nil, dao.ErrNoRows
+}
+
+func (stub *reservationDaoStub) GetAzureById(ctx context.Context, id int64) (*models.AzureReservation, error) {
+	for _, azureReservation := range stub.storeAzure {
+		if azureReservation.AccountID == ctxAccountId(ctx) && azureReservation.ID == id {
+			return azureReservation, nil
 		}
 	}
 	return nil, dao.ErrNoRows

--- a/internal/jobs/job_types.go
+++ b/internal/jobs/job_types.go
@@ -3,7 +3,8 @@ package jobs
 import "github.com/RHEnVision/provisioning-backend/pkg/worker"
 
 const (
-	TypeNoop              worker.JobType = "no_operation"
-	TypeLaunchInstanceAws worker.JobType = "launch_instances_aws"
-	TypeLaunchInstanceGcp worker.JobType = "launch_instances_gcp"
+	TypeNoop                worker.JobType = "no_operation"
+	TypeLaunchInstanceAws   worker.JobType = "launch_instances_aws"
+	TypeLaunchInstanceAzure worker.JobType = "launch_instances_azure"
+	TypeLaunchInstanceGcp   worker.JobType = "launch_instances_gcp"
 )

--- a/internal/jobs/launch_instance_azure.go
+++ b/internal/jobs/launch_instance_azure.go
@@ -1,0 +1,92 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/pkg/worker"
+)
+
+type LaunchInstanceAzureTaskArgs struct {
+	// Associated reservation
+	ReservationID int64
+
+	// Location to provision the instances into
+	Location string
+
+	// Associated public key
+	PubkeyID int64
+
+	// SourceID that was used to get the Subscription
+	SourceID string
+
+	// AzureImageID as fetched from image builder
+	AzureImageID string
+
+	// The Subscription fetched from Sources which is linked to a specific source
+	Subscription *clients.Authentication
+}
+
+func HandleLaunchInstanceAzure(ctx context.Context, job *worker.Job) {
+	args, ok := job.Args.(LaunchInstanceAzureTaskArgs)
+	if !ok {
+		ctxval.Logger(ctx).Error().Msgf("Type assertion error for job %s, unable to finish reservation: %#v", job.ID, job.Args)
+		return
+	}
+
+	logger := ctxval.Logger(ctx).With().Int64("reservation_id", args.ReservationID).Logger()
+	ctx = ctxval.WithLogger(ctx, &logger)
+
+	jobErr := DoLaunchInstanceAzure(ctx, &args)
+
+	finishJob(ctx, args.ReservationID, jobErr)
+}
+
+func DoLaunchInstanceAzure(ctx context.Context, args *LaunchInstanceAzureTaskArgs) error {
+	logger := ctxval.Logger(ctx)
+	logger.Debug().Msg("Started launch instance Azure job")
+
+	// status updates before and after the code logic
+	updateStatusBefore(ctx, args.ReservationID, "Launching instance(s)")
+	defer updateStatusAfter(ctx, args.ReservationID, "Launched instance(s)", 1)
+
+	pkDao := dao.GetPubkeyDao(ctx)
+	resDao := dao.GetReservationDao(ctx)
+
+	pubkey, err := pkDao.GetById(ctx, args.PubkeyID)
+	if err != nil {
+		return fmt.Errorf("cannot get public key by id: %w", err)
+	}
+
+	reservation, err := resDao.GetAzureById(ctx, args.ReservationID)
+	if err != nil {
+		return fmt.Errorf("cannot get azure reservation by id: %w", err)
+	}
+
+	azureClient, err := clients.GetAzureClient(ctx, args.Subscription)
+	if err != nil {
+		return fmt.Errorf("cannot create new Azure client: %w", err)
+	}
+
+	// TODO create multiple
+	instanceId, err := azureClient.CreateVM(ctx, args.AzureImageID, pubkey, clients.InstanceTypeName(reservation.Detail.InstanceSize))
+	if err != nil {
+		return fmt.Errorf("cannot create Azure instance(s): %w", err)
+	}
+	err = resDao.CreateInstance(ctx, &models.ReservationInstance{
+		ReservationID: args.ReservationID,
+		InstanceID:    *instanceId,
+	})
+	if err != nil {
+		return fmt.Errorf("cannot create instance reservation for id %d: %w", instanceId, err)
+	}
+	logger.Debug().Msgf("Created new instance (%s) via Azure CreateVM", *instanceId)
+
+	logger.Debug().Msg("Finished launch instance Azure job")
+
+	return nil
+}

--- a/internal/migrations/sql/017_create_azure_reservation_details.sql
+++ b/internal/migrations/sql/017_create_azure_reservation_details.sql
@@ -1,0 +1,14 @@
+
+CREATE TABLE azure_reservation_details
+(
+  reservation_id BIGINT NOT NULL,
+  provider_fk INTEGER NOT NULL DEFAULT provider_type_azure(),
+  pubkey_id BIGINT NOT NULL REFERENCES pubkeys(id),
+  source_id TEXT NOT NULL,
+  image_id TEXT NOT NULL,
+  detail JSONB,
+
+  FOREIGN KEY (reservation_id, provider_fk) REFERENCES reservations(id, provider) ON DELETE CASCADE,
+  CHECK (provider_fk = provider_type_azure())
+);
+

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -123,6 +123,38 @@ type GCPReservation struct {
 	Detail *GCPDetail `db:"detail" json:"detail"`
 }
 
+type AzureDetail struct {
+	Location string `json:"location"`
+
+	// Instance name
+	Name string `json:"name"`
+
+	// InstanceSize of Azure VM.
+	InstanceSize string `json:"instance_size"`
+
+	// Amount of instances to provision of type: Instance type.
+	Amount int64 `json:"amount"`
+
+	// Immediately power off the system after initialization
+	PowerOff bool `json:"poweroff"`
+}
+
+type AzureReservation struct {
+	Reservation
+
+	// Pubkey ID.
+	PubkeyID int64 `db:"pubkey_id" json:"pubkey_id"`
+
+	// Source ID.
+	SourceID string `db:"source_id" json:"source_id"`
+
+	// The ID of the image from which the instance is created.
+	ImageID string `json:"image_id"`
+
+	// Detail information is stored as JSON in DB
+	Detail *AzureDetail `db:"detail" json:"detail"`
+}
+
 type ReservationInstance struct {
 	// Reservation ID.
 	ReservationID int64 `db:"reservation_id" json:"reservation_id"`

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -76,6 +76,35 @@ type AWSReservationResponsePayload struct {
 	Instances []string `json:"instances,omitempty"`
 }
 
+type AzureReservationResponsePayload struct {
+	ID int64 `json:"reservation_id"`
+
+	PubkeyID int64 `json:"pubkey_id"`
+
+	SourceID string `json:"source_id"`
+
+	// Azure Location.
+	Location string `json:"location"`
+
+	// Azure Instance size.
+	InstanceSize string `json:"instance_size"`
+
+	// Amount of instances to provision of type: Instance type.
+	Amount int64 `json:"amount"`
+
+	// The ID of the image from which the instance is created.
+	ImageID string `json:"image_id"`
+
+	// Optional name of the instance(s).
+	Name string `json:"name"`
+
+	// Immediately PowerOff the system after initialization.
+	PowerOff bool `json:"poweroff"`
+
+	// Instances IDs, only present for finished reservations.
+	Instances []string `json:"instances,omitempty"`
+}
+
 type GCPReservationResponsePayload struct {
 	ID int64 `json:"reservation_id"`
 
@@ -134,6 +163,30 @@ type AWSReservationRequestPayload struct {
 	PowerOff bool `json:"poweroff"`
 }
 
+type AzureReservationRequestPayload struct {
+	PubkeyID int64 `json:"pubkey_id"`
+
+	SourceID string `json:"source_id"`
+
+	// Image Builder UUID of the image that should be launched. This can be directly Azure image ID.
+	ImageID string `json:"image_id"`
+
+	// Azure Location to deploy into.
+	Location string `json:"location"`
+
+	// Azure Instance type.
+	InstanceSize string `json:"instance_size"`
+
+	// Amount of instances to provision of size: InstanceSize.
+	Amount int64 `json:"amount"`
+
+	// Name of the instance(s).
+	Name string `json:"name"`
+
+	// Immediately power off the system after initialization.
+	PowerOff bool `json:"poweroff"`
+}
+
 type GCPReservationRequestPayload struct {
 	// Pubkey ID.
 	PubkeyID int64 `json:"pubkey_id"`
@@ -153,7 +206,7 @@ type GCPReservationRequestPayload struct {
 	// Image Builder UUID of the image that should be launched.
 	ImageID string `json:"image_id"`
 
-	// Immediately power off the system after initialization
+	// Immediately power off the system after initialization.
 	PowerOff bool `json:"poweroff"`
 }
 
@@ -166,6 +219,14 @@ func (p *AWSReservationRequestPayload) Bind(_ *http.Request) error {
 }
 
 func (p *AWSReservationResponsePayload) Render(_ http.ResponseWriter, _ *http.Request) error {
+	return nil
+}
+
+func (p *AzureReservationRequestPayload) Bind(_ *http.Request) error {
+	return nil
+}
+
+func (p *AzureReservationResponsePayload) Render(_ http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
 
@@ -205,6 +266,27 @@ func NewAWSReservationResponse(reservation *models.AWSReservation, instances []*
 	}
 	if reservation.AWSReservationID != nil {
 		response.AWSReservationID = *reservation.AWSReservationID
+	}
+	return &response
+}
+
+func NewAzureReservationResponse(reservation *models.AzureReservation, instances []*models.ReservationInstance) render.Renderer {
+	instanceIds := make([]string, len(instances))
+	for iter, inst := range instances {
+		instanceIds[iter] = inst.InstanceID
+	}
+
+	response := AzureReservationResponsePayload{
+		PubkeyID:     reservation.PubkeyID,
+		ImageID:      reservation.ImageID,
+		SourceID:     reservation.SourceID,
+		Location:     reservation.Detail.Location,
+		Amount:       reservation.Detail.Amount,
+		InstanceSize: reservation.Detail.InstanceSize,
+		ID:           reservation.ID,
+		Name:         reservation.Detail.Name,
+		PowerOff:     reservation.Detail.PowerOff,
+		Instances:    instanceIds,
 	}
 	return &response
 }

--- a/internal/queue/jq/worker.go
+++ b/internal/queue/jq/worker.go
@@ -29,6 +29,7 @@ func RegisterJobs(logger *zerolog.Logger) {
 	logger.Debug().Msg("Registering job queue handlers and interfaces")
 	workers.RegisterHandler(jobs.TypeNoop, jobs.HandleNoop, jobs.NoopJobArgs{})
 	workers.RegisterHandler(jobs.TypeLaunchInstanceAws, jobs.HandleLaunchInstanceAWS, jobs.LaunchInstanceAWSTaskArgs{})
+	workers.RegisterHandler(jobs.TypeLaunchInstanceAzure, jobs.HandleLaunchInstanceAzure, jobs.LaunchInstanceAzureTaskArgs{})
 	workers.RegisterHandler(jobs.TypeLaunchInstanceGcp, jobs.HandleLaunchInstanceGCP, jobs.LaunchInstanceGCPTaskArgs{})
 }
 

--- a/internal/services/azure_reservation_service.go
+++ b/internal/services/azure_reservation_service.go
@@ -1,0 +1,133 @@
+package services
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/clients/http/azure/types"
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/RHEnVision/provisioning-backend/internal/jobs"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+	"github.com/RHEnVision/provisioning-backend/internal/queue"
+	"github.com/RHEnVision/provisioning-backend/pkg/worker"
+	"github.com/go-chi/render"
+)
+
+func CreateAzureReservation(w http.ResponseWriter, r *http.Request) {
+	logger := *ctxval.Logger(r.Context())
+
+	payload := &payloads.AzureReservationRequestPayload{}
+	if err := render.Bind(r, payload); err != nil {
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Azure reservation", err))
+		return
+	}
+
+	pkDao := dao.GetPubkeyDao(r.Context())
+	rDao := dao.GetReservationDao(r.Context())
+
+	// validate pubkey
+	logger.Debug().Msgf("Validating existence of pubkey %d for this account", payload.PubkeyID)
+	pk, err := pkDao.GetById(r.Context(), payload.PubkeyID)
+	if err != nil {
+		message := fmt.Sprintf("get pubkey with id %d", payload.PubkeyID)
+		renderNotFoundOrDAOError(w, r, err, message)
+		return
+	}
+	logger.Debug().Msgf("Found pubkey %d named '%s'", pk.ID, pk.Name)
+
+	// Get Sources client
+	sourcesClient, err := clients.GetSourcesClient(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	// Fetch SubscriptionID from Sources
+	authentication, err := sourcesClient.GetAuthentication(r.Context(), payload.SourceID)
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	if typeErr := authentication.MustBe(models.ProviderTypeAzure); typeErr != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), typeErr))
+		return
+	}
+
+	var azureImageID string
+	if strings.HasPrefix(payload.ImageID, "/subscriptions/") {
+		// Direct AMI ID was provided, no need to call image builder
+		azureImageID = payload.ImageID
+	} else {
+		// TODO fetch image ID from Image Builder
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "fetching Azure image id from Image Builder is not implemented", ProviderTypeNotImplementedError))
+		return
+	}
+
+	supportedArch := "x86_64"
+	it := types.FindInstanceSize(clients.InstanceTypeName(payload.InstanceSize))
+	if it == nil {
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), fmt.Sprintf("unknown instance size: %s", payload.InstanceSize), UnknownInstanceTypeNameError))
+		return
+	}
+	if it.Architecture.String() != supportedArch {
+		renderError(w, r, payloads.NewWrongArchitectureUserError(r.Context(), ArchitectureMismatch))
+		return
+	}
+
+	name := config.Application.InstancePrefix + payload.Name
+	detail := &models.AzureDetail{
+		Location:     payload.Location,
+		InstanceSize: payload.InstanceSize,
+		Amount:       payload.Amount,
+		PowerOff:     payload.PowerOff,
+		Name:         name,
+	}
+	reservation := &models.AzureReservation{
+		PubkeyID: payload.PubkeyID,
+		SourceID: payload.SourceID,
+		ImageID:  payload.ImageID,
+		Detail:   detail,
+	}
+	reservation.Steps = 1
+	reservation.StepTitles = []string{"Launch instance(s)"}
+
+	// create reservation in the database
+	err = rDao.CreateAzure(r.Context(), reservation)
+	if err != nil {
+		renderError(w, r, payloads.NewDAOError(r.Context(), "create Azure reservation", err))
+		return
+	}
+	logger.Debug().Msgf("Created a new reservation %d", reservation.ID)
+
+	launchJob := worker.Job{
+		Type:      jobs.TypeLaunchInstanceAzure,
+		Identity:  ctxval.Identity(r.Context()),
+		AccountID: ctxval.AccountId(r.Context()),
+		Args: jobs.LaunchInstanceAzureTaskArgs{
+			ReservationID: reservation.ID,
+			Location:      reservation.Detail.Location,
+			PubkeyID:      pk.ID,
+			SourceID:      reservation.SourceID,
+			AzureImageID:  azureImageID,
+			Subscription:  authentication,
+		},
+	}
+
+	err = queue.GetEnqueuer().Enqueue(r.Context(), &launchJob)
+	if err != nil {
+		renderError(w, r, payloads.NewEnqueueTaskError(r.Context(), "job enqueue error", err))
+		return
+	}
+
+	// Return response payload
+	unused := make([]*models.ReservationInstance, 0, 0)
+	if err = render.Render(w, r, payloads.NewAzureReservationResponse(reservation, unused)); err != nil {
+		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render Azure reservation", err))
+	}
+}

--- a/internal/services/instance_types_service_test.go
+++ b/internal/services/instance_types_service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/dao/stubs"
 	"github.com/RHEnVision/provisioning-backend/internal/services"
 	"github.com/RHEnVision/provisioning-backend/internal/testing/identity"
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,6 +27,9 @@ func TestListInstanceTypesHandler(t *testing.T) {
 		ctx = clientStub.WithSourcesClient(ctx)
 		ctx = clientStub.WithEC2Client(ctx)
 
+		rctx := chi.NewRouteContext()
+		ctx = context.WithValue(ctx, chi.RouteCtxKey, rctx)
+		rctx.URLParams.Add("ID", "1")
 		req, err := http.NewRequestWithContext(ctx, "GET", "/api/provisioning/sources/1/instance_types?region=us-east-1", nil)
 		require.NoError(t, err, "failed to create request")
 

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -34,7 +34,11 @@ func CreateReservation(w http.ResponseWriter, r *http.Request) {
 	case models.ProviderTypeAWS:
 		CreateAWSReservation(w, r)
 	case models.ProviderTypeAzure:
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "azure reservation is not implemented", ProviderTypeNotImplementedError))
+		if config.FeatureEnabled(r.Context(), "azure") {
+			CreateAzureReservation(w, r)
+		} else {
+			renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "azure reservation is not implemented", ProviderTypeNotImplementedError))
+		}
 	case models.ProviderTypeGCP:
 		CreateGCPReservation(w, r)
 	case models.ProviderTypeUnknown:

--- a/scripts/rest_examples/reservation-create-azure.http
+++ b/scripts/rest_examples/reservation-create-azure.http
@@ -1,0 +1,14 @@
+// @no-log
+POST http://{{hostname}}:{{port}}/{{prefix}}/reservations/azure HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}
+
+{
+  "name": "azure-linux-us-east",
+  "source_id": "5",
+  "image_id": "/subscriptions/4b9d213f-712f-4d17-a483-8a10bbe9df3a/resourceGroups/oezr/providers/Microsoft.Compute/images/composer-api-00e391e7-e6c8-4283-b94a-ea719a58bc05",
+  "amount": 1,
+  "instance_size": "Standard_B1ls",
+  "pubkey_id": 2,
+  "poweroff": true
+}


### PR DESCRIPTION
Implements Azure client minimal version of CreateVM with most values staticly defined. Implements direct call from a service to the Azure client, which bypasses the job, which will need to be defined in followup.

Refs HMS-1058