### PR TITLE
fix(HMS-1259): update avail check buckets to ms

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -43,6 +43,7 @@ var AvailabilityCheckReqsDuration = prometheus.NewHistogramVec(
 		Name:        "provisioning_source_availability_check_request_duration_ms",
 		Help:        "availability check request duration partitioned by type and error",
 		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName, "component": "statuser"},
+		Buckets:     []float64{5, 10, 50, 100, 250, 500, 1000, 2500, 5000, 10000},
 	},
 	[]string{"type", "error"},
 )


### PR DESCRIPTION
Default prometheus buckets are in seconds:

    var DefBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}

However our metric is in ms, therefore we need to define buckets in ms too in order to get any reasonable numbers from this metric. This patch fixes that.