### PR TITLE
docs: Update HMSPROV to HMS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,10 @@
 Make sure your commit message follows this subject style:
 
         type: brief summary up to 70 characters
-        Refs: HMSPROV-XXX
+        Refs: HMS-XXX
 OR
 
-        type(HMSPROV-XXX): brief summary up to 70 characters
+        type(HMS-XXX): brief summary up to 70 characters
 
 Type must be one of the following:
 
@@ -23,11 +23,11 @@ Type must be one of the following:
 * **test**: Adding missing tests or correcting existing tests
 * **revert**: A commit revert
 
-The scope must be [HMSPROV](https://issues.redhat.com/projects/HMSPROV) Jira issue.
+The scope must be [HMS](https://issues.redhat.com/projects/HMS) Jira issue.
 
 For **feat** and **fix** types a Jira issue link is required.
-Please use the scope like `feat(HMSPROV-XXX): subject`
-or put the issue reference in commit body as `Fixes: HMSPROV-XXX` or `Refs: HMSPROV-XXX`
+Please use the scope like `feat(HMS-XXX): subject`
+or put the issue reference in commit body as `Fixes: HMS-XXX` or `Refs: HMS-XXX`
 
 Use `make check-commits` to check commit message locally.
 


### PR DESCRIPTION
Since the HMSPROV commits are failing and the link to Jira is outdated, we might want to update the docs.