### PR TITLE
feat: Create Azure VMs in paralel

### DIFF
--- a/internal/clients/http/azure/create_vms.go
+++ b/internal/clients/http/azure/create_vms.go
@@ -1,0 +1,50 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+)
+
+func (c *client) CreateVMs(ctx context.Context, vmParams clients.AzureInstanceParams, amount int64, vmNamePrefix string) ([]*string, error) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "CreateVMs")
+	defer span.End()
+
+	logger := logger(ctx)
+	logger.Debug().Msgf("Started creating %d Azure VM instances", amount)
+
+	vmIds := make([]*string, amount)
+	var resumeTokens []string
+	var i int64
+	for i = 0; i < amount; i++ {
+		uuid, err := uuid.NewUUID()
+		if err != nil {
+			return vmIds, fmt.Errorf("could not generate a new UUID: %w", err)
+		}
+		vmName := fmt.Sprintf("%s-%s", vmNamePrefix, uuid.String())
+		resumeToken, err := c.BeginCreateVM(ctx, vmParams, vmName)
+		if err != nil {
+			span.SetStatus(codes.Error, "failed to start creation of Azure instance")
+			return vmIds, fmt.Errorf("cannot start a create of Azure instance(s): %w", err)
+		}
+		resumeTokens = append(resumeTokens, resumeToken)
+	}
+
+	for j, token := range resumeTokens {
+		instanceId, err := c.WaitForVM(ctx, token)
+		if err != nil {
+			span.SetStatus(codes.Error, "failed to create Azure instance")
+			return vmIds, fmt.Errorf("cannot create Azure instance(s): %w", err)
+		}
+		vmIds[j] = instanceId
+		logger.Debug().Msgf("Created new instance (%s) via Azure CreateVM", *instanceId)
+	}
+
+	logger.Debug().Msgf("Created %d new instance", amount)
+
+	return vmIds, nil
+}

--- a/internal/clients/instance_params.go
+++ b/internal/clients/instance_params.go
@@ -1,6 +1,9 @@
 package clients
 
-import "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+import (
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
 
 type GCPInstanceParams struct {
 	// The string pattern used for the name of the VM.
@@ -34,6 +37,27 @@ type AWSInstanceParams struct {
 
 	// Pubkey to use for the instance access
 	KeyName string
+
+	// UserData for the instance launch
+	UserData []byte
+}
+
+// AzureInstanceParams define parameters for a single instance launch on Azure.
+type AzureInstanceParams struct {
+	// Location - to deploy into
+	Location string
+
+	// ResourceGroupName to launch the instance in
+	ResourceGroupName string
+
+	// ImageName - the imageID will be inferred as /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}
+	ImageName string
+
+	// Pubkey to use for the instance access
+	Pubkey *models.Pubkey
+
+	// InstanceType to launch
+	InstanceType InstanceTypeName
 
 	// UserData for the instance launch
 	UserData []byte

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -6,6 +6,8 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 )
 
+type AzureInstanceID string
+
 // GetSourcesClient returns Sources interface implementation. There are currently
 // two implementations available: HTTP and stub
 var GetSourcesClient func(ctx context.Context) (Sources, error)
@@ -113,12 +115,9 @@ type Azure interface {
 	// EnsureResourceGroup makes sure that group with give name exists in a location
 	EnsureResourceGroup(ctx context.Context, name string, location string) (*string, error)
 
-	// CreateVM creates Azure virtual machine.
-	CreateVM(ctx context.Context, params AzureInstanceParams, vmName string) (*string, error)
-
 	// CreateVMs creates multiple Azure virtual machines
 	// Returns array of instance IDs and error if something went wrong
-	CreateVMs(ctx context.Context, instanceParams AzureInstanceParams, amount int64, vmNamePrefix string) (vmIds []*string, err error)
+	CreateVMs(ctx context.Context, instanceParams AzureInstanceParams, amount int64, vmNamePrefix string) (vmIds []AzureInstanceID, err error)
 
 	ListResourceGroups(ctx context.Context) ([]string, error)
 }

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -114,10 +114,11 @@ type Azure interface {
 	EnsureResourceGroup(ctx context.Context, name string, location string) (*string, error)
 
 	// CreateVM creates Azure virtual machine.
-	// Most of the parameters are constant for now.
-	// location - to deploy into
-	// imageName - the imageID will be inferred as /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}
-	CreateVM(ctx context.Context, location string, resourceGroupName string, imageName string, pubkey *models.Pubkey, instanceType InstanceTypeName, vmName string, userData []byte) (*string, error)
+	CreateVM(ctx context.Context, params AzureInstanceParams, vmName string) (*string, error)
+
+	// CreateVMs creates multiple Azure virtual machines
+	// Returns array of instance IDs and error if something went wrong
+	CreateVMs(ctx context.Context, instanceParams AzureInstanceParams, amount int64, vmNamePrefix string) (vmIds []*string, err error)
 
 	ListResourceGroups(ctx context.Context) ([]string, error)
 }

--- a/internal/dao/stubs/context_getters.go
+++ b/internal/dao/stubs/context_getters.go
@@ -43,7 +43,9 @@ func WithReservationDao(parent context.Context) context.Context {
 		panic(dao.ErrStubContextAlreadySet)
 	}
 
-	ctx := context.WithValue(parent, reservationCtxKey, &reservationDaoStub{})
+	ctx := context.WithValue(parent, reservationCtxKey, &reservationDaoStub{
+		instances: make(map[int64][]*models.ReservationInstance),
+	})
 	return ctx
 }
 

