### PR TITLE
chore: avoid logging Err().Msgf("msg with error")

### DIFF
--- a/cmd/pbstatuser/main.go
+++ b/cmd/pbstatuser/main.go
@@ -66,7 +66,7 @@ func processMessage(origCtx context.Context, message *kafka.GenericMessage) {
 	// Get source id
 	asm, err := kafka.NewAvailabilityStatusMessage(message)
 	if err != nil {
-		logger.Warn().Err(err).Msgf("Could not get availability status message %s", err)
+		logger.Warn().Err(err).Msg("Could not get availability status message")
 		return
 	}
 	logger.Trace().Msgf("Received a message from sources to be processed with source id %s", asm.SourceID)
@@ -80,7 +80,7 @@ func processMessage(origCtx context.Context, message *kafka.GenericMessage) {
 	// Get sources client
 	sourcesClient, err := clients.GetSourcesClient(ctx)
 	if err != nil {
-		logger.Warn().Err(err).Msgf("Could not get sources client %s", err)
+		logger.Warn().Err(err).Msg("Could not get sources client")
 		return
 	}
 
@@ -89,10 +89,10 @@ func processMessage(origCtx context.Context, message *kafka.GenericMessage) {
 	if err != nil {
 		metrics.IncTotalInvalidAvailabilityCheckReqs()
 		if errors.Is(err, clients.NotFoundErr) {
-			logger.Warn().Err(err).Msgf("Not found error: %s", err)
+			logger.Warn().Err(err).Msg("Not found error from sources")
 			return
 		}
-		logger.Warn().Err(err).Msgf("Could not get authentication: %s", err)
+		logger.Warn().Err(err).Msg("Could not get authentication")
 		return
 	}
 
@@ -155,7 +155,7 @@ func checkSourceAvailabilityAWS(ctx context.Context) {
 			if err != nil {
 				sr.Status = kafka.StatusUnavailable
 				sr.Err = err
-				logger.Warn().Err(err).Msgf("Could not get aws assumed client %s", err)
+				logger.Warn().Err(err).Msg("Could not get aws assumed client")
 				chSend <- sr
 			} else {
 				sr.Status = kafka.StatusAvaliable
@@ -184,14 +184,14 @@ func checkSourceAvailabilityGCP(ctx context.Context) {
 			if err != nil {
 				sr.Status = kafka.StatusUnavailable
 				sr.Err = err
-				logger.Warn().Err(err).Msgf("Could not get gcp client %s", err)
+				logger.Warn().Err(err).Msg("Could not get gcp client")
 				chSend <- sr
 			}
 			_, err = gcpClient.ListAllRegions(ctx)
 			if err != nil {
 				sr.Status = kafka.StatusUnavailable
 				sr.Err = err
-				logger.Warn().Err(err).Msgf("Could not list gcp regions %s", err)
+				logger.Warn().Err(err).Msg("Could not list gcp regions")
 				chSend <- sr
 			} else {
 				sr.Status = kafka.StatusAvaliable
@@ -217,7 +217,7 @@ func sendResults(ctx context.Context, batchSize int, tickDuration time.Duration)
 			ctx = ctxval.WithIdentity(ctx, sr.Identity)
 			msg, err := sr.GenericMessage(ctx)
 			if err != nil {
-				logger.Warn().Err(err).Msgf("Could not generate generic message %s", err)
+				logger.Warn().Err(err).Msg("Could not generate generic message")
 				continue
 			}
 			messages = append(messages, &msg)
@@ -227,7 +227,7 @@ func sendResults(ctx context.Context, batchSize int, tickDuration time.Duration)
 				logger.Trace().Int("messages", length).Msgf("Sending %d source availability status messages (full buffer)", length)
 				err := kafka.Send(ctx, messages...)
 				if err != nil {
-					logger.Warn().Err(err).Msgf("Could not send source availability status messages (full buffer) %s", err)
+					logger.Warn().Err(err).Msg("Could not send source availability status messages (full buffer)")
 				}
 				messages = messages[:0]
 			}
@@ -237,7 +237,7 @@ func sendResults(ctx context.Context, batchSize int, tickDuration time.Duration)
 				logger.Trace().Int("messages", length).Msgf("Sending %d source availability status messages (tick)", length)
 				err := kafka.Send(ctx, messages...)
 				if err != nil {
-					logger.Warn().Err(err).Msgf("Could not send source availability status messages (tick) %s", err)
+					logger.Warn().Err(err).Msg("Could not send source availability status messages (tick)")
 				}
 				messages = messages[:0]
 			}
@@ -249,7 +249,7 @@ func sendResults(ctx context.Context, batchSize int, tickDuration time.Duration)
 				logger.Trace().Int("messages", length).Msgf("Sending %d source availability status messages (cancel)", length)
 				err := kafka.Send(ctx, messages...)
 				if err != nil {
-					logger.Warn().Err(err).Msgf("Could not send source availability status messages (cancel) %s", err)
+					logger.Warn().Err(err).Msg("Could not send source availability status messages (cancel)")
 				}
 			}
 

--- a/internal/clients/http/azure/create_vm.go
+++ b/internal/clients/http/azure/create_vm.go
@@ -50,7 +50,7 @@ func (c *client) CreateVM(ctx context.Context, location string, resourceGroupNam
 	virtualNetwork, err := c.createVirtualNetwork(ctx, location, resourceGroupName, vnetName)
 	if err != nil {
 		span.SetStatus(codes.Error, "cannot create virtual network")
-		logger.Error().Err(err).Msgf("cannot create virtual network")
+		logger.Error().Err(err).Msg("cannot create virtual network")
 		return nil, err
 	}
 	logger.Trace().Msgf("Using virtual network id=%s", *virtualNetwork.ID)
@@ -58,7 +58,7 @@ func (c *client) CreateVM(ctx context.Context, location string, resourceGroupNam
 	subnet, err := c.createSubnets(ctx, resourceGroupName, vnetName, subnetName)
 	if err != nil {
 		span.SetStatus(codes.Error, "cannot create subnet")
-		logger.Error().Err(err).Msgf("cannot create subnet")
+		logger.Error().Err(err).Msg("cannot create subnet")
 		return nil, err
 	}
 	logger.Trace().Msgf("Using subnet id=%s", *subnet.ID)
@@ -67,7 +67,7 @@ func (c *client) CreateVM(ctx context.Context, location string, resourceGroupNam
 	nsg, err := c.createNetworkSecurityGroup(ctx, location, resourceGroupName, nsgName)
 	if err != nil {
 		span.SetStatus(codes.Error, "cannot create network security group")
-		logger.Error().Err(err).Msgf("cannot create network security group")
+		logger.Error().Err(err).Msg("cannot create network security group")
 		return nil, err
 	}
 	logger.Trace().Msgf("Using network security group id=%s", *nsg.ID)
@@ -76,7 +76,7 @@ func (c *client) CreateVM(ctx context.Context, location string, resourceGroupNam
 	publicIP, err := c.createPublicIP(ctx, location, resourceGroupName, publicIPName)
 	if err != nil {
 		span.SetStatus(codes.Error, "cannot create public IP address")
-		logger.Error().Err(err).Msgf("cannot create public IP address")
+		logger.Error().Err(err).Msg("cannot create public IP address")
 		return nil, err
 	}
 	logger.Trace().Msgf("Using public IP address id=%s", *publicIP.ID)
@@ -85,7 +85,7 @@ func (c *client) CreateVM(ctx context.Context, location string, resourceGroupNam
 	networkInterface, err := c.createNetworkInterface(ctx, location, resourceGroupName, subnet, publicIP, nsg, nicName)
 	if err != nil {
 		span.SetStatus(codes.Error, "cannot create network interface")
-		logger.Error().Err(err).Msgf("cannot create network interface")
+		logger.Error().Err(err).Msg("cannot create network interface")
 		return nil, err
 	}
 	logger.Trace().Msgf("Using network interface id=%s", *networkInterface.ID)
@@ -94,7 +94,7 @@ func (c *client) CreateVM(ctx context.Context, location string, resourceGroupNam
 	virtualMachine, err := c.createVirtualMachine(ctx, resourceGroupName, vmName, vmParams)
 	if err != nil {
 		span.SetStatus(codes.Error, "cannot create virtual machine")
-		logger.Error().Err(err).Msgf("cannot create virtual machine")
+		logger.Error().Err(err).Msg("cannot create virtual machine")
 		return nil, err
 	}
 	logger.Debug().Msgf("Created virtual machine id=%s", *virtualMachine.ID)

--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -129,7 +129,8 @@ func getStsAssumedCredentials(ctx context.Context, arn string, region string) (*
 	}
 	stsClient := sts.NewFromConfig(*cfg)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create an sts client %w", err)
+		logger.Error().Err(err).Msg("Cannot create STS client")
+		return nil, fmt.Errorf("cannot create STS client %w", err)
 	}
 
 	output, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
@@ -137,7 +138,7 @@ func getStsAssumedCredentials(ctx context.Context, arn string, region string) (*
 		RoleSessionName: ptr.To("name"),
 	})
 	if err != nil {
-		logger.Error().Err(err).Msgf("cannot assume role %s", err)
+		logger.Error().Err(err).Msg("Cannot assume role")
 		return nil, fmt.Errorf("cannot assume role %w", err)
 	}
 

--- a/internal/clients/http/gcp/gcp_client.go
+++ b/internal/clients/http/gcp/gcp_client.go
@@ -100,7 +100,7 @@ func (c *gcpClient) InsertInstances(ctx context.Context, params *clients.GCPInst
 
 	client, err := c.newInstancesClient(ctx)
 	if err != nil {
-		logger.Error().Err(err).Msgf("Could not get instances client: %v", err)
+		logger.Error().Err(err).Msg("Could not get instances client")
 		return nil, nil, fmt.Errorf("unable to bulk insert instances: %w", err)
 	}
 	defer client.Close()
@@ -152,11 +152,11 @@ func (c *gcpClient) InsertInstances(ctx context.Context, params *clients.GCPInst
 	op, err := client.BulkInsert(ctx, req)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		logger.Error().Err(err).Msgf("Bulk insert operation has failed: %v", err)
+		logger.Error().Err(err).Msg("Bulk insert operation failed")
 		return nil, nil, fmt.Errorf("cannot bulk insert instances: %w", err)
 	}
 	if err := op.Wait(ctx); err != nil {
-		logger.Error().Err(err).Msgf("Bulk insert operation has failed: %v", err)
+		logger.Error().Err(err).Msg("Bulk wait operation failed")
 		span.SetStatus(codes.Error, err.Error())
 		return nil, nil, fmt.Errorf("cannot bulk insert instances: %w", err)
 	}
@@ -179,7 +179,7 @@ func (c *gcpClient) InsertInstances(ctx context.Context, params *clients.GCPInst
 			logger.Error().Err(err).Msg("Instances iterator has finished")
 			break
 		} else if err != nil {
-			logger.Error().Err(err).Msgf("An error occured during fetching instance ids %s", err.Error())
+			logger.Error().Err(err).Msg("An error occurred during fetching instance ids")
 			span.SetStatus(codes.Error, err.Error())
 			return nil, nil, fmt.Errorf("cannot fetch instance ids: %w", err)
 		} else {

--- a/internal/clients/http/image_builder/image_client.go
+++ b/internal/clients/http/image_builder/image_client.go
@@ -48,7 +48,7 @@ func (c *ibClient) Ready(ctx context.Context) error {
 	logger := logger(ctx)
 	resp, err := c.client.GetReadiness(ctx, headers.AddImageBuilderIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
-		logger.Error().Err(err).Msgf("Readiness request failed for image builder: %s", err.Error())
+		logger.Error().Err(err).Msg("Readiness request failed for image builder")
 		return err
 	}
 	defer resp.Body.Close()

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -65,7 +65,7 @@ func (c *sourcesClient) Ready(ctx context.Context) error {
 	logger := logger(ctx)
 	resp, err := c.client.ListApplicationTypes(ctx, &ListApplicationTypesParams{}, headers.AddSourcesIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
-		logger.Error().Err(err).Msgf("Readiness request failed for sources: %s", err.Error())
+		logger.Error().Err(err).Msg("Readiness request failed for sources")
 		return err
 	}
 	defer resp.Body.Close()

--- a/internal/config/flags_listener.go
+++ b/internal/config/flags_listener.go
@@ -11,12 +11,12 @@ type logListener struct {
 
 // OnError prints out errors.
 func (l logListener) OnError(err error) {
-	l.logger.Error().Err(err).Msgf("Unleash error: %s", err.Error())
+	l.logger.Error().Err(err).Msg("Unleash error")
 }
 
 // OnWarning prints out warning.
 func (l logListener) OnWarning(err error) {
-	l.logger.Warn().Err(err).Msgf("Unleash error: %s", err.Error())
+	l.logger.Warn().Err(err).Msg("Unleash warning")
 }
 
 // OnReady prints to the console when the repository is ready.

--- a/internal/dao/dao_transaction.go
+++ b/internal/dao/dao_transaction.go
@@ -38,7 +38,7 @@ func WithTransaction(ctx context.Context, fn TxFn) error {
 	callErr := fn(tx)
 
 	if callErr != nil {
-		logger.Warn().Err(callErr).Msgf("DB error (rollback): %s", callErr.Error())
+		logger.Warn().Err(callErr).Msg("DB error (rollback)")
 		rollErr := tx.Rollback(ctx)
 		if rollErr != nil {
 			logger.Warn().Err(rollErr).Msg("Cannot rollback database transaction")

--- a/internal/jobs/common.go
+++ b/internal/jobs/common.go
@@ -11,6 +11,8 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/metrics"
 )
 
+var ErrTypeAssertion = errors.New("type assert error")
+
 func finishJob(ctx context.Context, reservationId int64, jobErr error) {
 	if jobErr != nil {
 		finishWithError(ctx, reservationId, jobErr)
@@ -62,8 +64,7 @@ func finishWithError(ctx context.Context, reservationId int64, jobError error) {
 		logger.Warn().Err(err).Msg("unable to update job status: get by id")
 		return
 	}
-	logger.Warn().Err(jobError).Msgf("Job of type %s (%d/%d) returned an error: %s",
-		reservation.Provider.String(), reservation.Step, reservation.Steps, jobError.Error())
+	logger.Warn().Err(jobError).Msg("Job returned an error")
 
 	// total count of reservations
 	metrics.IncReservationCount(reservation.Provider.String(), "failure")

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -46,7 +46,8 @@ type LaunchInstanceAWSTaskArgs struct {
 func HandleLaunchInstanceAWS(ctx context.Context, job *worker.Job) {
 	args, ok := job.Args.(LaunchInstanceAWSTaskArgs)
 	if !ok {
-		ctxval.Logger(ctx).Error().Msgf("Type assertion error for job %s, unable to finish reservation: %#v", job.ID, job.Args)
+		err := fmt.Errorf("%w: job %s, reservation: %#v", ErrTypeAssertion, job.ID, job.Args)
+		ctxval.Logger(ctx).Error().Err(err).Msg("Type assertion error for job")
 		return
 	}
 

--- a/internal/jobs/launch_instance_azure.go
+++ b/internal/jobs/launch_instance_azure.go
@@ -48,7 +48,8 @@ type LaunchInstanceAzureTaskArgs struct {
 func HandleLaunchInstanceAzure(ctx context.Context, job *worker.Job) {
 	args, ok := job.Args.(LaunchInstanceAzureTaskArgs)
 	if !ok {
-		ctxval.Logger(ctx).Error().Msgf("Type assertion error for job %s, unable to finish reservation: %#v", job.ID, job.Args)
+		err := fmt.Errorf("%w: job %s, reservation: %#v", ErrTypeAssertion, job.ID, job.Args)
+		ctxval.Logger(ctx).Error().Err(err).Msg("Type assertion error for job")
 		return
 	}
 
@@ -90,7 +91,7 @@ func DoEnsureAzureResourceGroup(ctx context.Context, args *LaunchInstanceAzureTa
 	resourceGroupID, err := azureClient.EnsureResourceGroup(ctx, resourceGroupName, location)
 	if err != nil {
 		span.SetStatus(codes.Error, "cannot create resource group")
-		logger.Error().Err(err).Msgf("cannot create resource group")
+		logger.Error().Err(err).Msg("Cannot create resource group")
 		return fmt.Errorf("failed to ensure resource group: %w", err)
 	}
 	logger.Trace().Msgf("Using resource group id=%s", *resourceGroupID)

--- a/internal/jobs/launch_instance_gcp.go
+++ b/internal/jobs/launch_instance_gcp.go
@@ -37,7 +37,8 @@ type LaunchInstanceGCPTaskArgs struct {
 func HandleLaunchInstanceGCP(ctx context.Context, job *worker.Job) {
 	args, ok := job.Args.(LaunchInstanceGCPTaskArgs)
 	if !ok {
-		ctxval.Logger(ctx).Error().Msgf("Type assertion error for job %s, unable to finish reservation: %#v", job.ID, job.Args)
+		err := fmt.Errorf("%w: job %s, reservation: %#v", ErrTypeAssertion, job.ID, job.Args)
+		ctxval.Logger(ctx).Error().Err(err).Msg("Type assertion error for job")
 		return
 	}
 

--- a/internal/jobs/noop_job.go
+++ b/internal/jobs/noop_job.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
@@ -21,7 +22,8 @@ var NoOperationFailure = errors.New("job failed on request")
 func HandleNoop(ctx context.Context, job *worker.Job) {
 	args, ok := job.Args.(NoopJobArgs)
 	if !ok {
-		ctxval.Logger(ctx).Error().Msgf("Type assertion error for job %s, unable to finish reservation: %#v", job.ID, job.Args)
+		err := fmt.Errorf("%w: job %s, reservation: %#v", ErrTypeAssertion, job.ID, job.Args)
+		ctxval.Logger(ctx).Error().Err(err).Msg("Type assertion error for job")
 		return
 	}
 

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -198,7 +198,7 @@ func (b *kafkaBroker) Consume(ctx context.Context, topic string, since time.Time
 			logger.Debug().Msg("Kafka receiver has been cancelled")
 			break
 		} else if err != nil {
-			logger.Warn().Err(err).Msgf("Error when reading message: %s", err.Error())
+			logger.Warn().Err(err).Msg("Error when reading message")
 		} else {
 			logger.Trace().Bytes("payload", msg.Value).Msgf("Received message with key: %s, topic: %s, offset: %d, partition: %d",
 				msg.Key, msg.Topic, msg.Offset, msg.Partition)

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -143,7 +143,7 @@ func Migrate(ctx context.Context, schema string) error {
 			logger.Info().Msgf("Migration callback for %s %s", name, direction)
 			callErr := CallCallback(ctx, sequence)
 			if callErr != nil {
-				logger.Error().Err(callErr).Msgf("Error during execution of callback script before %s, cannot continue: %s", name, callErr.Error())
+				logger.Error().Err(callErr).Str("script", name).Msg("Error during execution of callback script")
 				panic(callErr)
 			}
 		}

--- a/internal/models/pubkey_model.go
+++ b/internal/models/pubkey_model.go
@@ -45,7 +45,7 @@ func (pk *Pubkey) FindAwsFingerprint(ctx context.Context) string {
 	case "ssh-rsa":
 		fp, err := ssh.GenerateAWSFingerprint([]byte(pk.Body))
 		if err != nil {
-			ctxval.Logger(ctx).Warn().Err(err).Msgf("Unable to generate AWS fingerprint for pubkey %s: %s", pk.Name, err.Error())
+			ctxval.Logger(ctx).Warn().Err(err).Msg("Unable to generate AWS fingerprint for pubkey")
 			return ""
 		}
 		return string(fp)

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	httpClients "github.com/RHEnVision/provisioning-backend/internal/clients/http"
@@ -54,7 +55,8 @@ func newResponse(ctx context.Context, status int, userMsg string, err error) *Re
 		strError = err.Error()
 	}
 	if userMsg == "" {
-		userMsg = err.Error()
+		// take only part up to the first colon to avoid unique ids (UUIDs, database IDs etc)
+		userMsg = strings.SplitN(err.Error(), ":", 2)[0]
 	}
 	event.Msg(userMsg)
 

--- a/internal/services/error_renderer.go
+++ b/internal/services/error_renderer.go
@@ -15,7 +15,7 @@ import (
 // be used for fatal errors which happens during rendering pipeline (e.g. JSON errors).
 func writeBasicError(w http.ResponseWriter, r *http.Request, err error) {
 	if logger := ctxval.Logger(r.Context()); logger != nil {
-		logger.Error().Msgf("unable to render error %v", err)
+		logger.Error().Err(err).Msg("Unable to render error")
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusInternalServerError)

--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -125,7 +125,7 @@ func DeletePubkey(w http.ResponseWriter, r *http.Request) {
 				} else if errors.Is(errAuth, httpClients.AuthenticationForSourcesNotFoundErr) {
 					logger.Warn().Msgf("Skipping source %s authorization which is no longer available", res.SourceID)
 				} else {
-					logger.Warn().Err(errAuth).Msgf("Skipping source %s authorization because sources returned an error: %s", res.SourceID, errAuth.Error())
+					logger.Warn().Err(errAuth).Msg("Skipping source authorization because sources returned an error")
 				}
 			} else {
 				logger.Warn().Msgf("Skipping pubkey resource %d with empty handle", res.ID)

--- a/pkg/worker/redis.go
+++ b/pkg/worker/redis.go
@@ -161,7 +161,7 @@ func recoverAndLog(ctx context.Context) {
 		logger := ctxval.Logger(ctx).Error().Stack()
 
 		if err, ok := rec.(error); ok {
-			logger.Err(err).Stack().Msgf("Job queue panic: %s, stacktrace: %s", err.Error(), debug.Stack())
+			logger.Err(err).Stack().Msg("Job queue panic")
 		} else {
 			logger.Msgf("Error during job handling: %v, stacktrace: %s", rec, debug.Stack())
 		}


### PR DESCRIPTION
Heads up: Please do not include error message in log message body, because it leads to unique messages like _cannot assume role operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: 47e5734c-a37e-4be3-aba2-77f4e306a055_ which are incorrectly identified as unique errors by Sentry and creates too many error reports with the same cause.

The code which is causing this is:

    logger.Error().Err(err).Msgf("cannot assume role %s", err)

The correct way is:

    logger.Error().Err(err).Msg("Cannot assume role")

Note the error itself actually goes into logger through Err function, there is no need to copy it again. This is counter intuitive because when wrapping errors, you do exactly the opposite: fmt.Errorf("cannot assume role %w", err)
