### PR TITLE
fix(HMS-1105): improve reservations dashboard

### DIFF
--- a/deploy/Provisioning-1674548289785.json
+++ b/deploy/Provisioning-1674548289785.json
@@ -52,15 +52,23 @@
           },
           "mappings": [],
           "thresholds": {
-            "mode": "percentage",
+            "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "dark-red",
                 "value": null
               },
               {
                 "color": "red",
-                "value": 95.0007
+                "value": 0.8
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.9
+              },
+              {
+                "color": "green",
+                "value": 0.95
               }
             ]
           },
@@ -77,7 +85,7 @@
       "id": 59,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -97,13 +105,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(provisioning_reservation_count{result=\"success\",type=\"aws\"}[$__interval])) /\nsum(rate(provisioning_reservation_count{type=\"aws\"}[$__interval]))",
+          "expr": "(sum(increase(provisioning_reservation_count{result=\"success\",type=~\"$type\"}[$__range]))\n/\nsum(increase(provisioning_reservation_count{type=~\"$type\"}[$__range]))) or on() vector(0)",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "AWS reservation success",
+      "title": "Reservation success rate per hyperscaler",
       "type": "stat"
     },
     {
@@ -116,27 +124,25 @@
           "color": {
             "mode": "thresholds"
           },
+          "decimals": 0,
           "mappings": [],
+          "min": 0,
           "thresholds": {
-            "mode": "percentage",
+            "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "blue",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 95.0007
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 6,
         "x": 12,
         "y": 1
       },
@@ -163,13 +169,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(provisioning_reservation_count{result=\"success\",type=\"azure\"}[$__interval])) /\nsum(rate(provisioning_reservation_count{type=\"azure\"}[$__interval]))",
+          "expr": "sum(increase(provisioning_reservation_count{type=~\"$type\"}[$__range]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Azure reservation success",
+      "title": "Total reservations per hyperscaler",
       "type": "stat"
     },
     {
@@ -177,6 +183,165 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 61,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(provisioning_background_job_duration_bucket{type=~\"launch_instances_$type\"}[$__range])) by (le))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reservation duration per hyperscaler (p95)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(sum(rate(provisioning_reservation_count{result=\"failure\",type=~\"$type\"}[$__interval]))\n/\nsum(rate(provisioning_reservation_count{type=~\"$type\"}[$__interval]))) or on() vector(0)",
+          "hide": false,
+          "legendFormat": "{{type}} failure",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Reservation error rate per hyperscaler",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Duration of background job types",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -189,14 +354,17 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
             "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
             "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
@@ -219,120 +387,10 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 9
-      },
-      "id": 54,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum (rate(provisioning_reservation_count{result=\"success\"}[$__interval])) by (type)",
-          "legendFormat": "{{type}} success",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum (rate(provisioning_reservation_count{result=\"failure\"}[$__interval])) by (type)",
-          "hide": false,
-          "legendFormat": "{{type}} failure",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Reservation success/error rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Duration of background job types",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -362,16 +420,29 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "exemplar": false,
-          "expr": "histogram_quantile(0.95, sum by (type, le) (rate(background_job_duration_ms_bucket[$__interval])))",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum(rate(provisioning_background_job_duration_bucket{type=~\"launch_instances_$type\"}[$__interval])) by (le)) OR on() vector(0)",
           "format": "time_series",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "p95",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(provisioning_background_job_duration_bucket{type=~\"launch_instances_$type\"}[$__interval])) by (le)) OR on() vector(0)",
+          "hide": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Job latency 95th percentile (ms)",
+      "title": "Job duration per hyperscaler",
       "type": "timeseries"
     },
     {
@@ -444,7 +515,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "tooltip": {
           "mode": "single",
@@ -481,11 +552,12 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
+            "axisGridShow": false,
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
+            "drawStyle": "points",
+            "fillOpacity": 100,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -493,12 +565,12 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
+            "lineWidth": 0,
+            "pointSize": 3,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -508,20 +580,19 @@
               "mode": "off"
             }
           },
+          "decimals": 0,
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
@@ -537,7 +608,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "tooltip": {
           "mode": "single",
@@ -1503,8 +1574,8 @@
         "auto_min": "10s",
         "current": {
           "selected": false,
-          "text": "6h",
-          "value": "6h"
+          "text": "1d",
+          "value": "1d"
         },
         "hide": 0,
         "name": "interval",
@@ -1525,7 +1596,7 @@
             "value": "1h"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "6h",
             "value": "6h"
           },
@@ -1535,7 +1606,7 @@
             "value": "12h"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "1d",
             "value": "1d"
           },
@@ -1555,11 +1626,55 @@
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "description": "Hyperscaler to display results for",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Hyperscaler type",
+        "multi": true,
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "aws",
+            "value": "aws"
+          },
+          {
+            "selected": false,
+            "text": "azure",
+            "value": "azure"
+          },
+          {
+            "selected": false,
+            "text": "gcp",
+            "value": "gcp"
+          }
+        ],
+        "query": "aws,azure,gcp",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {
@@ -1590,6 +1705,6 @@
   "timezone": "",
   "title": "Provisioning",
   "uid": "211",
-  "version": 2,
+  "version": 7,
   "weekStart": ""
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -48,10 +48,10 @@ var AvailabilityCheckReqsDuration = prometheus.NewHistogramVec(
 
 var BackgroundJobDuration = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
-		Name:        "provisioning_background_job_duration_ms",
-		Help:        "task queue job duration (ms) by type",
+		Name:        "provisioning_background_job_duration",
+		Help:        "task queue job duration (in seconds) by type",
 		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName, "component": "worker"},
-		Buckets:     []float64{50, 100, 250, 500, 1000, 2500, 6000},
+		Buckets:     []float64{1, 4, 5, 10, 30, 60 * 2, 60 * 5, 60 * 10, 60 * 20, 60 * 30, 60 * 60},
 	},
 	[]string{"type"},
 )


### PR DESCRIPTION
This is a big update of the jobs/reservations panes on our dashboard. Now it shows proper numbers even when there is no data, I learned this from IB team and the trick is to use `on() vector(0)`.

![image](https://user-images.githubusercontent.com/49752/228472536-812c2748-6469-47e2-8d64-60302e572153.png)

But the big new feature is (also learned from IB dashboard) a new variable called Hyperscaler where you can switch between azure, aws and gcp to drill down the data. Hard to show on an image so here is a short demo:

https://www.youtube.com/watch?v=X7M7WxkBLHc