### PR TITLE
feat: allow Azure group principal in Lighthouse

### DIFF
--- a/config/api.env.example
+++ b/config/api.env.example
@@ -70,8 +70,10 @@
 #     	Azure service account client id (default "")
 #   AZURE_CLIENT_SECRET string
 #     	Azure service account client secret (default "")
-#   AZURE_CLIENT_NAME string
-#     	Azure service account display name (default "RH HCC")
+#   AZURE_CLIENT_PRINCIPAL_ID string
+#     	Azure Principal ID. It is used for lighthouse delegation. It can be object ID of the service principal or Group object id having the service principal as a member (default "")
+#   AZURE_CLIENT_PRINCIPAL_NAME string
+#     	Azure display name for the offering principal (default "RH HCC")
 #   AZURE_DEFAULT_REGION string
 #     	Azure region when not provided (default "eastus")
 #   AZURE_SUBSCRIPTION_ID string

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -78,12 +78,6 @@ objects:
                     name: provisioning-azure-acc
                     key: client_secret
                     optional: true
-              - name: AZURE_CLIENT_NAME
-                valueFrom:
-                  secretKeyRef:
-                    name: provisioning-azure-acc
-                    key: client_name
-                    optional: true
               - name: SENTRY_DSN
                 valueFrom:
                   secretKeyRef:
@@ -254,11 +248,17 @@ objects:
                     name: provisioning-azure-acc
                     key: client_secret
                     optional: true
-              - name: AZURE_CLIENT_NAME
+              - name: AZURE_PRINCIPAL_ID
                 valueFrom:
                   secretKeyRef:
                     name: provisioning-azure-acc
-                    key: client_name
+                    key: principal_id
+                    optional: true
+              - name: AZURE_PRINCIPAL_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: provisioning-azure-acc
+                    key: principal_name
                     optional: true
               - name: SENTRY_DSN
                 valueFrom:

--- a/docs/configure-azure.md
+++ b/docs/configure-azure.md
@@ -14,11 +14,12 @@ In our use case we use only permission delegation.
 The template we will prepare provides roles in target Tenant to the Principal from offering tenant.
 The template assigns following roles to the offering Principal:
 
