### PR TITLE
feat: respect Amount in Azure deployments

### DIFF
--- a/internal/clients/stubs/azure_stub.go
+++ b/internal/clients/stubs/azure_stub.go
@@ -28,17 +28,12 @@ func DidCreateAzureResourceGroup(ctx context.Context, name string) bool {
 	return false
 }
 
-func DidCreateAzureVM(ctx context.Context, name string) bool {
+func CountStubAzureVMs(ctx context.Context) int {
 	client, err := getAzureClientStub(ctx)
 	if err != nil {
-		return false
+		return 0
 	}
-	for _, vm := range client.createdVms {
-		if *vm.Name == name {
-			return true
-		}
-	}
-	return false
+	return len(client.createdVms)
 }
 
 func (stub *AzureClientStub) Status(ctx context.Context) error {

--- a/internal/jobs/launch_instance_azure_test.go
+++ b/internal/jobs/launch_instance_azure_test.go
@@ -86,6 +86,7 @@ func TestDoLaunchInstanceAzure(t *testing.T) {
 	require.NoError(t, err, "failed to add stubbed key")
 
 	res := prepareAzureReservation(t, ctx, pk)
+	res.Detail.Amount = 2
 
 	rDao := dao.GetReservationDao(ctx)
 	err = rDao.CreateAzure(ctx, res)
@@ -103,5 +104,5 @@ func TestDoLaunchInstanceAzure(t *testing.T) {
 	err = jobs.DoLaunchInstanceAzure(ctx, args)
 	require.NoError(t, err, "launch instances failed to run")
 
-	assert.True(t, clientStubs.DidCreateAzureVM(ctx, "redhat-vm"))
+	assert.Equal(t, 2, clientStubs.CountStubAzureVMs(ctx))
 }


### PR DESCRIPTION
Deploy multiple Azure instances at once.
We need to generate unique names for the instances, so we generate uuid suffix for each of them.

Fixes HMS-1146