### PR TITLE
fix(HMS-1240): add step titles back

### DIFF
--- a/internal/dao/pgx/reservation_pgx.go
+++ b/internal/dao/pgx/reservation_pgx.go
@@ -127,12 +127,13 @@ func (x *reservationDao) createGenericReservation(ctx context.Context, reservati
 	reservation.AccountID = ctxval.AccountId(ctx)
 	reservation.Status = "Created"
 
-	reservationQuery := `INSERT INTO reservations (provider, account_id, steps, status)
-		VALUES ($1, $2, $3, $4) RETURNING id, created_at`
+	reservationQuery := `INSERT INTO reservations (provider, account_id, steps, step_titles, status)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id, created_at`
 	err := db.Pool.QueryRow(ctx, reservationQuery,
 		reservation.Provider,
 		reservation.AccountID,
 		reservation.Steps,
+		reservation.StepTitles,
 		reservation.Status).Scan(&reservation.ID, &reservation.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("failed to create reservation record: %w", err)

--- a/internal/dao/tests/reservation_test.go
+++ b/internal/dao/tests/reservation_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/db"
@@ -76,6 +77,11 @@ func TestReservationCreateNoop(t *testing.T) {
 		newRes, err := reservationDao.GetById(ctx, res.ID)
 		require.NoError(t, err)
 		assert.Equal(t, res.ID, newRes.ID)
+		assert.Equal(t, res.AccountID, newRes.AccountID)
+		assert.Equal(t, res.StepTitles, newRes.StepTitles)
+		assert.Equal(t, res.Steps, newRes.Steps)
+		assert.Equal(t, res.Status, newRes.Status)
+		assert.Equal(t, time.Now().Year(), res.CreatedAt.Year())
 	})
 }
 
@@ -91,6 +97,11 @@ func TestReservationGetById(t *testing.T) {
 		newRes, err := reservationDao.GetById(ctx, res.ID)
 		require.NoError(t, err)
 		assert.Equal(t, res.ID, newRes.ID)
+		assert.Equal(t, res.AccountID, newRes.AccountID)
+		assert.Equal(t, res.StepTitles, newRes.StepTitles)
+		assert.Equal(t, res.Steps, newRes.Steps)
+		assert.Equal(t, res.Status, newRes.Status)
+		assert.Equal(t, time.Now().Year(), res.CreatedAt.Year())
 	})
 
 	t.Run("no rows", func(t *testing.T) {
@@ -111,6 +122,11 @@ func TestReservationCreateAWS(t *testing.T) {
 		newRes, err := reservationDao.GetById(ctx, res.ID)
 		require.NoError(t, err)
 		assert.Equal(t, res.ID, newRes.ID)
+		assert.Equal(t, res.AccountID, newRes.AccountID)
+		assert.Equal(t, res.StepTitles, newRes.StepTitles)
+		assert.Equal(t, res.Steps, newRes.Steps)
+		assert.Equal(t, res.Status, newRes.Status)
+		assert.Equal(t, time.Now().Year(), res.CreatedAt.Year())
 	})
 }
 
@@ -126,6 +142,11 @@ func TestReservationCreateGCP(t *testing.T) {
 		newRes, err := reservationDao.GetById(ctx, res.ID)
 		require.NoError(t, err)
 		assert.Equal(t, res.ID, newRes.ID)
+		assert.Equal(t, res.AccountID, newRes.AccountID)
+		assert.Equal(t, res.StepTitles, newRes.StepTitles)
+		assert.Equal(t, res.Steps, newRes.Steps)
+		assert.Equal(t, res.Status, newRes.Status)
+		assert.Equal(t, time.Now().Year(), res.CreatedAt.Year())
 	})
 }
 


### PR DESCRIPTION
This fixes a regression introduced by Azure refactoring: https://github.com/RHEnVision/provisioning-backend/commit/02b55c39af439a06db029ec0fb7a02a1286406c4

The step_titles column somehow dropped from the code, I assume you had the branch from earlier than it was introduced.

This is a regression. QA scenario:

* Create an AWS reservation.
* Get reservation details through `reservations/aws/ID` (not `reservations/ID` that returns only basic data)
* Check if it contains all the generic fields (success, status, steps, step_titles...)
* Check if it contains all the AWS fields (instance id, amount, instance type...)
