### PR TITLE
feat: integrate Sentry via OpenTelemetry

### DIFF
--- a/cmd/pbapi/main.go
+++ b/cmd/pbapi/main.go
@@ -105,7 +105,7 @@ func main() {
 	apiRouter := chi.NewRouter()
 
 	apiRouter.Use(m.NewPatternMiddleware(version.PrometheusLabelName))
-	apiRouter.Use(telemetry.Middleware(apiRouter))
+	apiRouter.Use(telemetry.Middleware(rootRouter))
 	apiRouter.Use(m.VersionMiddleware)
 	apiRouter.Use(m.TraceID)
 	apiRouter.Use(m.LoggerMiddleware(&log.Logger))

--- a/config/api.env.example
+++ b/config/api.env.example
@@ -38,8 +38,10 @@
 #     	logger standard output, disabled in clowder by default, stdout is still used if there is no other writer (default "true")
 #   LOGGING_MAX_FIELD int
 #     	logger maximum field length (dev only) (default "0")
-#   TELEMETRY_ENABLED bool
-#     	open telemetry collecting (default "false")
+#   LOGGING_SENTRY_ENABLED bool
+#     	send errors from logger to sentry (requires SENTRY_DSN) (default "false")
+#   TELEMETRY_TYPE string
+#     	open telemetry exporting, valid values: sentry, jaeger, logger or blank for no telemetry (default "")
 #   CLOUDWATCH_ENABLED bool
 #     	cloudwatch logging exporter (enabled in clowder) (default "false")
 #   CLOUDWATCH_REGION string
@@ -110,6 +112,10 @@
 #     	unleash service client access token (default "")
 #   SENTRY_DSN string
 #     	data source name (empty value disables Sentry) (default "")
+#   SENTRY_SAMPLE_RATE float64
+#     	sample rate (0.0 - 1.0) (default "1.0")
+#   SENTRY_DEBUG bool
+#     	debug sentry (default "false")
 #   KAFKA_ENABLED bool
 #     	kafka service enabled (default "false")
 #   KAFKA_BROKERS slice
@@ -122,12 +128,8 @@
 #     	application cache (none, memory, redis) (default "none")
 #   APP_CACHE_EXPIRATION int64
 #     	expiration for both memory and Redis (time interval syntax) (default "1h")
-#   TELEMETRY_JAEGER_ENABLED bool
-#     	open telemetry jaeger exporter (default "false")
 #   TELEMETRY_JAEGER_ENDPOINT string
 #     	jaeger endpoint (default "http://localhost:14268/api/traces")
-#   TELEMETRY_LOGGER_ENABLED bool
-#     	open telemetry logger output (dev only) (default "false")
 #   REST_ENDPOINTS_IMAGE_BUILDER_URL string
 #     	image builder URL (default "")
 #   REST_ENDPOINTS_IMAGE_BUILDER_USERNAME string

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -40,10 +40,14 @@ objects:
                 value: ${LOGGING_LEVEL}
               - name: DATABASE_LOGGING_LEVEL
                 value: ${DATABASE_LOGGING_LEVEL}
-              - name: TELEMETRY_ENABLED
-                value: ${TELEMETRY_ENABLED}
-              - name: TELEMETRY_LOGGER_ENABLED
-                value: ${TELEMETRY_LOGGER_ENABLED}
+              - name: LOGGING_SENTRY_ENABLED
+                value: ${LOGGING_SENTRY_ENABLED}
+              - name: TELEMETRY_TYPE
+                value: ${TELEMETRY_TYPE}
+              - name: SENTRY_DEBUG
+                value: ${SENTRY_DEBUG}
+              - name: SENTRY_SAMPLE_RATE
+                value: ${SENTRY_SAMPLE_RATE}
               - name: CLOWDER_ENABLED
                 value: ${CLOWDER_ENABLED}
               - name: REST_ENDPOINTS_IMAGE_BUILDER_URL
@@ -117,10 +121,14 @@ objects:
                 value: ${LOGGING_LEVEL}
               - name: DATABASE_LOGGING_LEVEL
                 value: ${DATABASE_LOGGING_LEVEL}
-              - name: TELEMETRY_ENABLED
-                value: ${TELEMETRY_ENABLED}
-              - name: TELEMETRY_LOGGER_ENABLED
-                value: ${TELEMETRY_LOGGER_ENABLED}
+              - name: LOGGING_SENTRY_ENABLED
+                value: ${LOGGING_SENTRY_ENABLED}
+              - name: TELEMETRY_TYPE
+                value: ${TELEMETRY_TYPE}
+              - name: SENTRY_DEBUG
+                value: ${SENTRY_DEBUG}
+              - name: SENTRY_SAMPLE_RATE
+                value: ${SENTRY_SAMPLE_RATE}
               - name: CLOWDER_ENABLED
                 value: ${CLOWDER_ENABLED}
               - name: REST_ENDPOINTS_IMAGE_BUILDER_URL
@@ -211,10 +219,14 @@ objects:
                 value: ${LOGGING_LEVEL}
               - name: DATABASE_LOGGING_LEVEL
                 value: ${DATABASE_LOGGING_LEVEL}
-              - name: TELEMETRY_ENABLED
-                value: ${TELEMETRY_ENABLED}
-              - name: TELEMETRY_LOGGER_ENABLED
-                value: ${TELEMETRY_LOGGER_ENABLED}
+              - name: LOGGING_SENTRY_ENABLED
+                value: ${LOGGING_SENTRY_ENABLED}
+              - name: TELEMETRY_TYPE
+                value: ${TELEMETRY_TYPE}
+              - name: SENTRY_DEBUG
+                value: ${SENTRY_DEBUG}
+              - name: SENTRY_SAMPLE_RATE
+                value: ${SENTRY_SAMPLE_RATE}
               - name: CLOWDER_ENABLED
                 value: ${CLOWDER_ENABLED}
               - name: REST_ENDPOINTS_IMAGE_BUILDER_URL
@@ -351,15 +363,23 @@ parameters:
   - description: Logging level (trace, debug, info, warn, error, fatal, panic)
     name: LOGGING_LEVEL
     value: "debug"
+  - description: Log errors from logger to sentry
+    name: LOGGING_SENTRY_ENABLED
+    value: "false"
   - description: Postgres driver logging level (trace, debug, info, warn, error, fatal, panic)
     name: DATABASE_LOGGING_LEVEL
     value: "debug"
-  - description: OpenTelemetry collecting
-    name: TELEMETRY_ENABLED
-    value: "true"
-  - description: OpenTelemetry export into the logger
-    name: TELEMETRY_LOGGER_ENABLED
-    value: "true"
+  - description: "OpenTelemetry collecting (NOTE: do not enable sentry)"
+    # sentry cannot be configured concurrently: https://github.com/archdx/zerolog-sentry/pull/7
+    # also our platform instance currently ignores performance
+    name: TELEMETRY_TYPE
+    value: ""
+  - description: Sentry debug logs
+    name: SENTRY_DEBUG
+    value: "false"
+  - description: Sentry sample rate
+    name: SENTRY_SAMPLE_RATE
+    value: "1.0"
   - description: Enable compression of the API responses
     name: APP_COMPRESSION
     value: "true"

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/georgysavva/scany/v2 v2.0.0
 	github.com/getkin/kin-openapi v0.115.0
 	github.com/getsentry/sentry-go v0.19.0
+	github.com/getsentry/sentry-go/otel v0.19.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/render v1.0.2
 	github.com/go-openapi/runtime v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/getkin/kin-openapi v0.115.0 h1:c8WHRLVY3G8m9jQTy0/DnIuljgRwTCB5twZytQ
 github.com/getkin/kin-openapi v0.115.0/go.mod h1:l5e9PaFUo9fyLJCPGQeXI2ML8c3P8BHOEV2VaAVf/pc=
 github.com/getsentry/sentry-go v0.19.0 h1:BcCH3CN5tXt5aML+gwmbFwVptLLQA+eT866fCO9wVOM=
 github.com/getsentry/sentry-go v0.19.0/go.mod h1:y3+lGEFEFexZtpbG1GUE2WD/f9zGyKYwpEqryTOC/nE=
+github.com/getsentry/sentry-go/otel v0.19.0 h1:U49QS+rwwd+R7BOSvP0b+5nVSsZiuSoGdLJ0DTIpSEY=
+github.com/getsentry/sentry-go/otel v0.19.0/go.mod h1:1CkTB32NWdtJWe82ah3lI6hDPLAjf1zBwvIOGqL4C1U=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
 github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/internal/clients/http/azure/create_vm.go
+++ b/internal/clients/http/azure/create_vm.go
@@ -19,11 +19,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
+	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 )
 
