### PR TITLE
chore: limit cpu and use 3-3-1

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -26,7 +26,7 @@ objects:
         iqePlugin: provisioning
       deployments:
         - name: worker
-          replicas: 2
+          replicas: 3
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command:
@@ -178,7 +178,7 @@ objects:
                 cpu: ${CPU_REQUESTS}
                 memory: ${MEMORY_REQUESTS}
         - name: api
-          replicas: 2
+          replicas: 3
           webServices:
             public:
               enabled: true
@@ -331,7 +331,7 @@ parameters:
     required: true
   - description: Cpu limit of service
     name: CPU_LIMIT
-    value: "1"
+    value: 500m
   - description: Cpu request increment
     name: CPU_REQUESTS
     value: 100m


### PR DESCRIPTION
Since we are playing around with pod counts and limits, I would like to experiment a bit more. I was told that the limits are currently.

```
$ oc get quota compute-resources-non-terminating -o json | jq ".status"
{
  "hard": {
    "limits.cpu": "6",
    "limits.memory": "24Gi",
    "requests.cpu": "3",
    "requests.memory": "12Gi"
  },
  "used": {
    "limits.cpu": "6",
    "limits.memory": "6Gi",
    "requests.cpu": "600m",
    "requests.memory": "600Mi"
  }
}
```

In our configuration, we are requesting limit quota of 1000m (full CPU) with 100m increment per pod. I think that is a bit overkill for our use case and that is why we are hitting the hard limit: 3+3+1 = 7 CPUs (7000m). If I half the hard limit that is actually 3500m so we still have some room to grow in terms of amount of pods.

Memory wise, I think we are good. So let’s try this?