### PR TITLE
fix(HMS-1260): document pubkey and template behavior

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -559,7 +559,7 @@
     },
     "/reservations/aws": {
       "post": {
-        "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. An AWS reservation is a reservation created for an AWS job. Image Builder UUID image is required, the service will also launch any AMI image prefixed with \"ami-\".\n",
+        "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. An AWS reservation is a reservation created for an AWS job. Image Builder UUID image is required, the service will also launch any AMI image prefixed with \"ami-\". Optionally, AWS EC2 launch template ID can be provided. All flags set through this endpoint override template values. Public key must exist prior calling this endpoint and ID must be provided, even when AWS EC2 launch template provides ssh-keys. Public key will be always be overwritten.\n",
         "operationId": "createAwsReservation",
         "requestBody": {
           "content": {

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -295,6 +295,10 @@ paths:
         A reservation is a way to activate a job, keeps all data needed for a job to start.
         An AWS reservation is a reservation created for an AWS job. Image Builder UUID image
         is required, the service will also launch any AMI image prefixed with "ami-".
+        Optionally, AWS EC2 launch template ID can be provided. All flags set through this
+        endpoint override template values.
+        Public key must exist prior calling this endpoint and ID must be provided, even when
+        AWS EC2 launch template provides ssh-keys. Public key will be always be overwritten.
       requestBody:
         content:
           application/json:

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -295,6 +295,10 @@ paths:
         A reservation is a way to activate a job, keeps all data needed for a job to start.
         An AWS reservation is a reservation created for an AWS job. Image Builder UUID image
         is required, the service will also launch any AMI image prefixed with "ami-".
+        Optionally, AWS EC2 launch template ID can be provided. All flags set through this
+        endpoint override template values.
+        Public key must exist prior calling this endpoint and ID must be provided, even when
+        AWS EC2 launch template provides ssh-keys. Public key will be always be overwritten.
       requestBody:
         content:
           application/json:

--- a/internal/dao/pgx/reservation_pgx.go
+++ b/internal/dao/pgx/reservation_pgx.go
@@ -56,7 +56,7 @@ func (x *reservationDao) CreateAWS(ctx context.Context, reservation *models.AWSR
 	})
 
 	if txErr != nil {
-		return fmt.Errorf("pgx transaction error: %w", txErr)
+		return fmt.Errorf("pgx tx error: %w", txErr)
 	}
 	return nil
 }
@@ -87,7 +87,7 @@ func (x *reservationDao) CreateAzure(ctx context.Context, reservation *models.Az
 	})
 
 	if txErr != nil {
-		return fmt.Errorf("pgx transaction error: %w", txErr)
+		return fmt.Errorf("pgx tx error: %w", txErr)
 	}
 	return nil
 }
@@ -118,7 +118,7 @@ func (x *reservationDao) CreateGCP(ctx context.Context, reservation *models.GCPR
 	})
 
 	if txErr != nil {
-		return fmt.Errorf("pgx transaction error: %w", txErr)
+		return fmt.Errorf("pgx tx error: %w", txErr)
 	}
 	return nil
 }

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -141,7 +141,7 @@ type NoopReservationResponsePayload struct {
 }
 
 type AWSReservationRequestPayload struct {
-	// Pubkey ID.
+	// Pubkey ID. Always required even when launch template provides one.
 	PubkeyID int64 `json:"pubkey_id"`
 
 	// Source ID.
@@ -154,7 +154,7 @@ type AWSReservationRequestPayload struct {
 	Name string `json:"name"`
 
 	// Optional launch template ID ("lt-9848392734432") or empty for no template.
-	LaunchTemplateID string `json:"launch_template_id"`
+	LaunchTemplateID string `json:"launch_template_id,omitempty"`
 
 	// AWS Instance type.
 	InstanceType string `json:"instance_type"`

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -77,7 +77,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	newName := config.Application.InstancePrefix + payload.Name
 	reservation.Detail.Name = &newName
 
-	// validate pubkey
+	// validate pubkey - must be always present because of data integrity (foreign keys)
 	logger.Debug().Msgf("Validating existence of pubkey %d for this account", reservation.PubkeyID)
 	pk, err := pkDao.GetById(r.Context(), reservation.PubkeyID)
 	if err != nil {


### PR DESCRIPTION
I propose to insist on pubkeys even when launch templates are required. We have foreign keys and we would need to introduce NULLs and do OUTER JOINs just for this small use case. For now I think this should be reasonable approach.

So this patch changes nothing effectively, but documents this in the OpenAPI spec.

While working on this, I noticed that the transaction code tries to commit after rollback which is leading to incorrect error - the original root cause is thrown away and "cannot commit: transaction is closed" is returned to the client. This fixes it.