### PR TITLE
chore: remove linter annotation

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -17,8 +17,6 @@ objects:
       labels:
         app: provisioning-backend
         service: provisioning
-      annotations:
-        ignore-check.kube-linter.io/minimum-three-replicas: "statuser pod runs in a single instance"
     spec:
       envName: ${ENV_NAME}
       featureFlags: true


### PR DESCRIPTION
I _think_ added annotation to a wrong type, this should fix this.

Hopefully this fixes deployments.