### PR TITLE
chore: Update Makefile to work for Go 1.18

### DIFF
--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -3,7 +3,7 @@
 .PHONY: install-tools
 install-tools: ## Install required Go commands
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 	go install github.com/jackc/tern@latest
 	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
 	go install mvdan.cc/gofumpt@latest


### PR DESCRIPTION
Update of the make install-tools to work for our required version of Go.