### PR TITLE
feat(HMS-1001): Add created instances ids to GCP reservation

### DIFF
--- a/config/api.env.example
+++ b/config/api.env.example
@@ -81,7 +81,7 @@
 #   GCP_JSON string
 #     	GCP service account credentials (base64 encoded) (default "e30K")
 #   GCP_DEFAULT_ZONE string
-#     	GCP region when not provided (default "us-central1-a")
+#     	GCP region when not provided (default "us-east4-a")
 #   PROMETHEUS_PORT int
 #     	prometheus HTTP port (default "9000")
 #   PROMETHEUS_PATH string

--- a/config/api.env.example
+++ b/config/api.env.example
@@ -81,7 +81,7 @@
 #   GCP_JSON string
 #     	GCP service account credentials (base64 encoded) (default "e30K")
 #   GCP_DEFAULT_ZONE string
-#     	GCP region when not provided (default "us-east1")
+#     	GCP region when not provided (default "us-central1-a")
 #   PROMETHEUS_PORT int
 #     	prometheus HTTP port (default "9000")
 #   PROMETHEUS_PATH string

--- a/internal/clients/http/gcp/gcp_errors.go
+++ b/internal/clients/http/gcp/gcp_errors.go
@@ -1,0 +1,5 @@
+package gcp
+
+import "errors"
+
+var ErrOperationFailed = errors.New("operation has failed to finish within expected time")

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -144,6 +144,6 @@ type GCP interface {
 	// ListAllRegions returns list of all GCP regions
 	ListAllRegions(ctx context.Context) ([]Region, error)
 
-	// InsertInstances launches one or more instances
-	InsertInstances(ctx context.Context, namePattern *string, imageName *string, amount int64, machineType string, zone string, keyBody string) (*string, error)
+	// InsertInstances launches one or more instances and returns a list of instances ids that were created, the GCP operation name and error
+	InsertInstances(ctx context.Context, namePattern *string, imageName *string, amount int64, machineType, zone, keyBody string) ([]*string, *string, error)
 }

--- a/internal/clients/stubs/gcp_stub.go
+++ b/internal/clients/stubs/gcp_stub.go
@@ -59,8 +59,8 @@ func (mock *GCPClientStub) Status(ctx context.Context) error {
 	return nil
 }
 
-func (mock *GCPClientStub) InsertInstances(ctx context.Context, namePattern *string, imageName *string, amount int64, machineType string, zone string, keyBody string) (*string, error) {
-	return nil, NotImplementedErr
+func (mock *GCPClientStub) InsertInstances(ctx context.Context, namePattern *string, imageName *string, amount int64, machineType, zone, keyBody string) ([]*string, *string, error) {
+	return nil, nil, NotImplementedErr
 }
 
 func (mock *GCPServiceClientStub) ListMachineTypes(ctx context.Context, zone string) ([]*clients.InstanceType, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,7 +92,7 @@ var config struct {
 	GCP struct {
 		ProjectID   string `env:"PROJECT_ID" env-default:"" env-description:"GCP service account project id"`
 		JSON        string `env:"JSON" env-default:"e30K" env-description:"GCP service account credentials (base64 encoded)"`
-		DefaultZone string `env:"DEFAULT_ZONE" env-default:"us-central1-a" env-description:"GCP region when not provided"`
+		DefaultZone string `env:"DEFAULT_ZONE" env-default:"us-east4" env-description:"GCP region when not provided"`
 	} `env-prefix:"GCP_"`
 	Prometheus struct {
 		Port int    `env:"PORT" env-default:"9000" env-description:"prometheus HTTP port"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,7 +92,7 @@ var config struct {
 	GCP struct {
 		ProjectID   string `env:"PROJECT_ID" env-default:"" env-description:"GCP service account project id"`
 		JSON        string `env:"JSON" env-default:"e30K" env-description:"GCP service account credentials (base64 encoded)"`
-		DefaultZone string `env:"DEFAULT_ZONE" env-default:"us-east1" env-description:"GCP region when not provided"`
+		DefaultZone string `env:"DEFAULT_ZONE" env-default:"us-central1-a" env-description:"GCP region when not provided"`
 	} `env-prefix:"GCP_"`
 	Prometheus struct {
 		Port int    `env:"PORT" env-default:"9000" env-description:"prometheus HTTP port"`

--- a/scripts/rest_examples/reservation-create-gcp.http
+++ b/scripts/rest_examples/reservation-create-gcp.http
@@ -4,8 +4,8 @@ Content-Type: application/json
 X-Rh-Identity: {{identity}}
 
 {
-  "name": "gcp-linux-us-central1-a",
-  "zone": "us-central1-a",
+  "name": "gcp-linux-us-east4-a",
+  "zone": "us-east4-a",
   "source_id": "3",
   "image_id": "80967e7f-efef-4eee-85b0-bd4cef4c455d",
   "amount": 1,


### PR DESCRIPTION
After an investigation, I have not found a better way to fetch the information of the instances created under a single reservation. 

This PR: 
- Generates a uuid for each bulkInsert request and  will be used as a label
-  Fetches the created instances corresponding to bulkInsert requests' uuid 
-  saves the instances ids in the db and also share them under GetGCPByID

**Things I would like to get feedback on:** 
- Does the usage of uuid make sense like that? 
-  Did I use otel correctly and did not miss something? 