### PR TITLE
feat: Fetch Azure image name from image builder

### DIFF
--- a/internal/clients/http/azure/azure_client.go
+++ b/internal/clients/http/azure/azure_client.go
@@ -43,6 +43,14 @@ func (c *client) newResourceGroupsClient(ctx context.Context) (*armresources.Res
 	return client, nil
 }
 
+func (c *client) newImagesClient(ctx context.Context) (*armcompute.ImagesClient, error) {
+	vmClient, err := armcompute.NewImagesClient(c.subscriptionID, c.credential, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create Image Azure client: %w", err)
+	}
+	return vmClient, nil
+}
+
 func (c *client) newVirtualMachinesClient(ctx context.Context) (*armcompute.VirtualMachinesClient, error) {
 	vmClient, err := armcompute.NewVirtualMachinesClient(c.subscriptionID, c.credential, nil)
 	if err != nil {

--- a/internal/clients/http/image_builder_errors.go
+++ b/internal/clients/http/image_builder_errors.go
@@ -8,10 +8,9 @@ import (
 )
 
 var (
-	CloneNotFoundErr       = fmt.Errorf("image clone not found: %w", clients.NotFoundErr)
-	ComposeNotFoundErr     = fmt.Errorf("image compose not found: %w", clients.NotFoundErr)
-	ImageStatusErr         = errors.New("build of requested image has not finished yet")
-	UnknownImageTypeErr    = errors.New("unknown image type")
-	AmiNotFoundInStatusErr = fmt.Errorf("AMI not found in image status: %w", clients.NotFoundErr)
-	UploadStatusErr        = fmt.Errorf("could not fetch upload status: %w", clients.NotFoundErr)
+	CloneNotFoundErr    = fmt.Errorf("image clone not found: %w", clients.NotFoundErr)
+	ComposeNotFoundErr  = fmt.Errorf("image compose not found: %w", clients.NotFoundErr)
+	ImageStatusErr      = errors.New("build of requested image has not finished yet")
+	UnknownImageTypeErr = errors.New("unknown image type")
+	UploadStatusErr     = fmt.Errorf("could not fetch upload status: %w", clients.NotFoundErr)
 )

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -35,6 +35,9 @@ type ImageBuilder interface {
 	// GetAWSAmi returns related AWS image AMI identifier
 	GetAWSAmi(ctx context.Context, composeID string) (string, error)
 
+	// GetAzureImageName returns name of the Azure image, without the subscription and resource group scope
+	GetAzureImageName(ctx context.Context, composeID string) (string, error)
+
 	// GetGCPImageName returns GCP image name
 	GetGCPImageName(ctx context.Context, composeID string) (string, error)
 
@@ -95,9 +98,9 @@ type Azure interface {
 
 	// CreateVM creates Azure virtual machine.
 	// Most of the parameters are constant for now.
-	// imageID is expected in format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageID}
-	// sshKeyBody should be full public key body
-	CreateVM(ctx context.Context, location string, resourceGroupName string, imageID string, pubkey *models.Pubkey, instanceType InstanceTypeName, vmName string) (*string, error)
+	// location - to deploy into
+	// imageName - the imageID will be inferred as /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}
+	CreateVM(ctx context.Context, location string, resourceGroupName string, imageName string, pubkey *models.Pubkey, instanceType InstanceTypeName, vmName string) (*string, error)
 }
 
 type ServiceAzure interface {

--- a/internal/clients/stubs/image_builder_stub.go
+++ b/internal/clients/stubs/image_builder_stub.go
@@ -37,6 +37,10 @@ func (mock *ImageBuilderClientStub) GetAWSAmi(ctx context.Context, composeID str
 	return "ami-0c830793775595d4b-test", nil
 }
 
+func (mock *ImageBuilderClientStub) GetAzureImageName(ctx context.Context, composeID string) (string, error) {
+	return "composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7", nil
+}
+
 func (mock *ImageBuilderClientStub) GetGCPImageName(ctx context.Context, composeID string) (string, error) {
 	return "projects/red-hat-image-builder/global/images/composer-api-871fa36d-0b5b-4001-8c95-a11f751a4d66-test", nil
 }

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -120,8 +120,6 @@ func ImageBuilderHelper(err error) (int, string) {
 		return 500, "image builder has not finished the build of requested image"
 	} else if errors.Is(err, httpClients.UnknownImageTypeErr) {
 		return 500, "unknown image type"
-	} else if errors.Is(err, httpClients.AmiNotFoundInStatusErr) {
-		return 404, "image builder did not find AMI in status"
 	} else if errors.Is(err, httpClients.UploadStatusErr) {
 		return 404, "could not fetch upload status from image builder"
 	}

--- a/internal/services/azure_reservation_service_test.go
+++ b/internal/services/azure_reservation_service_test.go
@@ -36,7 +36,7 @@ func TestCreateAzureReservationHandler(t *testing.T) {
 
 	values := map[string]interface{}{
 		"source_id":     source.Id,
-		"image_id":      "/subscriptions/uuid/group/images/uuid",
+		"image_id":      "92ea98f8-7697-472e-80b1-7454fa0e7fa7",
 		"amount":        1,
 		"instance_size": "Basic_A0",
 		"pubkey_id":     pk.ID,

--- a/scripts/rest_examples/reservation-create-azure.http
+++ b/scripts/rest_examples/reservation-create-azure.http
@@ -6,7 +6,7 @@ X-Rh-Identity: {{identity}}
 {
   "name": "azure-linux-us-east",
   "source_id": "5",
-  "image_id": "/subscriptions/4b9d213f-712f-4d17-a483-8a10bbe9df3a/resourceGroups/oezr/providers/Microsoft.Compute/images/composer-api-00e391e7-e6c8-4283-b94a-ea719a58bc05",
+  "image_id": "9be1ff26-da9e-4947-9cd7-eaa7a87c00f0",
   "amount": 1,
   "instance_size": "Standard_B1ls",
   "pubkey_id": 2,


### PR DESCRIPTION
Fetch Azure image name from image builder.
Unfortunatelly IB provides only the Name and nID.
Thus we are composing the ID manually on our side.

Fixes HMS-1219