### PR TITLE
refactor: Add test for valid region/zone/location

### DIFF
--- a/internal/services/aws_reservation_service_test.go
+++ b/internal/services/aws_reservation_service_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestCreateAWSReservationHandler(t *testing.T) {
-	var err error
 	var json_data []byte
 	ctx := stubs.WithAccountDaoOne(context.Background())
 	ctx = identity.WithTenant(t, ctx)
@@ -28,30 +27,59 @@ func TestCreateAWSReservationHandler(t *testing.T) {
 	ctx = stubs.WithReservationDao(ctx)
 	ctx = stubs.WithPubkeyDao(ctx)
 	pk := factories.NewPubkeyRSA()
-	err = stubs.AddPubkey(ctx, pk)
+	err := stubs.AddPubkey(ctx, pk)
 	require.NoError(t, err, "failed to generate pubkey")
 
-	values := map[string]interface{}{
-		"source_id":     "1",
-		"image_id":      "2bc640f6-927a-404a-9594-5b2da7e06608",
-		"amount":        1,
-		"instance_type": "t1.micro",
-		"pubkey_id":     pk.ID,
-	}
-	if json_data, err = json.Marshal(values); err != nil {
-		t.Fatalf("unable to marshal values to json: %v", err)
-	}
+	t.Run("successful reservation", func(t *testing.T) {
+		var err error
+		values := map[string]interface{}{
+			"source_id":     "1",
+			"image_id":      "2bc640f6-927a-404a-9594-5b2da7e06608",
+			"amount":        1,
+			"instance_type": "t1.micro",
+			"pubkey_id":     pk.ID,
+		}
+		if json_data, err = json.Marshal(values); err != nil {
+			t.Fatalf("unable to marshal values to json: %v", err)
+		}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/reservations/aws", bytes.NewBuffer(json_data))
-	require.NoError(t, err, "failed to create request")
-	req.Header.Add("Content-Type", "application/json")
+		req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/reservations/aws", bytes.NewBuffer(json_data))
+		require.NoError(t, err, "failed to create request")
+		req.Header.Add("Content-Type", "application/json")
 
-	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(services.CreateAWSReservation)
-	handler.ServeHTTP(rr, req)
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(services.CreateAWSReservation)
+		handler.ServeHTTP(rr, req)
 
-	require.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
+		require.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
 
-	stubCount := stubs.AWSReservationStubCount(ctx)
-	assert.Equal(t, 1, stubCount, "Reservation has not been Created through DAO")
+		stubCount := stubs.AWSReservationStubCount(ctx)
+		assert.Equal(t, 1, stubCount, "Reservation has not been created through DAO")
+	})
+
+	t.Run("failed reservation with invalid region", func(t *testing.T) {
+		var err error
+		values := map[string]interface{}{
+			"source_id":     "1",
+			"image_id":      "2bc640f6-927a-404a-9594-5b2da7e06608",
+			"amount":        1,
+			"instance_type": "t1.micro",
+			"region":        "blank",
+			"pubkey_id":     pk.ID,
+		}
+		if json_data, err = json.Marshal(values); err != nil {
+			t.Fatalf("unable to marshal values to json: %v", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/reservations/aws", bytes.NewBuffer(json_data))
+		require.NoError(t, err, "failed to create request")
+		req.Header.Add("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(services.CreateAWSReservation)
+		handler.ServeHTTP(rr, req)
+
+		assert.Contains(t, rr.Body.String(), "Unsupported region")
+		require.Equal(t, http.StatusBadRequest, rr.Code, "Handler returned wrong status code")
+	})
 }

--- a/internal/services/gcp_reservation_service_test.go
+++ b/internal/services/gcp_reservation_service_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestCreateGCPReservationHandler(t *testing.T) {
-	var err error
 	var json_data []byte
 	ctx := stubs.WithAccountDaoOne(context.Background())
 	ctx = identity.WithTenant(t, ctx)
@@ -29,33 +28,61 @@ func TestCreateGCPReservationHandler(t *testing.T) {
 	ctx = stubs.WithReservationDao(ctx)
 	ctx = stubs.WithPubkeyDao(ctx)
 	pk := factories.NewPubkeyRSA()
-	err = stubs.AddPubkey(ctx, pk)
+	err := stubs.AddPubkey(ctx, pk)
 	require.NoError(t, err, "failed to generate pubkey")
 	source, err := Clientstubs.AddSource(ctx, models.ProviderTypeGCP)
 	require.NoError(t, err, "failed to generate GCP source")
 
-	values := map[string]interface{}{
-		"source_id":    source.Id,
-		"image_id":     "80967e7f-efef-4eee-85b0-bd4cef4c455d",
-		"amount":       1,
-		"zone":         "us-central1-a",
-		"machine_type": "n1-standard-1",
-		"pubkey_id":    pk.ID,
-	}
-	if json_data, err = json.Marshal(values); err != nil {
-		t.Fatalf("unable to marshal values to json: %v", err)
-	}
+	t.Run("successful reservation", func(t *testing.T) {
+		var err error
+		values := map[string]interface{}{
+			"source_id":    source.Id,
+			"image_id":     "80967e7f-efef-4eee-85b0-bd4cef4c455d",
+			"amount":       1,
+			"zone":         "us-central1-a",
+			"machine_type": "n1-standard-1",
+			"pubkey_id":    pk.ID,
+		}
+		if json_data, err = json.Marshal(values); err != nil {
+			t.Fatalf("unable to marshal values to json: %v", err)
+		}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/reservations/gcp", bytes.NewBuffer(json_data))
-	require.NoError(t, err, "failed to create request")
-	req.Header.Add("Content-Type", "application/json")
+		req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/reservations/gcp", bytes.NewBuffer(json_data))
+		require.NoError(t, err, "failed to create request")
+		req.Header.Add("Content-Type", "application/json")
 
-	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(services.CreateGCPReservation)
-	handler.ServeHTTP(rr, req)
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(services.CreateGCPReservation)
+		handler.ServeHTTP(rr, req)
 
-	require.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
+		require.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
 
-	stubCount := stubs.GCPReservationStubCount(ctx)
-	assert.Equal(t, 1, stubCount, "Reservation has not been Created through DAO")
+		stubCount := stubs.GCPReservationStubCount(ctx)
+		assert.Equal(t, 1, stubCount, "Reservation has not been created through DAO")
+	})
+
+	t.Run("failed reservation with invalid zone", func(t *testing.T) {
+		var err error
+		values := map[string]interface{}{
+			"source_id":    source.Id,
+			"image_id":     "80967e7f-efef-4eee-85b0-bd4cef4c455d",
+			"amount":       1,
+			"zone":         "us-central",
+			"machine_type": "n1-standard-1",
+			"pubkey_id":    pk.ID,
+		}
+		if json_data, err = json.Marshal(values); err != nil {
+			t.Fatalf("unable to marshal values to json: %v", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/reservations/gcp", bytes.NewBuffer(json_data))
+		require.NoError(t, err, "failed to create request")
+		req.Header.Add("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(services.CreateGCPReservation)
+		handler.ServeHTTP(rr, req)
+		assert.Contains(t, rr.Body.String(), "Unsupported zone")
+		require.Equal(t, http.StatusBadRequest, rr.Code, "Handler returned wrong status code")
+	})
 }


### PR DESCRIPTION
Adding a test for each provider's reservation checking we are failing the test if the region/zone/location provided are not supported. 