### PR TITLE
Logger initialization refactor

### DIFF
--- a/cmd/pbapi/main.go
+++ b/cmd/pbapi/main.go
@@ -49,20 +49,14 @@ func main() {
 	ctx := context.Background()
 	config.Initialize("config/api.env")
 
-	// initialize stdout logging and AWS clients first
-	logging.InitializeStdout()
-
 	// initialize cloudwatch using the AWS clients
-	logger, clsFunc, err := logging.InitializeCloudwatch(log.Logger)
-	if err != nil {
-		log.Fatal().Err(err).Msg("Error initializing cloudwatch")
-	}
-	defer clsFunc()
+	logger, closeFunc := logging.InitializeLogger()
+	defer closeFunc()
 	log.Logger = logger
 	logging.DumpConfigForDevelopment()
 
 	// initialize feature flags
-	err = config.InitializeFeatureFlags(ctx)
+	err := config.InitializeFeatureFlags(ctx)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Error initializing feature flags")
 	}

--- a/internal/background/initialize.go
+++ b/internal/background/initialize.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 )
 
@@ -25,10 +26,10 @@ func InitializeApi(ctx context.Context) {
 
 // InitializeWorker starts background goroutines for worker processes.
 // Use context cancellation to stop them.
-func InitializeWorker(ctx context.Context, workerName string) {
+func InitializeWorker(ctx context.Context) {
 	logger := ctxval.Logger(ctx).With().Bool("background", true).Logger()
 	ctx = ctxval.WithLogger(ctx, &logger)
 
 	// start job queue telemetry
-	go jobQueueMetricLoop(ctx, 30*time.Second, workerName)
+	go jobQueueMetricLoop(ctx, 30*time.Second, config.Hostname())
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,7 +260,7 @@ func Initialize(configFiles ...string) {
 			config.Cloudwatch.Secret = cw.SecretAccessKey
 			config.Cloudwatch.Region = cw.Region
 			config.Cloudwatch.Group = cw.LogGroup
-			config.Cloudwatch.Stream = path.Base(os.Args[0])
+			config.Cloudwatch.Stream = BinaryName()
 		}
 
 		// HTTP proxies are not allowed in clowder environment
@@ -280,6 +280,10 @@ func Initialize(configFiles ...string) {
 	if err := validate(); err != nil {
 		panic(err)
 	}
+}
+
+func BinaryName() string {
+	return path.Base(os.Args[0])
 }
 
 func HelpText() (string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,7 +51,7 @@ var config struct {
 	} `env-prefix:"DATABASE_"`
 	Logging struct {
 		Level    string `env:"LEVEL" env-default:"info" env-description:"logger level (trace, debug, info, warn, error, fatal, panic)"`
-		Stdout   bool   `env:"STDOUT" env-default:"true" env-description:"logger standard output"`
+		Stdout   bool   `env:"STDOUT" env-default:"true" env-description:"logger standard output, disabled in clowder by default, stdout is still used if there is no other writer"`
 		MaxField int    `env:"MAX_FIELD" env-default:"0" env-description:"logger maximum field length (dev only)"`
 	} `env-prefix:"LOGGING_"`
 	Telemetry struct {
@@ -161,6 +161,16 @@ var (
 	validateMissingSecretError = errors.New("config error: Cloudwatch enabled but Region or Key or Secret are blank")
 	validateGroupStreamError   = errors.New("config error: Cloudwatch enabled but Group or Stream is blank")
 )
+
+var hostname string
+
+func init() {
+	h, err := os.Hostname()
+	if err != nil {
+		h = "unknown-hostname"
+	}
+	hostname = h
+}
 
 // Initialize loads configuration from provided .env files, the first existing file wins.
 func Initialize(configFiles ...string) {
@@ -284,6 +294,10 @@ func Initialize(configFiles ...string) {
 
 func BinaryName() string {
 	return path.Base(os.Args[0])
+}
+
+func Hostname() string {
+	return hostname
 }
 
 func HelpText() (string, error) {

--- a/internal/logging/zerolog.go
+++ b/internal/logging/zerolog.go
@@ -3,7 +3,6 @@ package logging
 import (
 	"fmt"
 	"os"
-	"path"
 	"time"
 	"unicode/utf8"
 
@@ -72,7 +71,7 @@ func InitializeStdout() {
 		FormatFieldValue: func(i interface{}) string {
 			return truncateText(fmt.Sprintf("%s", i), config.Logging.MaxField)
 		},
-	})).With().Str("binary", path.Base(os.Args[0])).Logger()
+	})).With().Str("binary", config.BinaryName()).Logger()
 }
 
 func InitializeCloudwatch(logger zerolog.Logger) (zerolog.Logger, func(), error) {


### PR DESCRIPTION
Pulls initialization in a single function, `InitializeStdout` is used just in tests, where we know we need only stdout logger.