### PR TITLE
feat(HMSPROV-1133): add ec2 instance description endpoint

### DIFF
--- a/internal/clients/instance_description.go
+++ b/internal/clients/instance_description.go
@@ -1,0 +1,13 @@
+package clients
+
+// InstanceInfo defines a model for an instance description
+type InstanceDescription struct {
+	// The id of the instance
+	ID *string `json:"id,omitempty" yaml:"id"`
+
+	// The public ipv4 dns of the instance
+	DNS *string `json:"dns,omitempty" yaml:"dns"`
+
+	// the public ipv4 of the instance
+	IPV4 *string `json:"ipv4,omitempty" yaml:"ipv4"`
+}

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -79,6 +79,8 @@ type EC2 interface {
 	RunInstances(ctx context.Context, name *string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error)
 
 	GetAccountId(ctx context.Context) (string, error)
+
+	ListInstancesDescription(ctx context.Context, InstanceIds []string) ([]*InstanceDescription, error)
 }
 
 // GetAzureClient returns an Azure client with customer's subscription ID.

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -149,3 +149,16 @@ func (mock *EC2ClientStub) RunInstances(ctx context.Context, name *string, amoun
 func (mock *EC2ClientStub) GetAccountId(ctx context.Context) (string, error) {
 	return "", nil
 }
+
+func (mock *EC2ClientStub) ListInstancesDescription(ctx context.Context, InstanceIds []string) ([]*clients.InstanceDescription, error) {
+	id := "i-0a4caa2cf5b097ce1"
+	dns := "ec2-51-83-81-17.compute-1.amazonaws.com"
+	ip := "54.11.88.17"
+	return []*clients.InstanceDescription{
+		{
+			ID:   &id,
+			DNS:  &dns,
+			IPV4: &ip,
+		},
+	}, nil
+}

--- a/internal/payloads/instance_description_payload.go
+++ b/internal/payloads/instance_description_payload.go
@@ -1,0 +1,28 @@
+package payloads
+
+import (
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/go-chi/render"
+)
+
+type InstanceDescriptionResponse struct {
+	*clients.InstanceDescription
+}
+
+func (s *InstanceDescriptionResponse) Bind(_ *http.Request) error {
+	return nil
+}
+
+func (s *InstanceDescriptionResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
+	return nil
+}
+
+func NewListInstanceDescriptionResponse(instances []*clients.InstanceDescription) []render.Renderer {
+	list := make([]render.Renderer, len(instances))
+	for i, instance := range instances {
+		list[i] = &InstanceDescriptionResponse{instance}
+	}
+	return list
+}

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -79,8 +79,11 @@ func MountAPI(r *chi.Mux) {
 			// Different types do have different payloads, therefore TYPE must be part of
 			// URL and not a URL (filter) parameter.
 			r.Route("/{TYPE}", func(r chi.Router) {
-				r.Get("/{ID}", s.GetReservationDetail)
 				r.Post("/", s.CreateReservation)
+				r.Route("/{ID}", func(r chi.Router) {
+					r.Get("/", s.GetReservationDetail)
+					r.Get("/instances", s.ListInstancesDescription)
+				})
 			})
 			// Generic reservation detail request (no details provided)
 			r.Get("/{ID}", s.GetReservationDetail)

--- a/internal/services/instance_description_service.go
+++ b/internal/services/instance_description_service.go
@@ -1,0 +1,87 @@
+package services
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+	"github.com/go-chi/render"
+)
+
+func ListInstancesDescription(w http.ResponseWriter, r *http.Request) {
+	id, err := ParseInt64(r, "ID")
+	if err != nil {
+		renderError(w, r, payloads.NewURLParsingError(r.Context(), "unable to parse ID parameter", err))
+		return
+	}
+
+	rDao := dao.GetReservationDao(r.Context())
+	reservation, err := rDao.GetById(r.Context(), id)
+	if err != nil {
+		renderNotFoundOrDAOError(w, r, err, "get reservation detail")
+		return
+	}
+
+	switch reservation.Provider {
+	case models.ProviderTypeUnknown, models.ProviderTypeNoop:
+		if err := render.Render(w, r, payloads.NewReservationResponse(reservation)); err != nil {
+			renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render reservation", err))
+		}
+	case models.ProviderTypeAWS:
+		// TODO: move to aws_instance_description service
+		reservation, err := rDao.GetAWSById(r.Context(), id)
+		if err != nil {
+			message := fmt.Sprintf("get AWS reservation with id %d", id)
+			renderNotFoundOrDAOError(w, r, err, message)
+			return
+		}
+		instances, err := rDao.ListInstances(r.Context(), id)
+		if err != nil {
+			message := fmt.Sprintf("get reservation with id id %d", id)
+			renderNotFoundOrDAOError(w, r, err, message)
+			return
+		}
+
+		sourcesClient, err := clients.GetSourcesClient(r.Context())
+		if err != nil {
+			renderError(w, r, payloads.NewClientError(r.Context(), err))
+			return
+		}
+
+		authentication, err := sourcesClient.GetAuthentication(r.Context(), reservation.SourceID)
+		if err != nil {
+			renderError(w, r, payloads.NewClientError(r.Context(), err))
+			return
+		}
+
+		ec2Client, err := clients.GetEC2Client(r.Context(), authentication, "")
+		if err != nil {
+			renderError(w, r, payloads.NewAWSError(r.Context(), "unable to get AWS EC2 client", err))
+			return
+		}
+		instancesIDList := make([]string, len(instances))
+		for i, instance := range instances {
+			instancesIDList[i] = instance.InstanceID
+		}
+
+		instancesDescriptionList, err := ec2Client.ListInstancesDescription(r.Context(), instancesIDList)
+		if err != nil {
+			renderError(w, r, payloads.NewAWSError(r.Context(), "unable to get list of instance description", err))
+			return
+		}
+
+		if err := render.RenderList(w, r, payloads.NewListInstanceDescriptionResponse(instancesDescriptionList)); err != nil {
+			renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render instance description", err))
+			return
+		}
+	case models.ProviderTypeAzure:
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "azure instance description is not implemented", ProviderTypeNotImplementedError))
+	case models.ProviderTypeGCP:
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "gcp instance description is not implemented", ProviderTypeNotImplementedError))
+	default:
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", ProviderTypeNotImplementedError))
+	}
+}


### PR DESCRIPTION
This PR adds  `DescribeInstances` to ec2 client and a corresponding endpont, in order to fetch further information after a successful launch. used here - https://github.com/RHEnVision/provisioning-frontend/pull/188

