### PR TITLE
Improve logging statuser

### DIFF
--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -39,7 +39,7 @@ const ChannelBuffer = 32
 type SourceInfo struct {
 	Authentication clients.Authentication
 
-	SourceApplictionID string
+	SourceApplicationID string
 
 	Identity identity.XRHID
 }
@@ -85,9 +85,9 @@ func processMessage(ctx context.Context, message *kafka.GenericMessage) {
 	}
 
 	s := SourceInfo{
-		Authentication:     *authentication,
-		SourceApplictionID: authentication.SourceApplictionID,
-		Identity:           ctxval.Identity(ctx),
+		Authentication:      *authentication,
+		SourceApplicationID: authentication.SourceApplictionID,
+		Identity:            ctxval.Identity(ctx),
 	}
 
 	switch authentication.ProviderType {
@@ -110,7 +110,7 @@ func checkSourceAvailabilityAzure(ctx context.Context) {
 		metrics.ObserveAvailablilityCheckReqsDuration(models.ProviderTypeAzure, func() error {
 			var err error
 			sr := kafka.SourceResult{
-				ResourceID:   s.SourceApplictionID,
+				ResourceID:   s.SourceApplicationID,
 				Identity:     s.Identity,
 				ResourceType: "Application",
 			}
@@ -132,7 +132,7 @@ func checkSourceAvailabilityAWS(ctx context.Context) {
 		metrics.ObserveAvailablilityCheckReqsDuration(models.ProviderTypeAWS, func() error {
 			var err error
 			sr := kafka.SourceResult{
-				ResourceID:   s.SourceApplictionID,
+				ResourceID:   s.SourceApplicationID,
 				Identity:     s.Identity,
 				ResourceType: "Application",
 			}
@@ -160,7 +160,7 @@ func checkSourceAvailabilityGCP(ctx context.Context) {
 		metrics.ObserveAvailablilityCheckReqsDuration(models.ProviderTypeGCP, func() error {
 			var err error
 			sr := kafka.SourceResult{
-				ResourceID:   s.SourceApplictionID,
+				ResourceID:   s.SourceApplicationID,
 				Identity:     s.Identity,
 				ResourceType: "Application",
 			}

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/random"
 	"github.com/RHEnVision/provisioning-backend/internal/version"
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/protocol"
 	"github.com/segmentio/kafka-go/sasl"
 	"github.com/segmentio/kafka-go/sasl/plain"
 	"github.com/segmentio/kafka-go/sasl/scram"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type kafkaBroker struct {
@@ -200,10 +202,26 @@ func (b *kafkaBroker) Consume(ctx context.Context, topic string, since time.Time
 		} else {
 			logger.Trace().Bytes("payload", msg.Value).Msgf("Received message with key: %s, topic: %s, offset: %d, partition: %d",
 				msg.Key, msg.Topic, msg.Offset, msg.Partition)
+
+			// build new context - identity and trace id
 			ctx, err = ctxval.WithIdentityFrom64(ctx, header("x-rh-identity", msg.Headers))
 			if err != nil {
 				logger.Trace().Msgf("Could not extract identity from context to Kafka message: %s", err)
 			}
+			identity := ctxval.Identity(ctx)
+
+			traceId := trace.SpanFromContext(ctx).SpanContext().TraceID()
+			if !traceId.IsValid() {
+				traceId = random.TraceID()
+			}
+			ctx = ctxval.WithTraceId(ctx, traceId.String())
+
+			newLogger := logger.With().
+				Str("trace_id", traceId.String()).
+				Str("account_number", identity.Identity.AccountNumber).
+				Str("org_id", identity.Identity.OrgID).Logger()
+			ctx = ctxval.WithLogger(ctx, &newLogger)
+
 			handler(ctx, NewMessageFromKafka(&msg))
 		}
 	}


### PR DESCRIPTION
When I was searching in logs today I noticed that the statuser do not have account information for each log. Also it is missing any correlation id. So this patch adds that, also, when I was on that I also add source_id too so we can easily search for availability checks per source id.

In a separate patch, I noticed a typo in a variable name. Example log session:

```
9:25AM TRC Received message with key: 1, topic: platform.provisioning.internal.availability-check, offset: 0, partition: 0 binary=pbstatuser hostname=mone.home.lan payload="{\"source_id\":\"1\"}" version=HEAD
9:25AM TRC Getting authentication from source 1 account_number=6395343 binary=pbstatuser client=sources hostname=mone.home.lan org_id=13446659 source_id=1 trace_id=52fdfc072182654f163f5f0f9a621d72 version=HEAD
9:25AM WRN Could not get authentication: cannot list source authentication: Get "http://nuc:8131/api/sources/v3.1/sources/1/authentications": dial tcp 192.168.1.2:8131: connect: connection refused account_number=6395343 binary=pbstatuser hostname=mone.home.lan org_id=13446659 source_id=1 trace_id=52fdfc072182654f163f5f0f9a621d72 version=HEAD
9:25AM TRC Received message with key: 1, topic: platform.provisioning.internal.availability-check, offset: 1, partition: 0 binary=pbstatuser hostname=mone.home.lan payload="{\"source_id\":\"1\"}" version=HEAD
9:25AM TRC Getting authentication from source 1 account_number=6395343 binary=pbstatuser client=sources hostname=mone.home.lan org_id=13446659 source_id=1 trace_id=9566c74d10037c4d7bbb0407d1e2c649 version=HEAD
9:25AM WRN Could not get authentication: cannot list source authentication: Get "http://nuc:8131/api/sources/v3.1/sources/1/authentications": dial tcp 192.168.1.2:8131: connect: connection refused account_number=6395343 binary=pbstatuser hostname=mone.home.lan org_id=13446659 source_id=1 trace_id=9566c74d10037c4d7bbb0407d1e2c649 version=HEAD
9:25AM DBG looking up offset of kafka reader for partition 0 of platform.provisioning.internal.availability-check: 2 binary=pbstatuser hostname=mone.home.lan kafka=true version=HEAD
```