### PR TITLE
test: Allow collecting planned jobs in tests

### DIFF
--- a/internal/dao/tests/noop_job_test.go
+++ b/internal/dao/tests/noop_job_test.go
@@ -54,7 +54,7 @@ func TestReservationNoopOneSuccess(t *testing.T) {
 					},
 				}
 
-				err = queue.GetEnqueuer().Enqueue(context.Background(), &job)
+				err = queue.GetEnqueuer(ctx).Enqueue(context.Background(), &job)
 				require.NoError(t, err)
 
 				return res
@@ -94,7 +94,7 @@ func TestReservationNoopOneSuccess(t *testing.T) {
 					},
 				}
 
-				err = queue.GetEnqueuer().Enqueue(context.Background(), &job)
+				err = queue.GetEnqueuer(ctx).Enqueue(context.Background(), &job)
 				require.NoError(t, err)
 
 				return res

--- a/internal/queue/enqueuer.go
+++ b/internal/queue/enqueuer.go
@@ -1,7 +1,9 @@
 package queue
 
 import (
+	"context"
+
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
 )
 
-var GetEnqueuer func() worker.JobEnqueuer
+var GetEnqueuer func(ctx context.Context) worker.JobEnqueuer

--- a/internal/queue/jq/worker.go
+++ b/internal/queue/jq/worker.go
@@ -17,7 +17,7 @@ var (
 	workers  worker.JobWorker
 )
 
-func getEnqueuer() worker.JobEnqueuer {
+func getEnqueuer(_ context.Context) worker.JobEnqueuer {
 	return enqueuer
 }
 

--- a/internal/queue/stub/stub.go
+++ b/internal/queue/stub/stub.go
@@ -5,28 +5,59 @@ package stub
 
 import (
 	"context"
+	"errors"
 
 	"github.com/RHEnVision/provisioning-backend/internal/queue"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
 )
 
-var (
-	enqueuer worker.JobEnqueuer
-	workers  worker.JobWorker
-)
+type enqueueCtxKeyType string
 
-func getEnqueuer() worker.JobEnqueuer {
-	return enqueuer
+var ContextReadError = errors.New("failed to find or convert dao stored in testing context")
+
+var enqueueCtxKey enqueueCtxKeyType = "enqueuer-stub"
+
+type hollowEnqueuer struct{}
+
+type stubEnqueuer struct {
+	enqueued []*worker.Job
 }
 
 func init() {
-	InitializeStub(context.Background())
 	queue.GetEnqueuer = getEnqueuer
 }
 
-func InitializeStub(ctx context.Context) {
-	wk := worker.NewMemoryClient()
-	enqueuer = wk
-	workers = wk
-	workers.DequeueLoop(ctx)
+// WithEnqueuer returns new context with Job enqueue struct that keeps the jobs
+func WithEnqueuer(parent context.Context) context.Context {
+	ctx := context.WithValue(parent, enqueueCtxKey, &stubEnqueuer{})
+	return ctx
+}
+
+func EnqueuedJobs(ctx context.Context) []*worker.Job {
+	enquer := getEnqueuerStub(ctx)
+	return enquer.enqueued
+}
+
+func getEnqueuer(ctx context.Context) worker.JobEnqueuer {
+	if enqueue := getEnqueuerStub(ctx); enqueue != nil {
+		return enqueue
+	}
+	return hollowEnqueuer{}
+}
+
+func getEnqueuerStub(ctx context.Context) *stubEnqueuer {
+	if enqueue, ok := ctx.Value(enqueueCtxKey).(*stubEnqueuer); ok {
+		return enqueue
+	}
+	return nil
+}
+
+// Enqueue of hollow - default - enqueuer just ignores all enqueued jobs.
+func (h hollowEnqueuer) Enqueue(_ context.Context, _ *worker.Job) error {
+	return nil
+}
+
+func (s *stubEnqueuer) Enqueue(ctx context.Context, job *worker.Job) error {
+	s.enqueued = append(s.enqueued, job)
+	return nil
 }

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -160,7 +160,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	err = queue.GetEnqueuer().Enqueue(r.Context(), &launchJob)
+	err = queue.GetEnqueuer(r.Context()).Enqueue(r.Context(), &launchJob)
 	if err != nil {
 		renderError(w, r, payloads.NewEnqueueTaskError(r.Context(), "job enqueue error", err))
 		return

--- a/internal/services/azure_reservation_service.go
+++ b/internal/services/azure_reservation_service.go
@@ -137,7 +137,7 @@ func CreateAzureReservation(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	err = queue.GetEnqueuer().Enqueue(r.Context(), &launchJob)
+	err = queue.GetEnqueuer(r.Context()).Enqueue(r.Context(), &launchJob)
 	if err != nil {
 		renderError(w, r, payloads.NewEnqueueTaskError(r.Context(), "job enqueue error", err))
 		return

--- a/internal/services/gcp_reservation_service.go
+++ b/internal/services/gcp_reservation_service.go
@@ -126,7 +126,7 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	err = queue.GetEnqueuer().Enqueue(r.Context(), &launchJob)
+	err = queue.GetEnqueuer(r.Context()).Enqueue(r.Context(), &launchJob)
 	if err != nil {
 		renderError(w, r, payloads.NewEnqueueTaskError(r.Context(), "job enqueue error", err))
 		return

--- a/internal/services/noop_reservation_service.go
+++ b/internal/services/noop_reservation_service.go
@@ -47,7 +47,7 @@ func CreateNoopReservation(w http.ResponseWriter, r *http.Request) {
 			ReservationID: reservation.ID,
 		},
 	}
-	err = queue.GetEnqueuer().Enqueue(r.Context(), &pj)
+	err = queue.GetEnqueuer(r.Context()).Enqueue(r.Context(), &pj)
 	if err != nil {
 		renderError(w, r, payloads.NewEnqueueTaskError(r.Context(), "job enqueue error", err))
 		return


### PR DESCRIPTION
Adds two structs in tests, one that drops all the jobs, second that stores them in the context.
Second one needs to be initialized in the context first.

Shows the usage of it on an Azure service.
Needs to have the context passed for the GetEnqueuer, but given it's called just few times over our code I guess its acceptable change.