### PR TITLE
fix(HMS-1105): measure jobs in seconds

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -81,7 +81,7 @@ func ObserveAvailabilityCheckReqsDuration(provider string, observedFunc func() e
 func ObserveBackgroundJobDuration(jobType string, observedFunc func()) {
 	start := time.Now()
 	defer func() {
-		BackgroundJobDuration.WithLabelValues(jobType).Observe(float64(time.Since(start).Nanoseconds()) / 1000000)
+		BackgroundJobDuration.WithLabelValues(jobType).Observe(time.Since(start).Seconds())
 	}()
 
 	observedFunc()


### PR DESCRIPTION
The dashboard now shows 59 minutes p99 time for jobs, well, because we still measure this in milliseconds instead of seconds. This fixes it. Numbers will be off for few days I guess :-) Sorry!