### PR TITLE
feat: Azure lighthouse offering template

### DIFF
--- a/config/api.env.example
+++ b/config/api.env.example
@@ -41,7 +41,7 @@
 #   TELEMETRY_ENABLED bool
 #     	open telemetry collecting (default "false")
 #   CLOUDWATCH_ENABLED bool
-#     	cloudwatch logging exporter (default "false")
+#     	cloudwatch logging exporter (enabled in clowder) (default "false")
 #   CLOUDWATCH_REGION string
 #     	cloudwatch logging AWS region (default "")
 #   CLOUDWATCH_KEY string
@@ -66,14 +66,16 @@
 #     	AWS service account logging (verbose) (default "false")
 #   AZURE_TENANT_ID string
 #     	Azure service account tenant id (default "")
-#   AZURE_SUBSCRIPTION_ID string
-#     	Azure service account subscription id (default "")
 #   AZURE_CLIENT_ID string
 #     	Azure service account client id (default "")
 #   AZURE_CLIENT_SECRET string
 #     	Azure service account client secret (default "")
+#   AZURE_CLIENT_NAME string
+#     	Azure service account display name (default "RH HCC")
 #   AZURE_DEFAULT_REGION string
 #     	Azure region when not provided (default "eastus")
+#   AZURE_SUBSCRIPTION_ID string
+#     	Azure service account subscription id (default "")
 #   GCP_PROJECT_ID string
 #     	GCP service account project id (default "")
 #   GCP_JSON string
@@ -88,14 +90,32 @@
 #     	open telemetry HTTP context pass and trace (default "true")
 #   WORKER_QUEUE string
 #     	job worker implementation (memory, redis, sqs, postgres) (default "memory")
-#   WORKER_CONCURRENCY int
-#     	number of goroutines handling jobs (default "50")
-#   WORKER_HEARTBEAT int64
-#     	heartbeat interval (time interval syntax) (default "30s")
-#   WORKER_MAX_BEATS int
-#     	maximum amount of heartbeats allowed (default "10")
+#   WORKER_POLL_INTERVAL int64
+#     	polling interval (network timeout) (default "5s")
+#   WORKER_MAX_THREADS int
+#     	maximum allowed amount of polling goroutines (CPUs + 1) (default "64")
+#   UNLEASH_ENABLED bool
+#     	unleash service (feature flags) (default "false")
+#   UNLEASH_ENVIRONMENT string
+#     	unleash environment (default "")
+#   UNLEASH_PREFIX string
+#     	unleash flag prefix (default "provisioning")
+#   UNLEASH_URL string
+#     	unleash service URL (default "http://localhost:4242")
+#   UNLEASH_TOKEN string
+#     	unleash service client access token (default "")
+#   KAFKA_ENABLED bool
+#     	kafka service enabled (default "false")
+#   KAFKA_BROKERS slice
+#     	kafka hostname:port list of brokers (default "localhost:9092")
+#   KAFKA_AUTH_TYPE string
+#     	kafka authentication type (mtls, sasl or empty) (default "")
+#   KAFKA_CA_CERT string
+#     	kafka TLS CA certificate path (default "")
 #   APP_CACHE_TYPE string
 #     	application cache (none, memory, redis) (default "none")
+#   APP_CACHE_EXPIRATION int64
+#     	expiration for both memory and Redis (time interval syntax) (default "1h")
 #   TELEMETRY_JAEGER_ENABLED bool
 #     	open telemetry jaeger exporter (default "false")
 #   TELEMETRY_JAEGER_ENDPOINT string
@@ -114,6 +134,14 @@
 #     	sources credentials (dev only) (default "")
 #   REST_ENDPOINTS_SOURCES_PASSWORD string
 #     	sources credentials (dev only) (default "")
+#   KAFKA_SASL_USERNAME string
+#     	kafka SASL username (default "")
+#   KAFKA_SASL_PASSWORD string
+#     	kafka SASL password (default "")
+#   KAFKA_SASL_MECHANISM string
+#     	kafka SASL mechanism (scram-sha-512, scram-sha-256 or plain) (default "")
+#   KAFKA_SASL_PROTOCOL string
+#     	kafka SASL security protocol (default "")
 #   APP_CACHE_REDIS_HOST string
 #     	redis hostname (default "localhost")
 #   APP_CACHE_REDIS_PORT int