--- a/internal/dao/stubs/reservation_dao.go
+++ b/internal/dao/stubs/reservation_dao.go
@@ -13,6 +13,7 @@ type reservationDaoStub struct {
 	storeAWS   []*models.AWSReservation
 	storeAzure []*models.AzureReservation
 	storeGCP   []*models.GCPReservation
+	instances  map[int64][]*models.ReservationInstance
 }
 
 func init() {
@@ -60,7 +61,9 @@ func (stub *reservationDaoStub) CreateNoop(ctx context.Context, reservation *mod
 	return nil
 }
 
-func (stub *reservationDaoStub) CreateInstance(ctx context.Context, reservation *models.ReservationInstance) error {
+func (stub *reservationDaoStub) CreateInstance(ctx context.Context, resInstance *models.ReservationInstance) error {
+	resId := resInstance.ReservationID
+	stub.instances[resId] = append(stub.instances[resId], resInstance)
 	return nil
 }
 
@@ -96,7 +99,7 @@ func (stub *reservationDaoStub) List(ctx context.Context, limit, offset int64) (
 }
 
 func (stub *reservationDaoStub) ListInstances(ctx context.Context, reservationId int64) ([]*models.ReservationInstance, error) {
-	return nil, nil
+	return stub.instances[reservationId], nil
 }
 
 func (stub *reservationDaoStub) UpdateStatus(ctx context.Context, id int64, status string, addSteps int32) error {

--- a/internal/jobs/launch_instance_azure.go
+++ b/internal/jobs/launch_instance_azure.go
@@ -155,11 +155,11 @@ func DoLaunchInstanceAzure(ctx context.Context, args *LaunchInstanceAzureTaskArg
 	for _, instanceId := range instanceIds {
 		err = resDao.CreateInstance(ctx, &models.ReservationInstance{
 			ReservationID: args.ReservationID,
-			InstanceID:    *instanceId,
+			InstanceID:    string(instanceId),
 		})
 		if err != nil {
 			span.SetStatus(codes.Error, "failed to save instance to DB")
-			return fmt.Errorf("cannot create instance reservation for id %d: %w", instanceId, err)
+			return fmt.Errorf("cannot create instance reservation for id %s: %w", instanceId, err)
 		}
 	}
 

--- a/internal/jobs/launch_instance_azure_test.go
+++ b/internal/jobs/launch_instance_azure_test.go
@@ -105,4 +105,7 @@ func TestDoLaunchInstanceAzure(t *testing.T) {
 	require.NoError(t, err, "launch instances failed to run")
 
 	assert.Equal(t, 2, clientStubs.CountStubAzureVMs(ctx))
+	resultInstances, err := rDao.ListInstances(ctx, res.ID)
+	require.NoError(t, err, "failed to fetch created instances")
+	assert.Equal(t, 2, len(resultInstances))
 }

--- a/scripts/rest_examples/reservation-create-azure.http
+++ b/scripts/rest_examples/reservation-create-azure.http
@@ -7,7 +7,7 @@ X-Rh-Identity: {{identity}}
   "name": "azure-linux-us-east",
   "source_id": "5",
   "image_id": "composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7",
-  "amount": 1,
+  "amount": 2,
   "instance_size": "Standard_B1ls",
   "pubkey_id": {{pubkey_id}},
   "poweroff": true


### PR DESCRIPTION
Splits Azure launch start and polling for status.
Now we start the launch process for all instances first, only then we start polling for the creation result.

Fixes HMS-1407