### PR TITLE
fix(HMS-879): workers metrics

### DIFF
--- a/cmd/pbapi/main.go
+++ b/cmd/pbapi/main.go
@@ -160,10 +160,10 @@ func main() {
 		signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
 		<-sigint
 		if err := apiServer.Shutdown(context.Background()); err != nil {
-			log.Fatal().Err(err).Msg("Main service shutdown error")
+			log.Warn().Err(err).Msg("Main service shutdown error")
 		}
 		if err := metricsServer.Shutdown(context.Background()); err != nil {
-			log.Fatal().Err(err).Msg("Metrics service shutdown error")
+			log.Warn().Err(err).Msg("Metrics service shutdown error")
 		}
 		close(waitForSignal)
 	}()
@@ -181,7 +181,7 @@ func main() {
 
 	if err := apiServer.ListenAndServe(); err != nil {
 		if !errors.Is(err, http.ErrServerClosed) {
-			log.Fatal().Err(err).Msg("Main service listen error")
+			log.Warn().Err(err).Msg("Main service listen error")
 		}
 	}
 

--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -121,7 +121,7 @@ func checkSourceAvailabilityAzure(ctx context.Context) {
 
 	for s := range chAzure {
 		logger.Trace().Msgf("Checking Azure source availability status %s", s.SourceApplicationID)
-		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeAzure, func() error {
+		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeAzure.String(), func() error {
 			var err error
 			sr := kafka.SourceResult{
 				ResourceID:   s.SourceApplicationID,
@@ -131,7 +131,7 @@ func checkSourceAvailabilityAzure(ctx context.Context) {
 			// TODO: check if source is avavliable - WIP
 			sr.Status = kafka.StatusAvaliable
 			chSend <- sr
-			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeAzure, sr.Status, nil)
+			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeAzure.String(), sr.Status.String(), nil)
 
 			return fmt.Errorf("error during check: %w", err)
 		})
@@ -144,7 +144,7 @@ func checkSourceAvailabilityAWS(ctx context.Context) {
 
 	for s := range chAws {
 		logger.Trace().Msgf("Checking AWS source availability status %s", s.SourceApplicationID)
-		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeAWS, func() error {
+		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeAWS.String(), func() error {
 			var err error
 			sr := kafka.SourceResult{
 				ResourceID:   s.SourceApplicationID,
@@ -161,7 +161,7 @@ func checkSourceAvailabilityAWS(ctx context.Context) {
 				sr.Status = kafka.StatusAvaliable
 				chSend <- sr
 			}
-			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeAWS, sr.Status, err)
+			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeAWS.String(), sr.Status.String(), err)
 			return fmt.Errorf("error during check: %w", err)
 		})
 	}
@@ -173,7 +173,7 @@ func checkSourceAvailabilityGCP(ctx context.Context) {
 
 	for s := range chGcp {
 		logger.Trace().Msgf("Checking GCP source availability status %s", s.SourceApplicationID)
-		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeGCP, func() error {
+		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeGCP.String(), func() error {
 			var err error
 			sr := kafka.SourceResult{
 				ResourceID:   s.SourceApplicationID,
@@ -197,7 +197,7 @@ func checkSourceAvailabilityGCP(ctx context.Context) {
 				sr.Status = kafka.StatusAvaliable
 				chSend <- sr
 			}
-			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeGCP, sr.Status, err)
+			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeGCP.String(), sr.Status.String(), err)
 
 			return fmt.Errorf("error during check: %w", err)
 		})
@@ -311,7 +311,7 @@ func main() {
 		signal.Notify(sigint, syscall.SIGINT, syscall.SIGTERM)
 		<-sigint
 		if err := metricsServer.Shutdown(context.Background()); err != nil {
-			logger.Fatal().Err(err).Msg("Metrics service shutdown error")
+			logger.Warn().Err(err).Msg("Metrics service shutdown error")
 		}
 		close(signalNotify)
 	}()

--- a/internal/kafka/source_result.go
+++ b/internal/kafka/source_result.go
@@ -29,3 +29,7 @@ type SourceResult struct {
 func (sr SourceResult) GenericMessage(ctx context.Context) (GenericMessage, error) {
 	return genericMessage(ctx, sr, sr.ResourceID, SourcesStatusTopic)
 }
+
+func (st StatusType) String() string {
+	return string(st)
+}

--- a/pkg/worker/job.go
+++ b/pkg/worker/job.go
@@ -59,6 +59,10 @@ type JobWorker interface {
 	Stats(ctx context.Context) (Stats, error)
 }
 
+func (jt JobType) String() string {
+	return string(jt)
+}
+
 // Stats provides monitoring statistics.
 type Stats struct {
 	// Number of jobs currently in the queue. This is a global value - all clients see the same value.


### PR DESCRIPTION
This adds a new duration metric which captures duration of every job processed from the background redis queue. It contains "type" label which is the job name, e.g. `launch_instances_aws` for AWS EC2 launch job. Since this is the first metric we have in workers, the patch adds a new prometheus endpoint in the main function.