-const TraceName = "github.com/RHEnVision/provisioning-backend/internal/clients/http/azure"
+const TraceName = telemetry.TracePrefix + "internal/clients/http/azure"
 
 const (
 	vnetName              = "redhat-vnet"

--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
+	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsCfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -24,7 +25,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-const TraceName = "github.com/RHEnVision/provisioning-backend/internal/clients/http/ec2"
+const TraceName = telemetry.TracePrefix + "internal/clients/http/ec2"
 
 type ec2Client struct {
 	ec2     *ec2.Client

--- a/internal/clients/http/gcp/gcp_client.go
+++ b/internal/clients/http/gcp/gcp_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	guuid "github.com/google/uuid"
 
 	compute "cloud.google.com/go/compute/apiv1"
@@ -29,7 +30,7 @@ func init() {
 	clients.GetGCPClient = newGCPClient
 }
 
-const TraceName = "github.com/RHEnVision/provisioning-backend/internal/clients/http/gcp"
+const TraceName = telemetry.TracePrefix + "internal/clients/http/gcp"
 
 // GCP SDK does not provide a single client, so only configuration can be shared and
 // clients need to be created and closed in each function.

--- a/internal/clients/http/image_builder/image_client.go
+++ b/internal/clients/http/image_builder/image_client.go
@@ -10,13 +10,14 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/headers"
+	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 )
 
-const TraceName = "github.com/EnVision/provisioning/internal/clients/http/image_builder"
+const TraceName = telemetry.TracePrefix + "internal/clients/http/image_builder"
 
 type ibClient struct {
 	client *ClientWithResponses

--- a/internal/clients/http/platform_client.go
+++ b/internal/clients/http/platform_client.go
@@ -27,7 +27,7 @@ func NewPlatformClient(ctx context.Context, proxy string) HttpRequestDoer {
 		}
 	}
 
-	if config.Telemetry.Enabled {
+	if config.Telemetry.Type != "" {
 		rt = otelhttp.NewTransport(rt)
 	}
 

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -13,11 +13,12 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/headers"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 )
 
-const TraceName = "github.com/EnVision/provisioning/internal/clients/http/sources"
+const TraceName = telemetry.TracePrefix + "internal/clients/http/sources"
 
 type sourcesClient struct {
 	client *ClientWithResponses

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,19 +50,16 @@ var config struct {
 		LogLevel    string        `env:"LOG_LEVEL" env-default:"info" env-description:"logging level of database logs"`
 	} `env-prefix:"DATABASE_"`
 	Logging struct {
-		Level    string `env:"LEVEL" env-default:"info" env-description:"logger level (trace, debug, info, warn, error, fatal, panic)"`
-		Stdout   bool   `env:"STDOUT" env-default:"true" env-description:"logger standard output, disabled in clowder by default, stdout is still used if there is no other writer"`
-		MaxField int    `env:"MAX_FIELD" env-default:"0" env-description:"logger maximum field length (dev only)"`
+		Level         string `env:"LEVEL" env-default:"info" env-description:"logger level (trace, debug, info, warn, error, fatal, panic)"`
+		Stdout        bool   `env:"STDOUT" env-default:"true" env-description:"logger standard output, disabled in clowder by default, stdout is still used if there is no other writer"`
+		MaxField      int    `env:"MAX_FIELD" env-default:"0" env-description:"logger maximum field length (dev only)"`
+		SentryEnabled bool   `env:"SENTRY_ENABLED" env-default:"false" env-description:"send errors from logger to sentry (requires SENTRY_DSN)"`
 	} `env-prefix:"LOGGING_"`
 	Telemetry struct {
-		Enabled bool `env:"ENABLED" env-default:"false" env-description:"open telemetry collecting"`
-		Jaeger  struct {
-			Enabled  bool   `env:"ENABLED" env-default:"false" env-description:"open telemetry jaeger exporter"`
+		Type   string `env:"TYPE" env-default:"" env-description:"open telemetry exporting, valid values: sentry, jaeger, logger or blank for no telemetry"`
+		Jaeger struct {
 			Endpoint string `env:"ENDPOINT" env-default:"http://localhost:14268/api/traces" env-description:"jaeger endpoint"`
 		} `env-prefix:"JAEGER_"`
-		Logger struct {
-			Enabled bool `env:"ENABLED" env-default:"false" env-description:"open telemetry logger output (dev only)"`
-		} `env-prefix:"LOGGER_"`
 	} `env-prefix:"TELEMETRY_"`
 	Cloudwatch struct {
 		Enabled bool   `env:"ENABLED" env-default:"false" env-description:"cloudwatch logging exporter (enabled in clowder)"`
@@ -128,7 +125,9 @@ var config struct {
 		Token       string `env:"TOKEN" env-default:"" env-description:"unleash service client access token"`
 	} `env-prefix:"UNLEASH_"`
 	Sentry struct {
-		Dsn string `env:"DSN" env-default:"" env-description:"data source name (empty value disables Sentry)"`
+		Dsn        string  `env:"DSN" env-default:"" env-description:"data source name (empty value disables Sentry)"`
+		SampleRate float64 `env:"SAMPLE_RATE" env-default:"1.0" env-description:"sample rate (0.0 - 1.0)"`
+		Debug      bool    `env:"DEBUG" env-default:"false" env-description:"debug sentry"`
 	} `env-prefix:"SENTRY_"`
 	Kafka struct {
 		Enabled  bool     `env:"ENABLED" env-default:"false" env-description:"kafka service enabled"`

--- a/internal/dao/pgx/account_pgx.go
+++ b/internal/dao/pgx/account_pgx.go
@@ -12,6 +12,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/jackc/pgx/v5"
+	"go.opentelemetry.io/otel"
 )
 
 func init() {
@@ -51,6 +52,9 @@ func (x *accountDao) GetById(ctx context.Context, id int64) (*models.Account, er
 // this function into a single transaction at some point.
 func (x *accountDao) GetOrCreateByIdentity(ctx context.Context, orgId string, accountNumber string) (*models.Account, error) {
 	logger := ctxval.Logger(ctx)
+
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "GetOrCreateByIdentity")
+	defer span.End()
 
 	// Try to find by org ID first
 	acc, err := x.GetByOrgId(ctx, orgId)

--- a/internal/dao/pgx/package.go
+++ b/internal/dao/pgx/package.go
@@ -1,0 +1,6 @@
+// Provides DAO implementation via the native Postgres driver with scany library.
+package pgx
+
+import "github.com/RHEnVision/provisioning-backend/internal/telemetry"
+
+const TraceName = telemetry.TracePrefix + "internal/dao/pgx"

--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -63,7 +63,7 @@ func Initialize(ctx context.Context, schema string) error {
 	poolConfig.MaxConnLifetime = config.Database.MaxLifetime
 	poolConfig.MaxConnIdleTime = config.Database.MaxIdleTime
 
-	if config.Telemetry.Enabled {
+	if config.Telemetry.Type != "" {
 		poolConfig.ConnConfig.Tracer = otelpgx.NewTracer()
 	} else {
 		logLevel, configErr := tracelog.LogLevelFromString(config.Database.LogLevel)

--- a/internal/jobs/common.go
+++ b/internal/jobs/common.go
@@ -9,7 +9,10 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/metrics"
+	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 )
+
+const TraceName = telemetry.TracePrefix + "internal/jobs"
 
 var ErrTypeAssertion = errors.New("type assert error")
 

--- a/internal/jobs/launch_instance_azure.go
+++ b/internal/jobs/launch_instance_azure.go
@@ -14,8 +14,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-const TraceName = "github.com/RHEnVision/provisioning-backend/internal/jobs/launch_instance_azure"
-
 const (
 	resourceGroupName = "redhat-deployed"
 	location          = "eastus"

--- a/internal/jobs/noop_job.go
+++ b/internal/jobs/noop_job.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
+	"go.opentelemetry.io/otel"
 )
 
 type NoopJobArgs struct {
@@ -20,6 +21,9 @@ var NoOperationFailure = errors.New("job failed on request")
 
 // Unmarshall arguments and handle error
 func HandleNoop(ctx context.Context, job *worker.Job) {
+	ctx, span := otel.Tracer(TraceName).Start(ctx, "HandleNoop")
+	defer span.End()
+
 	args, ok := job.Args.(NoopJobArgs)
 	if !ok {
 		err := fmt.Errorf("%w: job %s, reservation: %#v", ErrTypeAssertion, job.ID, job.Args)

--- a/internal/logging/debug_writer.go
+++ b/internal/logging/debug_writer.go
@@ -1,0 +1,16 @@
+package logging
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+type DebugWriter struct {
+	Logger *zerolog.Logger
+}
+
+func (dw *DebugWriter) Write(p []byte) (n int, err error) {
+	dw.Logger.Debug().Msg(strings.TrimRight(string(p), "\n"))
+	return len(p), nil
+}

--- a/internal/logging/sentry.go
+++ b/internal/logging/sentry.go
@@ -12,7 +12,16 @@ import (
 // sentryWriter creates a zerolog writer for sentry.
 // Uses github.com/archdx/zerolog-sentry which is very simple wrapper.
 func sentryWriter(dsn string) (io.Writer, func(), error) {
-	wr, err := sentrywriter.New(dsn)
+	var opts []sentrywriter.WriterOption
+	if config.Sentry.Debug {
+		opts = append(opts, sentrywriter.WithDebug())
+	}
+	opts = append(opts, sentrywriter.WithSampleRate(config.Sentry.SampleRate))
+	// TODO this calls sentry.Init again (it is initialized in our telemetry package)
+	// We must be able to initialize it only once and pass it into here, or, create it
+	// here with tracing and sample rate enabled and use it also for otel.
+	// Currently it is not possible to have sentry for both errors and tracing.
+	wr, err := sentrywriter.New(dsn, opts...)
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("cannot initialize sentry: %w", err)
 	}

--- a/internal/logging/zerolog.go
+++ b/internal/logging/zerolog.go
@@ -108,7 +108,8 @@ func InitializeLogger() (zerolog.Logger, func()) {
 		log.Trace().Msg("Cloudwatch not enabled, enabling stdout")
 		writers = append(writers, stdoutWriter(false))
 	}
-	if config.Sentry.Dsn != "" {
+	if config.Logging.SentryEnabled && config.Sentry.Dsn != "" {
+		log.Debug().Msg("Initializing logging sentry integration")
 		sWriter, closeFn, err := sentryWriter(config.Sentry.Dsn)
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to initialize sentry, disabling sentry monitoring")

--- a/internal/telemetry/logging_transport.go
+++ b/internal/telemetry/logging_transport.go
@@ -1,0 +1,36 @@
+package telemetry
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/rs/zerolog"
+)
+
+// LoggingTransport logs warning when HTTP reply is not 2xx/3xx. In addition,
+// when trace logging level is enabled, it also dumps request/reply body.
+type LoggingTransport struct {
+	roundTripper http.RoundTripper
+	logger       *zerolog.Logger
+}
+
+func (d *LoggingTransport) RoundTrip(h *http.Request) (*http.Response, error) {
+	var dump []byte
+	if d.logger.GetLevel() <= zerolog.TraceLevel {
+		dump, _ = httputil.DumpRequestOut(h, true)
+	}
+	resp, err := d.roundTripper.RoundTrip(h)
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		d.logger.Warn().Msgf("Sentry replied with error: %s", resp.Status)
+		if d.logger.GetLevel() <= zerolog.TraceLevel {
+			d.logger.Trace().Msgf("Sentry HTTP request: %s", dump)
+			dump, _ = httputil.DumpResponse(resp, true)
+			d.logger.Trace().Msgf("Sentry HTTP response: %s", dump)
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("roundtrip error: %w", err)
+	}
+	return resp, err
+}

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -2,10 +2,14 @@ package telemetry
 
 import (
 	"context"
+	"log"
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/logging"
 	"github.com/RHEnVision/provisioning-backend/internal/version"
+	"github.com/getsentry/sentry-go"
+	sentryotel "github.com/getsentry/sentry-go/otel"
 	"github.com/go-chi/chi/v5"
 	"github.com/riandyrn/otelchi"
 	"github.com/rs/zerolog"
@@ -17,40 +21,26 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 )
 
+// AppName is the application name which appears in traces.
 const AppName = "provisioning-backend"
+
+// TracePrefix must be used as prefix for TraceNames in packages.
+const TracePrefix = AppName + "/"
 
 type Telemetry struct {
 	tracerProvider *trace.TracerProvider
-	propagator     propagation.TextMapPropagator
+	propagator     *propagation.TextMapPropagator
 }
 
 func Middleware(routes chi.Routes) func(next http.Handler) http.Handler {
-	return otelchi.Middleware(AppName, otelchi.WithChiRoutes(routes))
+	return otelchi.Middleware(AppName, otelchi.WithChiRoutes(routes), otelchi.WithRequestMethodInSpanName(true))
 }
 
 func Initialize(rootLogger *zerolog.Logger) *Telemetry {
-	if !config.Telemetry.Enabled {
+	if config.Telemetry.Type == "" {
 		return &Telemetry{}
 	}
 	logger := rootLogger.With().Bool("otel", true).Logger()
-
-	var exporterOption trace.TracerProviderOption
-	if config.Telemetry.Jaeger.Enabled {
-		// production use case: full exporting, batching
-		exporter, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(config.Telemetry.Jaeger.Endpoint)))
-		if err != nil {
-			panic(err)
-		}
-		exporterOption = trace.WithBatcher(exporter)
-	} else if config.Telemetry.Logger.Enabled {
-		// development use case: logger exporting, synchronous
-		exporter := NewZerologExporter(&logger)
-		exporterOption = trace.WithSyncer(exporter)
-	} else {
-		// No tracing configured - do nothing
-		exporter := NewNoopExporter()
-		exporterOption = trace.WithSyncer(exporter)
-	}
 
 	res := resource.NewWithAttributes(
 		semconv.SchemaURL,
@@ -58,20 +48,59 @@ func Initialize(rootLogger *zerolog.Logger) *Telemetry {
 		semconv.ServiceVersionKey.String(version.OpenTelemetryVersion),
 	)
 
-	tp := trace.NewTracerProvider(
-		exporterOption,
-		trace.WithResource(res),
-	)
+	var tpOptions []trace.TracerProviderOption
+	if config.Telemetry.Type == "sentry" {
+		// production use case: sentry exporting
+		sentryLogger := logger.With().Bool("sentry", true).Logger()
+		sentryLogger.Debug().Msg("Initializing otel sentry integration")
+		logWriter := logging.DebugWriter{Logger: &sentryLogger}
+		sentry.Logger = log.New(&logWriter, "", 0)
+		err := sentry.Init(sentry.ClientOptions{
+			Dsn:              config.Sentry.Dsn,
+			EnableTracing:    true,
+			TracesSampleRate: config.Sentry.SampleRate,
+			Debug:            config.Sentry.Debug,
+			DebugWriter:      &logWriter,
+			HTTPTransport: &LoggingTransport{
+				roundTripper: http.DefaultTransport,
+				logger:       &sentryLogger,
+			},
+		})
+		if err != nil {
+			panic(err)
+		}
 
-	propagator := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
+		tpOptions = append(tpOptions, trace.WithSpanProcessor(sentryotel.NewSentrySpanProcessor()))
+	} else if config.Telemetry.Type == "jaeger" {
+		// production use case: full exporting, batching
+		exporter, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(config.Telemetry.Jaeger.Endpoint)))
+		if err != nil {
+			panic(err)
+		}
+		tpOptions = append(tpOptions, trace.WithResource(res))
+		tpOptions = append(tpOptions, trace.WithBatcher(exporter))
+	} else if config.Telemetry.Type == "logger" {
+		// development use case: logger exporting, synchronous
+		exporter := NewZerologExporter(&logger)
+		tpOptions = append(tpOptions, trace.WithResource(res))
+		tpOptions = append(tpOptions, trace.WithSyncer(exporter))
+	} else {
+		// No tracing configured - do nothing
+		exporter := NewNoopExporter()
+		tpOptions = append(tpOptions, trace.WithResource(res))
+		tpOptions = append(tpOptions, trace.WithSyncer(exporter))
+	}
+
+	tp := trace.NewTracerProvider(tpOptions...)
+	propagator := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}, sentryotel.NewSentryPropagator())
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagator)
-	return &Telemetry{tracerProvider: tp, propagator: propagator}
+	return &Telemetry{tracerProvider: tp, propagator: &propagator}
 }
 
 func (t *Telemetry) Close(ctx context.Context) {
 	if t.tracerProvider == nil {
 		return
 	}
-	_ = t.tracerProvider.Shutdown(ctx)
+	_ = t.tracerProvider.Shutdown(context.Background())
 }


### PR DESCRIPTION
This is an experiment, but it appears that Sentry can be configured via OpenTelemetry API/SDK so it delivers traces into Sentry (Glitchtip in our case). I slightly updated how telemetry and sentry is configured to streamline the configuration experience and enabled this for ephemeral. Assuming the Glitchtip deployed in ephemeral is accepting traces, this should work "out of box".

I haven’t tried this locally, would like to ask @ezr-ondrej to test this first before I fully commit to elaborating this. There is one limitation at the moment - the logging sentry library we use currently does not allow to initialize Sentry and pass it in, but this should be pretty small change to either contribute or we could make a copy of that library.

But if this works out, then use of OpenTelemetry could already pay off and that is quite earlier than I expected.