### PR TITLE
chore: silence switch-case linter

### DIFF
--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -197,6 +197,7 @@ func (c *sourcesClient) loadAppId(ctx context.Context) (string, error) {
 	return "", http.ApplicationTypeNotFoundErr
 }
 
+//nolint:exhaustive
 func filterSourceAuthentications(authentications []AuthenticationRead) (AuthenticationRead, error) {
 	for _, auth := range authentications {
 		if *auth.ResourceType == "Application" {
@@ -205,23 +206,7 @@ func filterSourceAuthentications(authentications []AuthenticationRead) (Authenti
 				AuthenticationReadAuthtypeProvisioningLighthouseSubscriptionId,
 				AuthenticationReadAuthtypeProvisioningProjectId:
 				return auth, nil
-			case AuthenticationReadAuthtypeAccessKeySecretKey,
-				AuthenticationReadAuthtypeApiTokenAccountId,
-				AuthenticationReadAuthtypeArn,
-				AuthenticationReadAuthtypeBitbucketAppPassword,
-				AuthenticationReadAuthtypeCloudMeterArn,
-				AuthenticationReadAuthtypeDockerAccessToken,
-				AuthenticationReadAuthtypeGithubPersonalAccessToken,
-				AuthenticationReadAuthtypeGitlabPersonalAccessToken,
-				AuthenticationReadAuthtypeLighthouseSubscriptionId,
-				AuthenticationReadAuthtypeMarketplaceToken,
-				AuthenticationReadAuthtypeOcid,
-				AuthenticationReadAuthtypeProjectIdServiceAccountJson,
-				AuthenticationReadAuthtypeQuayEncryptedPassword,
-				AuthenticationReadAuthtypeReceptorNode,
-				AuthenticationReadAuthtypeTenantIdClientIdClientSecret,
-				AuthenticationReadAuthtypeToken,
-				AuthenticationReadAuthtypeUsernamePassword:
+			default:
 				continue
 			}
 		}

--- a/internal/logging/zerolog.go
+++ b/internal/logging/zerolog.go
@@ -62,6 +62,7 @@ func InitializeStdout() {
 		panic(fmt.Errorf("cannot parse log level '%s': %w", config.Logging.Level, err))
 	}
 	zerolog.SetGlobalLevel(level)
+	//nolint:reassign
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 
 	log.Logger = decorate(log.Output(zerolog.ConsoleWriter{


### PR DESCRIPTION
Quick reminder - it is fine to silence linters at some times where it makes no sense. I find this one quite useful because I already forgot some case statements myself that could lead to dangerous code, but here it is not very useful.

Also my version of golint already warns about the out-of-package reassignment, it is okay as Zerolog library works this way.