-| Role name                                                                                                                                   | UUID                                 | Motivation                                                                                                                                         |
-|---------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader)                                           | acdd72a7-3385-48ef-bd42-f606fba81ae7 | Allows us to fetch information about resources                                                                                                     |
-| [Virtual Machine Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#virtual-machine-contributor) | 9980e02c-c2be-4d73-94e8-173b1dc7cf3c | Allows to deploy virtual machines                                                                                                                  |
-| [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) | b24988ac-6180-42a0-ab88-20f7382dd24c | Unfortunate wokaround for creating supporting resources, hopefully better solution will be found and this role will not be necessary in the future |
+| Role name                                                                                                                                                                     | UUID                                 | Motivation                                                                                                                                                                                                               |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Reader](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#reader)                                                                             | acdd72a7-3385-48ef-bd42-f606fba81ae7 | Allows us to fetch information about resources                                                                                                                                                                           |
+| [Virtual Machine Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#virtual-machine-contributor)                                   | 9980e02c-c2be-4d73-94e8-173b1dc7cf3c | Allows to deploy virtual machines                                                                                                                                                                                        |
+| [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor)                                                                   | b24988ac-6180-42a0-ab88-20f7382dd24c | Unfortunate wokaround for creating supporting resources, hopefully better solution will be found and this role will not be necessary in the future                                                                       |
+| [Registration assignment Delete Role](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#managed-services-registration-assignment-delete-role)  | 91c1777a-f3dc-4fae-b103-61d183457e46 | Enables to remove the delegation when no longer needed. It is [recommended best practice](https://learn.microsoft.com/en-us/azure/lighthouse/concepts/tenants-users-roles#best-practices-for-defining-users-and-roles).  |
 
 
 ### Prepare Azure offering tenant
@@ -45,11 +46,20 @@ Following steps get us the offering template:
 
 - Start with the template [`lighthouse_template.json`](./lighthouse.tmpl.json)
 - Replace `{{.TenantID}}` by value in `AZURE_TENANT_ID`
-- Go to Azure AD -> Enterprise applications
-  - Select the App that was automatically registered for the App registration (provisioning-service)
-  - Copy Object ID
-  - Replace `{{.EnterpriseAppID}}` by the value copied from above
-  - Replace `{{.EnterpriseAppName}}` by the name of the enterprise application (provisioning-service)
+- Set a Principal ID - there are two options
+  1. Use the Enterprise App as a principal.
+     1. Go to Azure AD -> Enterprise applications
+     2. Select the App that was automatically registered for the App registration (provisioning-service)
+     3. Copy Object ID
+     4. Replace `{{.PrincipalID}}` by the value copied from above
+     5. Replace `{{.PrincipalName}}` by the name of the enterprise application (provisioning-service)
+  2. Create a Security group and add the Enterprise App as its member
+     1. Go to Azure AD -> Groups
+     2. Create a group and name it
+     3. Go to members and add our Enterprise App
+     4. Go to the Group overview and copy its Object ID
+     5. Replace `{{.PrincipalID}}` by the value copied from above
+     6. Replace `{{.PrincipalName}}` by the name of the Group
 - Set default offering name and description
   - Tenant account can change this while accepting the offering
   - Replace `{{.OfferingDefaultName}}` by a default offering name

--- a/internal/clients/azure_offering_template.go
+++ b/internal/clients/azure_offering_template.go
@@ -21,11 +21,11 @@ type AzureOfferingTemplate struct {
 	// TenantID of the offering tenant (Azure account)
 	TenantID string
 
-	// EnterpriseAppID of the App that will act as an offering Principal
-	EnterpriseAppID string
+	// PrincipalID of the App that will act as an offering Principal or a group that has the service principal as a member.
+	PrincipalID string
 
-	// EnterpriseAppName of the offering principal - the display name
-	EnterpriseAppName string
+	// PrincipalName of the offering principal - the display name
+	PrincipalName string
 }
 
 func (tempParams AzureOfferingTemplate) Render(ctx context.Context, wr io.Writer) error {

--- a/internal/clients/http/azure/lighthouse.tmpl.json
+++ b/internal/clients/http/azure/lighthouse.tmpl.json
@@ -23,19 +23,24 @@
     "managedByTenantId": "{{.TenantID}}",
     "authorizations": [
       {
-        "principalId": "{{.EnterpriseAppID}}",
-        "principalIdDisplayName": "{{.EnterpriseAppName}}",
+        "principalId": "{{.PrincipalID}}",
+        "principalIdDisplayName": "{{.PrincipalName}}",
         "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7"
       },
       {
-        "principalId": "{{.EnterpriseAppID}}",
-        "principalIdDisplayName": "{{.EnterpriseAppName}}",
+        "principalId": "{{.PrincipalID}}",
+        "principalIdDisplayName": "{{.PrincipalName}}",
         "roleDefinitionId": "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
       },
       {
-        "principalId": "{{.EnterpriseAppID}}",
-        "principalIdDisplayName": "{{.EnterpriseAppName}}",
+        "principalId": "{{.PrincipalID}}",
+        "principalIdDisplayName": "{{.PrincipalName}}",
         "roleDefinitionId": "b24988ac-6180-42a0-ab88-20f7382dd24c"
+      },
+      {
+        "principalId": "{{.PrincipalID}}",
+        "principalIdDisplayName": "{{.PrincipalName}}",
+        "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46"
       }
     ]
   },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,11 +81,12 @@ var config struct {
 		Logging       bool   `env:"LOGGING" env-default:"false" env-description:"AWS service account logging (verbose)"`
 	} `env-prefix:"AWS_"`
 	Azure struct {
-		TenantID      string `env:"TENANT_ID" env-default:"" env-description:"Azure service account tenant id"`
-		ClientID      string `env:"CLIENT_ID" env-default:"" env-description:"Azure service account client id"`
-		ClientSecret  string `env:"CLIENT_SECRET" env-default:"" env-description:"Azure service account client secret"`
-		ClientName    string `env:"CLIENT_NAME" env-default:"RH HCC" env-description:"Azure service account display name"`
-		DefaultRegion string `env:"DEFAULT_REGION" env-default:"eastus" env-description:"Azure region when not provided"`
+		TenantID            string `env:"TENANT_ID" env-default:"" env-description:"Azure service account tenant id"`
+		ClientID            string `env:"CLIENT_ID" env-default:"" env-description:"Azure service account client id"`
+		ClientSecret        string `env:"CLIENT_SECRET" env-default:"" env-description:"Azure service account client secret"`
+		ClientPrincipalID   string `env:"CLIENT_PRINCIPAL_ID" env-default:"" env-description:"Azure Principal ID. It is used for lighthouse delegation. It can be object ID of the service principal or Group object id having the service principal as a member"`
+		ClientPrincipalName string `env:"CLIENT_PRINCIPAL_NAME" env-default:"RH HCC" env-description:"Azure display name for the offering principal"`
+		DefaultRegion       string `env:"DEFAULT_REGION" env-default:"eastus" env-description:"Azure region when not provided"`
 		// SubscriptionID is not used in prod environments - used to fetch instance types
 		SubscriptionID string `env:"SUBSCRIPTION_ID" env-default:"" env-description:"Azure service account subscription id"`
 	} `env-prefix:"AZURE_"`

--- a/internal/services/azure_offering_template_service.go
+++ b/internal/services/azure_offering_template_service.go
@@ -9,7 +9,7 @@ import (
 )
 
 func AzureOfferingTemplate(w http.ResponseWriter, r *http.Request) {
-	clientName := config.Azure.ClientName
+	clientName := config.Azure.ClientPrincipalName
 	if clientName == "" {
 		clientName = "Red Hat Launch images client"
 	}
@@ -18,8 +18,8 @@ func AzureOfferingTemplate(w http.ResponseWriter, r *http.Request) {
 		OfferingDefaultName:        "Red Hat Hybrid Cloud Console",
 		OfferingDefaultDescription: "Allows Red Hat to upload images and deploy Virtual Machines from Hybrid cloud console",
 		TenantID:                   config.Azure.TenantID,
-		EnterpriseAppID:            config.Azure.ClientID,
-		EnterpriseAppName:          clientName,
+		PrincipalID:                config.Azure.ClientPrincipalID,
+		PrincipalName:              clientName,
 	}
 
 	if err := tmpl.Render(r.Context(), w); err != nil {


### PR DESCRIPTION
Azure supports permissions on Groups and it is a safer bet. We should support this in offering template.
It also allows for Enterprise Apps to be used properly as Principal ID is different to Client ID.

Refs HMS-1148


We finally have Azure stage and prod secrets, this gets ready to consume them.
Principal is only for the Lighthouse offering template, so now its values are set only on the API through clowdapp.