@@ -124,8 +152,6 @@
 #     	redis password (default "")
 #   APP_CACHE_REDIS_DB int
 #     	redis database number (default "0")
-#   APP_CACHE_MEM_EXPIRATION int64
-#     	in-memory cache expiration (time interval syntax) (default "1h")
 #   APP_CACHE_MEM_CLEANUP_INTERVAL int64
 #     	in-memory expiration interval (time interval syntax) (default "5m")
 #   REST_ENDPOINTS_IMAGE_BUILDER_PROXY_URL string

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -78,6 +78,12 @@ objects:
                     name: provisioning-azure-acc
                     key: client_secret
                     optional: true
+              - name: AZURE_CLIENT_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: provisioning-azure-acc
+                    key: client_name
+                    optional: true
               - name: SENTRY_DSN
                 valueFrom:
                   secretKeyRef:
@@ -248,6 +254,12 @@ objects:
                   secretKeyRef:
                     name: provisioning-azure-acc
                     key: client_secret
+                    optional: true
+              - name: AZURE_CLIENT_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: provisioning-azure-acc
+                    key: client_name
                     optional: true
               - name: SENTRY_DSN
                 valueFrom:

--- a/docs/configure-azure.md
+++ b/docs/configure-azure.md
@@ -6,9 +6,25 @@ In this article, we will describe how to create necessary service account setup 
 
 ## Setup Azure service account
 
-### Prepare the Azure account
+Lighthouse offering is concept how one Azure account offers (offering tenant) to another (target tenant, also customer) given solution.
+Main concept to understand is [cross-tenant management](https://learn.microsoft.com/en-us/azure/lighthouse/concepts/cross-tenant-management-experience).
+The offering can deploy anything that Azure Resource Manager allows.
+In our use case we use only permission delegation.
 
-This account is the one that our app will use to connect to the Azure service.
+The template we will prepare provides roles in target Tenant to the Principal from offering tenant.
+The template assigns following roles to the offering Principal:
+
+| Role name                                                                                                                                   | UUID                                 | Motivation                                                                                                                                         |
+|---------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader)                                           | acdd72a7-3385-48ef-bd42-f606fba81ae7 | Allows us to fetch information about resources                                                                                                     |
+| [Virtual Machine Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#virtual-machine-contributor) | 9980e02c-c2be-4d73-94e8-173b1dc7cf3c | Allows to deploy virtual machines                                                                                                                  |
+| [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) | b24988ac-6180-42a0-ab88-20f7382dd24c | Unfortunate wokaround for creating supporting resources, hopefully better solution will be found and this role will not be necessary in the future |
+
+
+### Prepare Azure offering tenant
+
+Here we will prepare the principal in offering tenant.
+This Principal will get the permissions once Customer tenant accepts the offering.
 
 - Go to Azure Active Directory
 - Copy Tenant ID into config/api.env `AZURE_TENANT_ID`
@@ -25,13 +41,19 @@ This account is the one that our app will use to connect to the Azure service.
 
 ### Prepare the Lighthouse offering
 
-- Take [`lighthouse_template.json`](./lighthouse_template.json)
-- Replace `<ProviderTenantID>` by value in `AZURE_TENANT_ID`
+Following steps get us the offering template:
+
+- Start with the template [`lighthouse_template.json`](./lighthouse.tmpl.json)
+- Replace `{{.TenantID}}` by value in `AZURE_TENANT_ID`
 - Go to Azure AD -> Enterprise applications
   - Select the App that was automatically registered for the App registration (provisioning-service)
   - Copy Object ID
-- Replace `<EnterpriseAppID>` by the value copied from above
-- Replace `<EnterpriseAppName>` by the name of the enterprise application (provisioning-service)
+  - Replace `{{.EnterpriseAppID}}` by the value copied from above
+  - Replace `{{.EnterpriseAppName}}` by the name of the enterprise application (provisioning-service)
+- Set default offering name and description
+  - Tenant account can change this while accepting the offering
+  - Replace `{{.OfferingDefaultName}}` by a default offering name
+  - Replace `{{.OfferingDefaultDescription}}` by a default offering description
 - Put this json on publicly available URL (gist for example)
 
 ### Get lighthouse offering URL
@@ -39,7 +61,7 @@ This account is the one that our app will use to connect to the Azure service.
 - Obfuscate the URL by escaping it for URL possibly by https://www.urlencoder.org/
 - Compose the url by replacing above url for `<obfuscatedURI>` in https://portal.azure.com/#create/Microsoft.Template/uri/<obfuscatedURI>
 
-## Setup Tenant account
+## Setup Tenant (Customer) account
 
 This is the account we want to deploy into.
 

--- a/docs/lighthouse.tmpl.json
+++ b/docs/lighthouse.tmpl.json
@@ -1,0 +1,1 @@
+internal/clients/http/azure/lighthouse.tmpl.json

--- a/internal/clients/azure_offering_template.go
+++ b/internal/clients/azure_offering_template.go
@@ -1,0 +1,40 @@
+package clients
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+	"text/template"
+)
+
+//go:embed http/azure/lighthouse.tmpl.json
+var offeringTemplate string
+
+type AzureOfferingTemplate struct {
+	// OfferingDefaultName that Customer can change while deploying the offering
+	OfferingDefaultName string
+
+	// OfferingDefaultDescription describing the offering, can be changed by Customer while deploying
+	OfferingDefaultDescription string
+
+	// TenantID of the offering tenant (Azure account)
+	TenantID string
+
+	// EnterpriseAppID of the App that will act as an offering Principal
+	EnterpriseAppID string
+
+	// EnterpriseAppName of the offering principal - the display name
+	EnterpriseAppName string
+}
+
+func (tempParams AzureOfferingTemplate) Render(ctx context.Context, wr io.Writer) error {
+	tmpl, err := template.New("lighthouse.tmpl.json").Parse(offeringTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse Azure template: %w", err)
+	}
+	if err = tmpl.Execute(wr, tempParams); err != nil {
+		return fmt.Errorf("failed to render Azure offering: %w", err)
+	}
+	return nil
+}

