### PR TITLE
Refactor cache metrics

### DIFF
--- a/internal/cache/metrics_decorator.go
+++ b/internal/cache/metrics_decorator.go
@@ -3,23 +3,8 @@ package cache
 import (
 	"context"
 
+	"github.com/RHEnVision/provisioning-backend/internal/metrics"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
-	"github.com/RHEnVision/provisioning-backend/internal/version"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-)
-
-var (
-	accountIdHits = promauto.NewCounter(prometheus.CounterOpts{
-		Name:        "app_cache_account_hits",
-		Help:        "The total number of cache hits for account ID",
-		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName},
-	})
-	accountIdMisses = promauto.NewCounter(prometheus.CounterOpts{
-		Name:        "app_cache_account_miss",
-		Help:        "The total number of cache misses for account ID",
-		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName},
-	})
 )
 
 type accountMetricsCache struct {
@@ -36,11 +21,11 @@ func NewAccountDecorator(accountId AccountIdCache) *accountMetricsCache {
 func (c *accountMetricsCache) FindAccountId(ctx context.Context, OrgID, AccountNumber string) (*models.Account, error) {
 	value, err := c.accountId.FindAccountId(ctx, OrgID, AccountNumber)
 	if err != nil {
-		accountIdMisses.Inc()
+		metrics.IncCacheHit("account", "miss")
 		return nil, err
 	}
 
-	accountIdHits.Inc()
+	metrics.IncCacheHit("account", "hit")
 	return value, nil
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,6 +24,12 @@ var TotalInvalidAvailabilityCheckReqs = prometheus.NewCounter(
 	},
 )
 
+var CacheHits = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name:        "provisioning_cache_hits",
+	Help:        "The total number of cache hits for individual resources with result (hit or miss)",
+	ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName},
+}, []string{"resource", "result"})
+
 var JobQueueSize = prometheus.NewGauge(prometheus.GaugeOpts{
 	Name:        "provisioning_job_queue_size",
 	Help:        "background job queue size (total pending jobs)",
@@ -97,6 +103,10 @@ func IncTotalSentAvailabilityCheckReqs(provider string, statusType string, err e
 
 func IncTotalInvalidAvailabilityCheckReqs() {
 	TotalInvalidAvailabilityCheckReqs.Inc()
+}
+
+func IncCacheHit(resource string, result string) {
+	CacheHits.WithLabelValues(resource, result).Inc()
 }
 
 func SetJobQueueSize(size uint64) {

--- a/internal/metrics/registration.go
+++ b/internal/metrics/registration.go
@@ -3,13 +3,13 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 func RegisterStatuserMetrics() {
-	prometheus.MustRegister(TotalSentAvailabilityCheckReqs, AvailabilityCheckReqsDuration, TotalInvalidAvailabilityCheckReqs)
+	prometheus.MustRegister(TotalSentAvailabilityCheckReqs, AvailabilityCheckReqsDuration, TotalInvalidAvailabilityCheckReqs, CacheHits)
 }
 
 func RegisterApiMetrics() {
-	// no metrics
+	prometheus.MustRegister(CacheHits)
 }
 
 func RegisterWorkerMetrics() {
-	prometheus.MustRegister(JobQueueSize, JobQueueInFlight, BackgroundJobDuration, ReservationCount)
+	prometheus.MustRegister(JobQueueSize, JobQueueInFlight, BackgroundJobDuration, ReservationCount, CacheHits)
 }


### PR DESCRIPTION
SSIA this was created before we introduced the package. Also, all our metrics starts with `provisioning_` prefix. I would like to put these into our dashboard as well once I implement RBAC cache and miss metrics.