### PR TITLE
build: Use static go build version

### DIFF
--- a/build/RedHat.dockerfile
+++ b/build/RedHat.dockerfile
@@ -1,11 +1,11 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:latest as build
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18 as build
 USER 0
 RUN mkdir /build
 WORKDIR /build
 COPY . .
 RUN make prep build strip
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY --from=build /build/pbapi /pbapi
 COPY --from=build /build/pbworker /pbworker
 COPY --from=build /build/pbstatuser /pbstatuser

--- a/build/Upstream.dockerfile
+++ b/build/Upstream.dockerfile
@@ -12,7 +12,7 @@ WORKDIR /build
 COPY . .
 RUN make prep build strip
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY --from=build /build/pbapi /pbapi
 COPY --from=build /build/pbworker /pbworker
 COPY --from=build /build/pbstatuser /pbstatuser

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/RHEnVision/provisioning-backend
 
+// When bumping version, dont forget to bump the build container as well.
+// see build/Dockerfile
 go 1.18
 
 require (


### PR DESCRIPTION
Use static version for go build container.
We want to migrate to new versions consciously.

OTH we want to use the latest ubi version for the final container.