--- a/internal/clients/http/azure/lighthouse.tmpl.json
+++ b/internal/clients/http/azure/lighthouse.tmpl.json
@@ -7,34 +7,34 @@
       "metadata": {
         "description": "Specify a unique name for your offer"
       },
-      "defaultValue": "Provisioning CRC"
+      "defaultValue": "{{.OfferingDefaultName}}"
     },
     "mspOfferDescription": {
       "type": "string",
       "metadata": {
         "description": "Name of the Managed Service Provider offering"
       },
-      "defaultValue": "ConsoleDot provisioning"
+      "defaultValue": "{{.OfferingDefaultDescription}}"
     }
   },
   "variables": {
     "mspRegistrationName": "[guid(parameters('mspOfferName'))]",
     "mspAssignmentName": "[guid(parameters('mspOfferName'))]",
-    "managedByTenantId": "<ProviderTenantID>",
+    "managedByTenantId": "{{.TenantID}}",
     "authorizations": [
       {
-        "principalId": "<EnterpriseAppID>",
-        "principalIdDisplayName": "<EnterpriseAppName>",
-        "roleDefinitionId": "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
-      },
-      {
-        "principalId": "<EnterpriseAppID>",
-        "principalIdDisplayName": "<EnterpriseAppName>",
+        "principalId": "{{.EnterpriseAppID}}",
+        "principalIdDisplayName": "{{.EnterpriseAppName}}",
         "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7"
       },
       {
-        "principalId": "<EnterpriseAppID>",
-        "principalIdDisplayName": "<EnterpriseAppName>",
+        "principalId": "{{.EnterpriseAppID}}",
+        "principalIdDisplayName": "{{.EnterpriseAppName}}",
+        "roleDefinitionId": "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+      },
+      {
+        "principalId": "{{.EnterpriseAppID}}",
+        "principalIdDisplayName": "{{.EnterpriseAppName}}",
         "roleDefinitionId": "b24988ac-6180-42a0-ab88-20f7382dd24c"
       }
     ]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,11 +81,13 @@ var config struct {
 		Logging       bool   `env:"LOGGING" env-default:"false" env-description:"AWS service account logging (verbose)"`
 	} `env-prefix:"AWS_"`
 	Azure struct {
-		TenantID       string `env:"TENANT_ID" env-default:"" env-description:"Azure service account tenant id"`
+		TenantID      string `env:"TENANT_ID" env-default:"" env-description:"Azure service account tenant id"`
+		ClientID      string `env:"CLIENT_ID" env-default:"" env-description:"Azure service account client id"`
+		ClientSecret  string `env:"CLIENT_SECRET" env-default:"" env-description:"Azure service account client secret"`
+		ClientName    string `env:"CLIENT_NAME" env-default:"RH HCC" env-description:"Azure service account display name"`
+		DefaultRegion string `env:"DEFAULT_REGION" env-default:"eastus" env-description:"Azure region when not provided"`
+		// SubscriptionID is not used in prod environments - used to fetch instance types
 		SubscriptionID string `env:"SUBSCRIPTION_ID" env-default:"" env-description:"Azure service account subscription id"`
-		ClientID       string `env:"CLIENT_ID" env-default:"" env-description:"Azure service account client id"`
-		ClientSecret   string `env:"CLIENT_SECRET" env-default:"" env-description:"Azure service account client secret"`
-		DefaultRegion  string `env:"DEFAULT_REGION" env-default:"eastus" env-description:"Azure region when not provided"`
 	} `env-prefix:"AZURE_"`
 	GCP struct {
 		ProjectID   string `env:"PROJECT_ID" env-default:"" env-description:"GCP service account project id"`

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -46,6 +46,9 @@ func MountAPI(r *chi.Mux) {
 		r.Use(middleware.ETagMiddleware(api.ETagValue))
 		r.Get("/", api.ServeOpenAPISpec)
 	})
+
+	r.Get("/azure_offering_template", s.AzureOfferingTemplate)
+
 	r.Group(func(r chi.Router) {
 		r.Use(middleware.EnforceIdentity)
 		r.Use(middleware.AccountMiddleware)

--- a/internal/services/azure_offering_template_service.go
+++ b/internal/services/azure_offering_template_service.go
@@ -1,0 +1,29 @@
+package services
+
+import (
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+)
+
+func AzureOfferingTemplate(w http.ResponseWriter, r *http.Request) {
+	clientName := config.Azure.ClientName
+	if clientName == "" {
+		clientName = "Red Hat Launch images client"
+	}
+
+	tmpl := clients.AzureOfferingTemplate{
+		OfferingDefaultName:        "Red Hat Hybrid Cloud Console",
+		OfferingDefaultDescription: "Allows Red Hat to upload images and deploy Virtual Machines from Hybrid cloud console",
+		TenantID:                   config.Azure.TenantID,
+		EnterpriseAppID:            config.Azure.ClientID,
+		EnterpriseAppName:          clientName,
+	}
+
+	if err := tmpl.Render(r.Context(), w); err != nil {
+		renderError(w, r, payloads.NewRenderError(r.Context(), "failed to render the Azure template", err))
+		return
+	}
+}

--- a/internal/services/azure_offering_template_service_test.go
+++ b/internal/services/azure_offering_template_service_test.go
@@ -1,0 +1,33 @@
+package services_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RHEnVision/provisioning-backend/internal/services"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAzureOfferingTemplate(t *testing.T) {
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/v1/azure_offering_template", nil)
+	require.NoError(t, err, "failed to create request")
+	req.Header.Add("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(services.AzureOfferingTemplate)
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
+
+	var data map[string]interface{}
+	err = json.Unmarshal(rr.Body.Bytes(), &data)
+	require.NoError(t, err, "failed to parse the template from response")
+
+	// Check template has expected key - just simple check for now
+	_, ok := data["parameters"]
+	require.True(t, ok, "the rendered template does not seem correct")
+}


### PR DESCRIPTION
Might not be ideal solution to the problem , I feel it being bit nasty, but it gives us quite some benefits:
- We are testing the template we use in documentation, cool :tada:
- We can't forget change the tenant in template, because it's dynamic
- We can change the template in code. Cool.

Happy to hear improvements on the technical solution tho :)
I would whole heartedly agree it has quite some quirks :stuck_out_tongue: 

-----

Adds lighthouse offering template rendering.
This makes the template available on a public URL.
Reuses the documentation template.

Also improves the documentation of Why in the Azure devel doc.

Refs HMS-1148

-----

Add lighthouse template to the container image during build.
Fixes the build container on 1.18 tag
Adds latest to ubi-minimal
