### PR TITLE
fix: allow setting proxy per client

### DIFF
--- a/internal/clients/http/platform_client.go
+++ b/internal/clients/http/platform_client.go
@@ -23,7 +23,7 @@ func NewPlatformClient(ctx context.Context, proxy string) HttpRequestDoer {
 			ctxval.Logger(ctx).Warn().Msgf("Unable to use HTTP client proxy in clowder environment: %s", proxy)
 		} else {
 			ctxval.Logger(ctx).Warn().Msgf("Creating HTTP client with proxy %s", proxy)
-			transport.Proxy = http.ProxyURL(config.StringToURL(proxy))
+			rt = &http.Transport{Proxy: http.ProxyURL(config.StringToURL(proxy))}
 		}
 	}
 


### PR DESCRIPTION
We are sharing the transport, so if the proxy is set for one client, it got set to all.

This isolates the clients by creating new http.Transport if a proxy is set for given client.

This should affect only devel instances so Production should still utilize caching.

Fixes HMS-1227