### PR TITLE
chore: fix padding and job pointer to body

### DIFF
--- a/internal/db/seeds/dev_small.sql
+++ b/internal/db/seeds/dev_small.sql
@@ -16,7 +16,7 @@ INSERT INTO pubkeys(id, account_id, name, body, type, fingerprint, fingerprint_l
 VALUES (1, 3, 'lzap-ed25519-2021',
         'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEhnn80ZywmjeBFFOGm+cm+5HUwm62qTVnjKlOdYFLHN lzap',
         'ssh-ed25519',
-        'gL/y6MvNmJ8jDXtsL/oMmK8jUuIefN39BBuvYw/Rndk',
+        'gL/y6MvNmJ8jDXtsL/oMmK8jUuIefN39BBuvYw/Rndk=',
         '89:c5:99:b5:33:48:1c:84:be:da:cb:97:45:b0:4a:ee')
 ON CONFLICT DO NOTHING;
 

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -125,7 +125,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 
 	launchJob := worker.Job{
 		Type: jobs.TypeLaunchInstanceAws,
-		Args: &jobs.LaunchInstanceAWSTaskArgs{
+		Args: jobs.LaunchInstanceAWSTaskArgs{
 			AccountID:     accountId,
 			ReservationID: reservation.ID,
 			Region:        reservation.Detail.Region,

--- a/internal/services/gcp_reservation_service.go
+++ b/internal/services/gcp_reservation_service.go
@@ -104,7 +104,7 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 
 	launchJob := worker.Job{
 		Type: jobs.TypeLaunchInstanceGcp,
-		Args: &jobs.LaunchInstanceGCPTaskArgs{
+		Args: jobs.LaunchInstanceGCPTaskArgs{
 			AccountID:     accountId,
 			ReservationID: reservation.ID,
 			Zone:          reservation.Detail.Zone,


### PR DESCRIPTION
Turns out that arguments must not be pointer because then the type assertion will fail when memory implementation is used:

https://github.com/RHEnVision/provisioning-backend/blob/main/internal/jobs/launch_instance_aws.go#L46-L50

For redis implementation it worked because gob decoder dereferences pointers.

Also added a missing padding in the dev seed script in another commit.

Both changes does not affect stage/prod it was a problem in local development mode (memory only job queue), therefore, I am not creating an issue.