### PR TITLE
fix: cascade delete of pubkey to Azure details

### DIFF
--- a/internal/migrations/sql/018_delete_cascade_azure.sql
+++ b/internal/migrations/sql/018_delete_cascade_azure.sql
@@ -1,0 +1,4 @@
+ALTER TABLE azure_reservation_details
+DROP CONSTRAINT azure_reservation_details_pubkey_id_fkey,
+ADD CONSTRAINT azure_reservation_details_pubkey_id_fkey
+FOREIGN key (pubkey_id) REFERENCES pubkeys(id) ON DELETE CASCADE;

--- a/scripts/rest_examples/reservation-get-1-azure.http
+++ b/scripts/rest_examples/reservation-get-1-azure.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/reservations/azure/{{azure-reservation-get-id}} HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}


### PR DESCRIPTION
This is what we do for other providers.
We loose all the details about the reservation.

Fixes HMS-1402
