### PR TITLE
chore: add edge request id into logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Provisioning backend service for cloud.redhat.com.
 
 Requirements: Go 1.18+
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/RHEnVision/provisioning-backend.svg)](https://pkg.go.dev/github.com/RHEnVision/provisioning-backend)
+
 ## Components
 
 * pbapi - API backend service

--- a/internal/clients/http/image_builder/image_client.go
+++ b/internal/clients/http/image_builder/image_client.go
@@ -44,7 +44,7 @@ func (c *ibClient) Ready(ctx context.Context) error {
 	defer span.End()
 
 	logger := logger(ctx)
-	resp, err := c.client.GetReadiness(ctx, headers.AddImageBuilderIdentityHeader)
+	resp, err := c.client.GetReadiness(ctx, headers.AddImageBuilderIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
 		logger.Error().Err(err).Msgf("Readiness request failed for image builder: %s", err.Error())
 		return err
@@ -140,7 +140,7 @@ func (c *ibClient) checkCompose(ctx context.Context, composeID string) (*UploadS
 	logger := logger(ctx)
 	logger.Trace().Msgf("Fetching image status %v from composes", composeID)
 
-	resp, err := c.client.GetComposeStatusWithResponse(ctx, composeID, headers.AddImageBuilderIdentityHeader)
+	resp, err := c.client.GetComposeStatusWithResponse(ctx, composeID, headers.AddImageBuilderIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to fetch image status from image builder")
 		return nil, fmt.Errorf("cannot get compose status: %w", err)
@@ -166,7 +166,7 @@ func (c *ibClient) checkClone(ctx context.Context, composeID string) (*UploadSta
 	logger := logger(ctx)
 	logger.Trace().Msgf("Fetching image status %v from clones", composeID)
 
-	resp, err := c.client.GetCloneStatusWithResponse(ctx, composeID, headers.AddImageBuilderIdentityHeader)
+	resp, err := c.client.GetCloneStatusWithResponse(ctx, composeID, headers.AddImageBuilderIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to fetch image status from image builder")
 		return nil, fmt.Errorf("cannot get compose status: %w", err)

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -63,7 +63,7 @@ func (c *sourcesClient) Ready(ctx context.Context) error {
 	defer span.End()
 
 	logger := logger(ctx)
-	resp, err := c.client.ListApplicationTypes(ctx, &ListApplicationTypesParams{}, headers.AddSourcesIdentityHeader)
+	resp, err := c.client.ListApplicationTypes(ctx, &ListApplicationTypesParams{}, headers.AddSourcesIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
 		logger.Error().Err(err).Msgf("Readiness request failed for sources: %s", err.Error())
 		return err
@@ -87,7 +87,7 @@ func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, p
 		return nil, fmt.Errorf("failed to get provisioning app type: %w", err)
 	}
 
-	resp, err := c.client.ListApplicationTypeSourcesWithResponse(ctx, appTypeId, &ListApplicationTypeSourcesParams{}, headers.AddSourcesIdentityHeader)
+	resp, err := c.client.ListApplicationTypeSourcesWithResponse(ctx, appTypeId, &ListApplicationTypeSourcesParams{}, headers.AddSourcesIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to fetch ApplicationTypes from sources")
 		return nil, fmt.Errorf("failed to get ApplicationTypes: %w", err)
@@ -133,7 +133,7 @@ func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clie
 		return nil, fmt.Errorf("failed to get provisioning app type: %w", err)
 	}
 
-	resp, err := c.client.ListApplicationTypeSourcesWithResponse(ctx, appTypeId, &ListApplicationTypeSourcesParams{}, headers.AddSourcesIdentityHeader)
+	resp, err := c.client.ListApplicationTypeSourcesWithResponse(ctx, appTypeId, &ListApplicationTypeSourcesParams{}, headers.AddSourcesIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to fetch ApplicationTypes from sources")
 		return nil, fmt.Errorf("failed to get ApplicationTypes: %w", err)
@@ -165,7 +165,7 @@ func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId clients.
 	logger.Trace().Msgf("Getting authentication from source %s", sourceId)
 
 	// Get all the authentications linked to a specific source
-	resp, err := c.client.ListSourceAuthenticationsWithResponse(ctx, sourceId, &ListSourceAuthenticationsParams{}, headers.AddSourcesIdentityHeader)
+	resp, err := c.client.ListSourceAuthenticationsWithResponse(ctx, sourceId, &ListSourceAuthenticationsParams{}, headers.AddSourcesIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list source authentication: %w", err)
 	}
@@ -216,7 +216,7 @@ func (c *sourcesClient) loadAppId(ctx context.Context) (string, error) {
 	logger := logger(ctx)
 	logger.Trace().Msg("Fetching the Application Type ID of Provisioning for Sources")
 
-	resp, err := c.client.ListApplicationTypes(ctx, &ListApplicationTypesParams{}, headers.AddSourcesIdentityHeader)
+	resp, err := c.client.ListApplicationTypes(ctx, &ListApplicationTypesParams{}, headers.AddSourcesIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to fetch ApplicationTypes from sources")
 		return "", fmt.Errorf("failed to fetch ApplicationTypes: %w", err)

--- a/internal/ctxval/edge_id.go
+++ b/internal/ctxval/edge_id.go
@@ -1,0 +1,17 @@
+package ctxval
+
+import "context"
+
+// EdgeRequestId returns edge API (3Scale) request id or an empty string when not set.
+func EdgeRequestId(ctx context.Context) string {
+	value := ctx.Value(edgeRequestIdCtxKey)
+	if value == nil {
+		return ""
+	}
+	return value.(string)
+}
+
+// WithEdgeRequestId returns context copy with trace id value.
+func WithEdgeRequestId(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, edgeRequestIdCtxKey, id)
+}

--- a/internal/ctxval/keys.go
+++ b/internal/ctxval/keys.go
@@ -8,4 +8,5 @@ const (
 	requestIdCtxKey      commonKeyId = iota
 	accountIdCtxKey      commonKeyId = iota
 	unleashContextCtxKey commonKeyId = iota
+	edgeRequestIdCtxKey  commonKeyId = iota
 )

--- a/internal/headers/headers.go
+++ b/internal/headers/headers.go
@@ -25,6 +25,14 @@ func addIdentityHeader(ctx context.Context, req *http.Request, username, passwor
 	return nil
 }
 
+func AddEdgeRequestIdHeader(ctx context.Context, req *http.Request) error {
+	reqId := ctxval.EdgeRequestId(ctx)
+	if reqId != "" {
+		req.Header.Set("X-Rh-Edge-Request-Id", reqId)
+	}
+	return nil
+}
+
 func AddSourcesIdentityHeader(ctx context.Context, req *http.Request) error {
 	username := config.Sources.Username
 	password := config.Sources.Password

--- a/internal/middleware/trace_id.go
+++ b/internal/middleware/trace_id.go
@@ -12,6 +12,13 @@ func TraceID(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		// Edge request id
+		edgeId := r.Header.Get("X-Rh-Edge-Request-Id")
+		if edgeId != "" {
+			ctx = ctxval.WithEdgeRequestId(ctx, edgeId)
+		}
+
+		// OpenTelemetry trace id
 		traceId := trace.SpanFromContext(ctx).SpanContext().TraceID()
 		if !traceId.IsValid() {
 			// OpenTelemetry library does not provide a public interface to create new IDs


### PR DESCRIPTION
This adds edge request id from headers into logs. This should be according to folks on the forum slack channel the best request id to log along for correlation with the edge API.

Also adds documentation link to the README.