### PR TITLE
Update job queue metrics

### DIFF
--- a/cmd/pbapi/main.go
+++ b/cmd/pbapi/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	// initialize background goroutines
 	bgCtx, bgCancel := context.WithCancel(ctx)
-	background.Initialize(bgCtx)
+	background.InitializeApi(bgCtx)
 	defer bgCancel()
 
 	// initialize job queue

--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -116,7 +116,7 @@ func checkSourceAvailabilityAzure(ctx context.Context) {
 
 	for s := range chAzure {
 		logger.Trace().Msgf("Checking Azure source availability status %s", s.SourceApplicationID)
-		metrics.ObserveAvailablilityCheckReqsDuration(models.ProviderTypeAzure, func() error {
+		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeAzure, func() error {
 			var err error
 			sr := kafka.SourceResult{
 				ResourceID:   s.SourceApplicationID,
@@ -139,7 +139,7 @@ func checkSourceAvailabilityAWS(ctx context.Context) {
 
 	for s := range chAws {
 		logger.Trace().Msgf("Checking AWS source availability status %s", s.SourceApplicationID)
-		metrics.ObserveAvailablilityCheckReqsDuration(models.ProviderTypeAWS, func() error {
+		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeAWS, func() error {
 			var err error
 			sr := kafka.SourceResult{
 				ResourceID:   s.SourceApplicationID,
@@ -168,7 +168,7 @@ func checkSourceAvailabilityGCP(ctx context.Context) {
 
 	for s := range chGcp {
 		logger.Trace().Msgf("Checking GCP source availability status %s", s.SourceApplicationID)
-		metrics.ObserveAvailablilityCheckReqsDuration(models.ProviderTypeGCP, func() error {
+		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeGCP, func() error {
 			var err error
 			sr := kafka.SourceResult{
 				ResourceID:   s.SourceApplicationID,

--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
+	"github.com/RHEnVision/provisioning-backend/internal/random"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 
 	// Clients
@@ -54,6 +55,10 @@ var (
 	processingWG = sync.WaitGroup{}
 	senderWG     = sync.WaitGroup{}
 )
+
+func init() {
+	random.SeedGlobal()
+}
 
 func processMessage(origCtx context.Context, message *kafka.GenericMessage) {
 	logger := ctxval.Logger(origCtx)

--- a/cmd/pbworker/main.go
+++ b/cmd/pbworker/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/RHEnVision/provisioning-backend/internal/background"
 	"github.com/RHEnVision/provisioning-backend/internal/cache"
 	"github.com/RHEnVision/provisioning-backend/internal/queue/jq"
 	"github.com/RHEnVision/provisioning-backend/internal/random"
@@ -72,6 +73,11 @@ func main() {
 	}
 	jq.RegisterJobs(&logger)
 	jq.StartDequeueLoop(ctx)
+
+	// initialize background goroutines
+	bgCtx, bgCancel := context.WithCancel(ctx)
+	background.InitializeWorker(bgCtx, hostname)
+	defer bgCancel()
 
 	// wait for term signal
 	c := make(chan os.Signal, 1)

--- a/internal/background/initialize.go
+++ b/internal/background/initialize.go
@@ -13,11 +13,22 @@ import (
 // incoming requests to overload the sender.
 const availabilityStatusBatchSize = 1024
 
-// Initialize starts background goroutines. Use context cancellation to stop them.
-func Initialize(ctx context.Context) {
+// InitializeApi starts background goroutines for REST API processes.
+// Use context cancellation to stop them.
+func InitializeApi(ctx context.Context) {
 	logger := ctxval.Logger(ctx).With().Bool("background", true).Logger()
 	ctx = ctxval.WithLogger(ctx, &logger)
 
 	// start availability request batch sender
 	go sendAvailabilityRequestMessages(ctx, availabilityStatusBatchSize, 5*time.Second)
+}
+
+// InitializeWorker starts background goroutines for worker processes.
+// Use context cancellation to stop them.
+func InitializeWorker(ctx context.Context, workerName string) {
+	logger := ctxval.Logger(ctx).With().Bool("background", true).Logger()
+	ctx = ctxval.WithLogger(ctx, &logger)
+
+	// start job queue telemetry
+	go jobQueueMetricLoop(ctx, 30*time.Second, workerName)
 }

--- a/internal/background/queue_metrics.go
+++ b/internal/background/queue_metrics.go
@@ -1,0 +1,40 @@
+package background
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/RHEnVision/provisioning-backend/internal/metrics"
+	"github.com/RHEnVision/provisioning-backend/internal/queue/jq"
+)
+
+//nolint:gosec
+// jobQueueMetricLoop is a background function that runs for all workers.
+// It polls job queue statistics from Redis as well as in-flight counters.
+// It waits a random delay between 0 and sleep for better polling spread
+// since job queue size is a global metric (redis queue length).
+func jobQueueMetricLoop(ctx context.Context, sleep time.Duration, name string) {
+	logger := ctxval.Logger(ctx)
+
+	// spread polling intervals
+	randSleep := rand.Int63() % sleep.Milliseconds()
+	logger.Debug().Msgf("Job queue metric delay %dms", randSleep)
+	time.Sleep(time.Duration(randSleep) * time.Millisecond)
+	ticker := time.NewTicker(sleep)
+
+	for {
+		select {
+		case <-ticker.C:
+			stats := jq.Stats(ctx)
+			metrics.SetJobQueueSize(stats.EnqueuedJobs)
+			metrics.SetJobQueueInFlight(name, stats.InFlight)
+
+		case <-ctx.Done():
+			ticker.Stop()
+			logger.Debug().Msg("Stopping job queue metric loop")
+			return
+		}
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -45,7 +45,7 @@ var AvailabilityCheckReqsDuration = prometheus.NewHistogramVec(
 	[]string{"type", "error"},
 )
 
-func ObserveAvailablilityCheckReqsDuration(provider models.ProviderType, ObservedFunc func() error) {
+func ObserveAvailabilityCheckReqsDuration(provider models.ProviderType, ObservedFunc func() error) {
 	errString := "false"
 	start := time.Now()
 	defer func() {

--- a/internal/random/random.go
+++ b/internal/random/random.go
@@ -7,23 +7,31 @@ package random
 import (
 	crand "crypto/rand"
 	"encoding/binary"
-	"math/rand"
+	mrand "math/rand"
 
 	"go.opentelemetry.io/otel/trace"
+	erand "golang.org/x/exp/rand"
 )
 
 // SeedGlobal can be used to initialize the global thread-safe pseudo-random
 // generator from the standard library. This should be called from all init()
 // functions for all binaries.
+//
+// It seeds both math/rand and e/exp/rand packages just in case IDE imports
+// one or the other by accident.
 func SeedGlobal() {
-	var rngSeed int64
-	_ = binary.Read(crand.Reader, binary.LittleEndian, &rngSeed)
-	rand.Seed(rngSeed)
+	var seedInt64 int64
+	_ = binary.Read(crand.Reader, binary.LittleEndian, &seedInt64)
+	mrand.Seed(seedInt64)
+
+	var seedUint64 uint64
+	_ = binary.Read(crand.Reader, binary.LittleEndian, &seedUint64)
+	erand.Seed(seedUint64)
 }
 
 // TraceID generates a random OpenTelemetry Trace ID.
 func TraceID() trace.TraceID {
 	tid := trace.TraceID{}
-	_, _ = rand.Read(tid[:])
+	_, _ = mrand.Read(tid[:])
 	return tid
 }

--- a/pkg/worker/job.go
+++ b/pkg/worker/job.go
@@ -61,10 +61,10 @@ type JobWorker interface {
 
 // Stats provides monitoring statistics.
 type Stats struct {
-	// Number of jobs currently in the queue
+	// Number of jobs currently in the queue. This is a global value - all clients see the same value.
 	EnqueuedJobs uint64
 
-	// Number of jobs currently being processed
+	// Number of jobs currently being processed. Local value - each client has its own number.
 	InFlight int64
 }
 

--- a/pkg/worker/redis.go
+++ b/pkg/worker/redis.go
@@ -136,7 +136,7 @@ func (w *RedisWorker) dequeueLoop(ctx context.Context, i, total int) {
 
 	// spread polling intervals
 	delayMs := (int(w.pollInterval.Milliseconds()) / total) * (i - 1)
-	logger.Info().Msgf("Worker start delay %dms", delayMs)
+	logger.Debug().Msgf("Worker start delay %dms", delayMs)
 	time.Sleep(time.Duration(delayMs) * time.Millisecond)
 
 	for {


### PR DESCRIPTION
This patch updates the job queue size metric and adds new metric that represents in-flight tasks: number of tasks which are currently in processing. Note that while job queue size is a global value (Gauge) - this is actually a redis queue length, the in-flight number is different for each consumer/worker (GaugeVec, vectorized by worker unique hostname).

For monitoring and alerts, we are interested in the following:

* Job queue size (one number). When it hits > 1000 we should alert that workers are too slow picking up new jobs (not running for example).
* In-flight count (sum). When the sum is > 500 we should alert that workers are probably too busy (can hit CPU/memory limits at some point).

I am making these numbers up these are educated guesses, feel free to tune them up. We have 3 workers which are each capable of executing hundreds of jobs in parallel each. So that's why 1000/500.

Now, the implementation is a bit tricky. I refactored the job queue size from a callback to just a regular "observation" function which is prefixed with Set as that is the function name Prometheus use for gauge metrics. There is now a new background goroutine which is spawned for each worker process. Every 30 seconds, it performs statistics read which in fact makes a call to Redis to get the queue length. It also picks up the in-flight number - this one is different for each worker.

Now, because we have 3 workers and we do not need this metric every 5 seconds, each worker does this. Ideally only one worker should be doing job queue length and all workers inflight, but since it is difficult to find out which is "number one" container in k8s, I am going for the easy solution - all do the same, the polling interval is 30 seconds and the start is randomized so approximetly every 10 seconds we get the updated gauge values.

During work, I noticed a typo in a metric name so I fixed it in a separate commit.

I also noticed that my IDE really wants me to use `x/exp/rand` package which has its own global pseudo random generator. This led to situation when my patch was always generating the same values, until Go 1.20 random generators are seeded with 1 therefore they always return the same numbers. Although this changes in 1.20, I am making a small change - our `random.InitializeSeed` function seeds both `math/rand` and `x/exp/rand` just in case someone else accidentally imports the experimental random package (which has the same interface but unseeded global generator).