### PR TITLE
Support for AWS Launch Templates

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -45,6 +45,9 @@
           "instance_type": {
             "type": "string"
           },
+          "launch_template_id": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },
@@ -84,6 +87,9 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "launch_template_id": {
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -166,6 +172,17 @@
           "vcpus": {
             "format": "int32",
             "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "v1.LaunchTemplatesResponse": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
           }
         },
         "type": "object"
@@ -753,7 +770,7 @@
             }
           },
           {
-            "description": "List instance types of the specified region",
+            "description": "Hyperscaler region",
             "in": "query",
             "name": "region",
             "required": true,
@@ -769,6 +786,54 @@
                 "schema": {
                   "items": {
                     "$ref": "#/components/schemas/v1.InstanceTypeResponse"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Return on success."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/sources/{ID}/launch_templates": {
+      "get": {
+        "description": "Return a list of launch templates",
+        "operationId": "getLaunchTemplatesList",
+        "parameters": [
+          {
+            "description": "Source ID from Sources Database",
+            "in": "path",
+            "name": "ID",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Hyperscaler region",
+            "in": "query",
+            "name": "region",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/v1.LaunchTemplatesResponse"
                   },
                   "type": "array"
                 }

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -143,10 +143,10 @@ paths:
           '500':
             $ref: "#/components/responses/InternalError"
   /sources/{ID}/instance_types:
-      get:
-        description: 'Return a list of instance types (DEPRECATED: use /instance_types)'
-        operationId: getInstanceTypeList
-        parameters:
+    get:
+      description: 'Return a list of instance types (DEPRECATED: use /instance_types)'
+      operationId: getInstanceTypeList
+      parameters:
         - in: path
           name: ID
           schema:
@@ -159,20 +159,51 @@ paths:
           schema:
             type: string
           required: true
-          description: List instance types of the specified region
-        responses:
-          '200':
-            description: Return on success.
-            content:
-              application/json:
-                schema:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/v1.InstanceTypeResponse'
-          '404':
-            $ref: "#/components/responses/NotFound"
-          '500':
-            $ref: "#/components/responses/InternalError"
+          description: Hyperscaler region
+      responses:
+        '200':
+          description: Return on success.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/v1.InstanceTypeResponse'
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '500':
+          $ref: "#/components/responses/InternalError"
+  /sources/{ID}/launch_templates:
+    get:
+      description: Return a list of launch templates
+      operationId: getLaunchTemplatesList
+      parameters:
+        - in: path
+          name: ID
+          schema:
+            type: integer
+            format: int64
+          required: true
+          description: Source ID from Sources Database
+        - in: query
+          name: region
+          schema:
+            type: string
+          required: true
+          description: Hyperscaler region
+      responses:
+        '200':
+          description: Return on success.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/v1.LaunchTemplatesResponse'
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '500':
+          $ref: "#/components/responses/InternalError"
   /instance_types/{PROVIDER}:
     get:
       description: >
@@ -369,6 +400,8 @@ components:
           type: string
         instance_type:
           type: string
+        launch_template_id:
+          type: string
         name:
           type: string
         poweroff:
@@ -396,6 +429,8 @@ components:
           items:
             type: string
           type: array
+        launch_template_id:
+          type: string
         name:
           type: string
         poweroff:
@@ -451,6 +486,13 @@ components:
         vcpus:
           format: int32
           type: integer
+      type: object
+    v1.LaunchTemplatesResponse:
+      properties:
+        id:
+          type: string
+        name:
+          type: string
       type: object
     v1.NoopReservationResponse:
       properties:

--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -48,7 +48,8 @@ func (s *APISchemaGen) addResponse(name string, description string, ref string) 
 func main() {
 	gen := APISchemaGen{}
 	gen.init()
-	// payloads
+
+	// payloads - MAKE SURE THE TYPE HAS JSON/YAML Go STRUCT TAGS (or "map key XXX not found" error occurs)
 	gen.addSchema("v1.PubkeyRequest", &payloads.PubkeyRequest{})
 	gen.addSchema("v1.PubkeyResponse", &payloads.PubkeyResponse{})
 	gen.addSchema("v1.SourceResponse", &payloads.SourceResponse{})
@@ -59,6 +60,7 @@ func main() {
 	gen.addSchema("v1.AWSReservationResponse", &payloads.AWSReservationResponsePayload{})
 	gen.addSchema("v1.AvailabilityStatusRequest", &payloads.AvailabilityStatusRequest{})
 	gen.addSchema("v1.AccountIDTypeResponse", &payloads.AccountIdentityResponse{})
+	gen.addSchema("v1.LaunchTemplatesResponse", &payloads.LaunchTemplateResponse{})
 
 	// error payloads
 	gen.addSchema("v1.ResponseError", &payloads.ResponseError{})

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -143,10 +143,10 @@ paths:
           '500':
             $ref: "#/components/responses/InternalError"
   /sources/{ID}/instance_types:
-      get:
-        description: 'Return a list of instance types (DEPRECATED: use /instance_types)'
-        operationId: getInstanceTypeList
-        parameters:
+    get:
+      description: 'Return a list of instance types (DEPRECATED: use /instance_types)'
+      operationId: getInstanceTypeList
+      parameters:
         - in: path
           name: ID
           schema:
@@ -159,20 +159,51 @@ paths:
           schema:
             type: string
           required: true
-          description: List instance types of the specified region
-        responses:
-          '200':
-            description: Return on success.
-            content:
-              application/json:
-                schema:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/v1.InstanceTypeResponse'
-          '404':
-            $ref: "#/components/responses/NotFound"
-          '500':
-            $ref: "#/components/responses/InternalError"
+          description: Hyperscaler region
+      responses:
+        '200':
+          description: Return on success.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/v1.InstanceTypeResponse'
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '500':
+          $ref: "#/components/responses/InternalError"
+  /sources/{ID}/launch_templates:
+    get:
+      description: Return a list of launch templates
+      operationId: getLaunchTemplatesList
+      parameters:
+        - in: path
+          name: ID
+          schema:
+            type: integer
+            format: int64
+          required: true
+          description: Source ID from Sources Database
+        - in: query
+          name: region
+          schema:
+            type: string
+          required: true
+          description: Hyperscaler region
+      responses:
+        '200':
+          description: Return on success.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/v1.LaunchTemplatesResponse'
+        '404':
+          $ref: "#/components/responses/NotFound"
+        '500':
+          $ref: "#/components/responses/InternalError"
   /instance_types/{PROVIDER}:
     get:
       description: >

--- a/cmd/typesctl/providers/ec2_types.go
+++ b/cmd/typesctl/providers/ec2_types.go
@@ -56,7 +56,7 @@ func generateTypesEC2() error {
 		if regionErr != nil {
 			return fmt.Errorf("unable to get regional EC2 client: %w", regionErr)
 		}
-		instTypes, regionErr := client.ListInstanceTypesWithPaginator(ctx)
+		instTypes, regionErr := client.ListInstanceTypes(ctx)
 		if regionErr != nil {
 			// skip
 			fmt.Printf("unable to list EC2 instance types (region STS not enabled?): %s\n", regionErr.Error())

--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -279,8 +279,8 @@ func (c *ec2Client) ListAllZones(ctx context.Context, region clients.Region) ([]
 	return result, nil
 }
 
-func (c *ec2Client) ListInstanceTypesWithPaginator(ctx context.Context) ([]*clients.InstanceType, error) {
-	ctx, span := otel.Tracer(TraceName).Start(ctx, "ListInstanceTypesWithPaginator")
+func (c *ec2Client) ListInstanceTypes(ctx context.Context) ([]*clients.InstanceType, error) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "ListInstanceTypes")
 	defer span.End()
 
 	input := &ec2.DescribeInstanceTypesInput{MaxResults: ptr.ToInt32(100)}

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -64,26 +64,28 @@ var GetServiceEC2Client func(ctx context.Context, region string) (EC2, error)
 type EC2 interface {
 	ClientStatuser
 
-	// ListAllRegions returns list of all EC2 regions
+	// ListAllRegions returns list of all EC2 regions.
 	ListAllRegions(ctx context.Context) ([]Region, error)
 
-	// ListAllZones returns list of all EC2 zones within a Region
+	// ListAllZones returns list of all EC2 zones within a Region.
 	ListAllZones(ctx context.Context, region Region) ([]Zone, error)
 
-	// ImportPubkey imports new ssh key-pair with given tag returning its AWS ID
+	// ImportPubkey imports new ssh key-pair with given tag returning its AWS ID.
 	ImportPubkey(ctx context.Context, key *models.Pubkey, tag string) (string, error)
 
-	// GetPubkeyName fetches the AWS key name using given pubkey fingerprint
+	// GetPubkeyName fetches the AWS key name using given pubkey fingerprint.
 	GetPubkeyName(ctx context.Context, fingerprint string) (string, error)
 
-	// DeleteSSHKey deletes a given ssh key-pair found by AWS ID
+	// DeleteSSHKey deletes a given ssh key-pair found by AWS ID.
 	DeleteSSHKey(ctx context.Context, handle string) error
 
-	ListInstanceTypesWithPaginator(ctx context.Context) ([]*InstanceType, error)
+	// ListInstanceTypesWithPaginator lists all instance types.
+	ListInstanceTypes(ctx context.Context) ([]*InstanceType, error)
 
-	// RunInstances launches one or more instances
+	// RunInstances launches one or more instances.
 	RunInstances(ctx context.Context, name *string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error)
 
+	// Returns AWS account number.
 	GetAccountId(ctx context.Context) (string, error)
 }
 

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -82,8 +82,14 @@ type EC2 interface {
 	// ListInstanceTypesWithPaginator lists all instance types.
 	ListInstanceTypes(ctx context.Context) ([]*InstanceType, error)
 
+	// ListLaunchTemplates lists all launch templates.
+	ListLaunchTemplates(ctx context.Context) ([]*LaunchTemplate, error)
+
 	// RunInstances launches one or more instances.
-	RunInstances(ctx context.Context, name *string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error)
+	//
+	// All arguments are required except: launchTemplateID (empty string means no template in use).
+	//
+	RunInstances(ctx context.Context, launchTemplateID string, name *string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error)
 
 	// Returns AWS account number.
 	GetAccountId(ctx context.Context) (string, error)

--- a/internal/clients/launch_template.go
+++ b/internal/clients/launch_template.go
@@ -1,0 +1,10 @@
+package clients
+
+// LaunchTemplate represents a generic launch template for a hyperscaler.
+type LaunchTemplate struct {
+	// ID is an identifier, for example "lt-94397398248932342" for AWS EC2.
+	ID string `json:"id" yaml:"id"`
+
+	// Name describes the launch template, user defined.
+	Name string `json:"name" yaml:"name"`
+}

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -142,7 +142,20 @@ func (mock *EC2ClientStub) ListInstanceTypes(ctx context.Context) ([]*clients.In
 	}, nil
 }
 
-func (mock *EC2ClientStub) RunInstances(ctx context.Context, name *string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error) {
+func (mock *EC2ClientStub) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchTemplate, error) {
+	return []*clients.LaunchTemplate{
+		{
+			ID:   "lt-8732678436272377",
+			Name: "Nano ARM64 load balancer",
+		},
+		{
+			ID:   "lt-8732678438462378",
+			Name: "XXLarge AMD64 database",
+		},
+	}, nil
+}
+
+func (mock *EC2ClientStub) RunInstances(ctx context.Context, launchTemplateID string, name *string, amount int32, instanceType types.InstanceType, AMI string, keyName string, userData []byte) ([]*string, *string, error) {
 	return nil, nil, nil
 }
 

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -110,7 +110,7 @@ func (mock *EC2ClientStub) ListAllZones(ctx context.Context, region clients.Regi
 	}, nil
 }
 
-func (mock *EC2ClientStub) ListInstanceTypesWithPaginator(ctx context.Context) ([]*clients.InstanceType, error) {
+func (mock *EC2ClientStub) ListInstanceTypes(ctx context.Context) ([]*clients.InstanceType, error) {
 	return []*clients.InstanceType{
 		{
 			Name:               "t4g.nano",

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -34,6 +34,9 @@ type LaunchInstanceAWSTaskArgs struct {
 	// AWS AMI as fetched from image builder
 	AMI string
 
+	// LaunchTemplateID or empty string when no template in use
+	LaunchTemplateID string
+
 	// The ARN fetched from Sources which is linked to a specific source
 	ARN *clients.Authentication
 }
@@ -183,7 +186,7 @@ func DoLaunchInstanceAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) e
 	}
 
 	logger.Trace().Msg("Executing RunInstances")
-	instances, awsReservationId, err := ec2Client.RunInstances(ctx, args.Detail.Name, args.Detail.Amount, types.InstanceType(args.Detail.InstanceType), args.AMI, reservation.Detail.PubkeyName, userData)
+	instances, awsReservationId, err := ec2Client.RunInstances(ctx, args.LaunchTemplateID, args.Detail.Name, args.Detail.Amount, types.InstanceType(args.Detail.InstanceType), args.AMI, reservation.Detail.PubkeyName, userData)
 	if err != nil {
 		return fmt.Errorf("cannot run instances: %w", err)
 	}

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -56,7 +56,10 @@ type AWSDetail struct {
 	// Optional instance name
 	Name *string `json:"name"`
 
-	// AWS Instance type.
+	// Optional launch template id ("lt-987432987342") or empty string
+	LaunchTemplateID string `json:"launch_template_id"`
+
+	// AWS Instance type. Can be blank if LaunchTemplateID is set.
 	InstanceType string `json:"instance_type"`
 
 	// Amount of instances to provision of type: Instance type.
@@ -82,6 +85,7 @@ type AWSReservation struct {
 	AWSReservationID *string `db:"aws_reservation_id" json:"aws_reservation_id"`
 
 	// The ID of the image from which the instance is created. AMI's must be prefixed with 'ami-'.
+	// Can be also set to blank, in that case launch template with a valid AMI must be provided.
 	ImageID string `db:"image_id" json:"image_id"`
 
 	// Detail information is stored as JSON in DB

--- a/internal/payloads/launch_template_payload.go
+++ b/internal/payloads/launch_template_payload.go
@@ -1,0 +1,28 @@
+package payloads
+
+import (
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/go-chi/render"
+)
+
+type LaunchTemplateResponse struct {
+	*clients.LaunchTemplate
+}
+
+func (s *LaunchTemplateResponse) Bind(_ *http.Request) error {
+	return nil
+}
+
+func (s *LaunchTemplateResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
+	return nil
+}
+
+func NewListLaunchTemplateResponse(sl []*clients.LaunchTemplate) []render.Renderer {
+	list := make([]render.Renderer, len(sl))
+	for i, instanceType := range sl {
+		list[i] = &LaunchTemplateResponse{instanceType}
+	}
+	return list
+}

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -63,6 +63,9 @@ type AWSReservationResponsePayload struct {
 	// The ID of the image from which the instance is created.
 	ImageID string `json:"image_id"`
 
+	// Optional launch template ID ("lt-9848392734432") or empty for no template.
+	LaunchTemplateID string `json:"launch_template_id"`
+
 	// The ID of the aws reservation which was created, or missing if not created yet.
 	AWSReservationID string `json:"aws_reservation_id,omitempty"`
 
@@ -149,6 +152,9 @@ type AWSReservationRequestPayload struct {
 
 	// Optional name of the instance(s).
 	Name string `json:"name"`
+
+	// Optional launch template ID ("lt-9848392734432") or empty for no template.
+	LaunchTemplateID string `json:"launch_template_id"`
 
 	// AWS Instance type.
 	InstanceType string `json:"instance_type"`
@@ -253,16 +259,17 @@ func NewAWSReservationResponse(reservation *models.AWSReservation, instances []*
 	}
 
 	response := AWSReservationResponsePayload{
-		PubkeyID:     reservation.PubkeyID,
-		ImageID:      reservation.ImageID,
-		SourceID:     reservation.SourceID,
-		Region:       reservation.Detail.Region,
-		Amount:       reservation.Detail.Amount,
-		InstanceType: reservation.Detail.InstanceType,
-		ID:           reservation.ID,
-		Name:         StringNullToEmpty(reservation.Detail.Name),
-		PowerOff:     reservation.Detail.PowerOff,
-		Instances:    instanceIds,
+		PubkeyID:         reservation.PubkeyID,
+		ImageID:          reservation.ImageID,
+		SourceID:         reservation.SourceID,
+		Region:           reservation.Detail.Region,
+		Amount:           reservation.Detail.Amount,
+		InstanceType:     reservation.Detail.InstanceType,
+		ID:               reservation.ID,
+		Name:             StringNullToEmpty(reservation.Detail.Name),
+		PowerOff:         reservation.Detail.PowerOff,
+		Instances:        instanceIds,
+		LaunchTemplateID: reservation.Detail.LaunchTemplateID,
 	}
 	if reservation.AWSReservationID != nil {
 		response.AWSReservationID = *reservation.AWSReservationID

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -61,6 +61,7 @@ func MountAPI(r *chi.Mux) {
 				// TODO move this to outside of /sources (see below)
 				r.Get("/instance_types", s.ListInstanceTypes)
 
+				r.Get("/launch_templates", s.ListLaunchTemplates)
 				r.Get("/account_identity", s.GetAccountIdentity)
 			})
 		})

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -35,23 +35,33 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	rDao := dao.GetReservationDao(r.Context())
 	pkDao := dao.GetPubkeyDao(r.Context())
 
-	// validate architecture match (hardcoded since image builder currently only supports x86_64)
-	supportedArch := "x86_64"
-	it := types.FindInstanceType(clients.InstanceTypeName(payload.InstanceType))
-	if it == nil {
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), fmt.Sprintf("unknown type: %s", payload.InstanceType), UnknownInstanceTypeNameError))
-		return
-	}
-	if it.Architecture.String() != supportedArch {
-		renderError(w, r, payloads.NewWrongArchitectureUserError(r.Context(), ArchitectureMismatch))
+	// Either Launch Template or Instance Type must be set. Both can be set too, in that case, instance type overrides the launch template.
+	if payload.InstanceType == "" && payload.LaunchTemplateID == "" {
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Both instance type and launch template are missing", BothTypeAndTemplateMissingError))
 		return
 	}
 
+	// Validate architecture match (hardcoded since image builder currently only supports x86_64). This can be only done
+	// when launch template is not set.
+	if payload.LaunchTemplateID == "" {
+		supportedArch := "x86_64"
+		it := types.FindInstanceType(clients.InstanceTypeName(payload.InstanceType))
+		if it == nil {
+			renderError(w, r, payloads.NewInvalidRequestError(r.Context(), fmt.Sprintf("unknown type: %s", payload.InstanceType), UnknownInstanceTypeNameError))
+			return
+		}
+		if it.Architecture.String() != supportedArch {
+			renderError(w, r, payloads.NewWrongArchitectureUserError(r.Context(), ArchitectureMismatch))
+			return
+		}
+	}
+
 	detail := &models.AWSDetail{
-		Region:       payload.Region,
-		InstanceType: payload.InstanceType,
-		Amount:       payload.Amount,
-		PowerOff:     payload.PowerOff,
+		Region:           payload.Region,
+		LaunchTemplateID: payload.LaunchTemplateID,
+		InstanceType:     payload.InstanceType,
+		Amount:           payload.Amount,
+		PowerOff:         payload.PowerOff,
 	}
 	reservation := &models.AWSReservation{
 		PubkeyID: payload.PubkeyID,
@@ -63,7 +73,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	reservation.Status = "Created"
 	reservation.Provider = models.ProviderTypeAWS
 	reservation.Steps = 2
-	reservation.StepTitles = []string{"Upload public key", "Launch instance(s)"}
+	reservation.StepTitles = []string{"Ensure public key", "Launch instance(s)"}
 	newName := config.Application.InstancePrefix + payload.Name
 	reservation.Detail.Name = &newName
 
@@ -105,8 +115,8 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var ami string
-	if strings.HasPrefix(reservation.ImageID, "ami-") {
-		// Direct AMI ID was provided, no need to call image builder
+	if reservation.ImageID == "" || strings.HasPrefix(reservation.ImageID, "ami-") {
+		// Direct AMI or no image were provided (launch template), no need to call image builder
 		ami = reservation.ImageID
 	} else {
 		// Get Image builder client
@@ -130,13 +140,14 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 		Identity:  id,
 		AccountID: accountId,
 		Args: jobs.LaunchInstanceAWSTaskArgs{
-			ReservationID: reservation.ID,
-			Region:        reservation.Detail.Region,
-			PubkeyID:      pk.ID,
-			SourceID:      reservation.SourceID,
-			Detail:        reservation.Detail,
-			AMI:           ami,
-			ARN:           authentication,
+			ReservationID:    reservation.ID,
+			Region:           reservation.Detail.Region,
+			PubkeyID:         pk.ID,
+			SourceID:         reservation.SourceID,
+			Detail:           reservation.Detail,
+			AMI:              ami,
+			LaunchTemplateID: reservation.Detail.LaunchTemplateID,
+			ARN:              authentication,
 		},
 	}
 

--- a/internal/services/instance_types_service.go
+++ b/internal/services/instance_types_service.go
@@ -34,7 +34,7 @@ func ListInstanceTypes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	instances, err := ec2Client.ListInstanceTypesWithPaginator(r.Context())
+	instances, err := ec2Client.ListInstanceTypes(r.Context())
 	if err != nil {
 		renderError(w, r, payloads.NewAWSError(r.Context(), "unable to list AWS EC2 instances", err))
 		return

--- a/internal/services/launch_templates_service.go
+++ b/internal/services/launch_templates_service.go
@@ -1,0 +1,47 @@
+package services
+
+import (
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+func ListLaunchTemplates(w http.ResponseWriter, r *http.Request) {
+	sourceId := chi.URLParam(r, "ID")
+	region := r.URL.Query().Get("region")
+	if region == "" {
+		renderError(w, r, payloads.NewMissingRequestParameterError(r.Context(), "region parameter is missing"))
+	}
+
+	sourcesClient, err := clients.GetSourcesClient(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	authentication, err := sourcesClient.GetAuthentication(r.Context(), sourceId)
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	ec2Client, err := clients.GetEC2Client(r.Context(), authentication, region)
+	if err != nil {
+		renderError(w, r, payloads.NewAWSError(r.Context(), "unable to get AWS EC2 client", err))
+		return
+	}
+
+	templates, err := ec2Client.ListLaunchTemplates(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewAWSError(r.Context(), "unable to list AWS EC2 launch templates", err))
+		return
+	}
+
+	if err := render.RenderList(w, r, payloads.NewListLaunchTemplateResponse(templates)); err != nil {
+		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render instance types list", err))
+		return
+	}
+}

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -19,6 +19,7 @@ var (
 	ProviderTypeNotImplementedError = errors.New("provider type not yet implemented")
 	UnknownInstanceTypeNameError    = errors.New("unknown instance type")
 	ArchitectureMismatch            = errors.New("instance type and image architecture mismatch")
+	BothTypeAndTemplateMissingError = errors.New("instance type or launch template not set")
 )
 
 // CreateReservation dispatches requests to type provider specific handlers

--- a/scripts/rest_examples/http-client.env.json
+++ b/scripts/rest_examples/http-client.env.json
@@ -6,7 +6,9 @@
     "prefix": "api/provisioning/v1",
     "identity": "eyJpZGVudGl0eSI6IHsidHlwZSI6ICJVc2VyIiwgImFjY291bnRfbnVtYmVyIjoiMTMiLCAiaW50ZXJuYWwiOnsib3JnX2lkIjoiMDAwMDEzIn19fQo=",
     "source_id": "1",
+    "pubkey_id": "1",
     "region": "us-east-1",
+    "launch_template_id": "",
     "reservation-get-id": "1"
   }
 }

--- a/scripts/rest_examples/launchtemplates-aws-list.http
+++ b/scripts/rest_examples/launchtemplates-aws-list.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources/1/launch_templates?region=us-east-1 HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/reservation-create-aws.http
+++ b/scripts/rest_examples/reservation-create-aws.http
@@ -8,7 +8,8 @@ X-Rh-Identity: {{identity}}
   "source_id": "1",
   "image_id": "ami-05fa00d4c63e32376",
   "amount": 1,
-  "instance_type": "t1.micro",
-  "pubkey_id": 1,
+  "launch_template_id": "{{launch_template_id}}",
+  "instance_type": "t2.nano",
+  "pubkey_id": {{pubkey_id}},
   "poweroff": true
 }

--- a/scripts/rest_examples/reservation-create-azure.http
+++ b/scripts/rest_examples/reservation-create-azure.http
@@ -9,6 +9,6 @@ X-Rh-Identity: {{identity}}
   "image_id": "9be1ff26-da9e-4947-9cd7-eaa7a87c00f0",
   "amount": 1,
   "instance_size": "Standard_B1ls",
-  "pubkey_id": 2,
+  "pubkey_id": {{pubkey_id}},
   "poweroff": true
 }

--- a/scripts/rest_examples/reservation-create-gcp.http
+++ b/scripts/rest_examples/reservation-create-gcp.http
@@ -8,8 +8,8 @@ X-Rh-Identity: {{identity}}
   "zone": "us-central1-a",
   "source_id": "3",
   "image_id": "80967e7f-efef-4eee-85b0-bd4cef4c455d",
-  "amount": 2,
+  "amount": 1,
   "machine_type": "n1-standard-1",
-  "pubkey_id": 1,
+  "pubkey_id": {{pubkey_id}},
   "poweroff": true
 }

--- a/scripts/rest_examples/reservation-get-1-aws.http
+++ b/scripts/rest_examples/reservation-get-1-aws.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/reservations/aws/{{reservation-get-id}} HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}


### PR DESCRIPTION
This patch introduces new client type:

```go
package clients

// LaunchTemplate represents a generic launch template for a hyperscaler.
type LaunchTemplate struct {
	// ID is an identifier, for example "lt-94397398248932342" for AWS EC2.
	ID string

	// Name describes the launch template, user defined.
	Name string
}
```

I am aiming to have a generic LaunchTemplate, the terminology we use for generic types is AWS EC2. I am assuming other hyperscalers have similar templating, well, except Azure where it is JSON. There is a new endpoint and OpenAPI spec update which lists those. The UI is supposed to load this once region is selected since region is required URL parameter (or error). The ID field must be then provided as a new field "LaunchTemplateID" in an AWS reservation detail or set to blank when no template should be used.

The RunInstances function was extended with new "LaunchTemplateID" string argument, when empty no template will be used. The function has always accepted empty instance type, no change here. A new check is added in the service function and error is returned when user provides empty string for BOTH instance type and template id. It is technically possible to create a template that does nothing (carries zero information), we currently do not check for this so it is possible that the launch will error out with insufficient data (instance type not set explicitly and also in a template).

[HMS-1209](https://issues.redhat.com/browse/HMS-1209)