### PR TITLE
fix(HMS-1105): add reservation counters

### DIFF
--- a/internal/ctxval/copy.go
+++ b/internal/ctxval/copy.go
@@ -1,0 +1,14 @@
+package ctxval
+
+import "context"
+
+// Copy returns a new context with key values copied. Used when the original
+// context has expired but there is still some work to be done.
+func Copy(ctx context.Context) context.Context {
+	nCtx := context.Background()
+	nCtx = WithLogger(nCtx, Logger(ctx))
+	nCtx = WithTraceId(nCtx, TraceId(ctx))
+	nCtx = WithEdgeRequestId(nCtx, EdgeRequestId(ctx))
+	nCtx = WithAccountId(nCtx, AccountId(ctx))
+	return nCtx
+}

--- a/internal/metrics/registration.go
+++ b/internal/metrics/registration.go
@@ -1,0 +1,15 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func RegisterStatuserMetrics() {
+	prometheus.MustRegister(TotalSentAvailabilityCheckReqs, AvailabilityCheckReqsDuration, TotalInvalidAvailabilityCheckReqs)
+}
+
+func RegisterApiMetrics() {
+	// no metrics
+}
+
+func RegisterWorkerMetrics() {
+	prometheus.MustRegister(JobQueueSize, JobQueueInFlight, BackgroundJobDuration, ReservationCount)
+}

--- a/pkg/worker/redis.go
+++ b/pkg/worker/redis.go
@@ -161,7 +161,7 @@ func recoverAndLog(ctx context.Context) {
 		logger := ctxval.Logger(ctx).Error().Stack()
 
 		if err, ok := rec.(error); ok {
-			logger.Err(err).Stack().Msgf("Job queue panic: %s", err.Error())
+			logger.Err(err).Stack().Msgf("Job queue panic: %s, stacktrace: %s", err.Error(), debug.Stack())
 		} else {
 			logger.Msgf("Error during job handling: %v, stacktrace: %s", rec, debug.Stack())
 		}


### PR DESCRIPTION
I noticed that the existing reservation job metrics are missing the prefix.

Also we need to track success and failure rate of jobs/reservations. This cannot be done on the job level as background jobs do not have any sort of error handling, this must be all done on the reservation level when we finish reservation either with error or success flag.

This PR adds a new metric which I will use on the dashboard for the main SLO.