### PR TITLE
chore: introduce Sentry replacer

### DIFF
--- a/internal/logging/sentry.go
+++ b/internal/logging/sentry.go
@@ -12,13 +12,18 @@ import (
 // sentryWriter creates a zerolog writer for sentry.
 // Uses github.com/archdx/zerolog-sentry which is very simple wrapper.
 func sentryWriter(dsn string) (io.Writer, func(), error) {
-	wr, err := sentrywriter.New(dsn)
+	sWriter, err := sentrywriter.New(dsn)
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("cannot initialize sentry: %w", err)
 	}
 	sentry.ConfigureScope(func(scope *sentry.Scope) {
 		scope.SetTag("stream", config.BinaryName())
 	})
-	// close function returns error, but it's always nil, so we are ignoring it here
-	return wr, func() { _ = wr.Close() }, nil
+	fWriter := NewSentryReplacer(sWriter)
+
+	closeFunc := func() {
+		_ = fWriter.Close()
+		_ = sWriter.Close()
+	}
+	return fWriter, closeFunc, nil
 }

--- a/internal/logging/sentry_replacer.go
+++ b/internal/logging/sentry_replacer.go
@@ -1,0 +1,85 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var filters = []string{
+	// Example (AWS SDK): RequestID: ca767444-d1f9-11ed-afa1-0242ac120002
+	`[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}`,
+	// Example (AWS SDK): arn:aws:iam::4328974392798432:role/my-role-123
+	`arn:aws:[[:word:]]+::\d+:[[:word:]\*-]+/[[:word:]\*-]+`,
+}
+
+var replacement = []byte{'?'}
+
+type SentryReplacer struct {
+	buf    []byte
+	w      io.Writer
+	re     *regexp.Regexp
+	mu     sync.Mutex
+	closed bool
+}
+
+func NewSentryReplacer(w io.Writer) *SentryReplacer {
+	sr := SentryReplacer{
+		w:  w,
+		re: regexp.MustCompile("(" + strings.Join(filters, "|") + ")"),
+	}
+	return &sr
+}
+
+func (sr *SentryReplacer) Write(p []byte) (n int, err error) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	if sr.closed {
+		return 0, io.EOF
+	}
+
+	// Append p to our own buffer, see if there's anything we need to censor.
+	sr.buf = append(sr.buf, p...)
+
+	// If we've appended at least a line, censor it and write it out.
+	for {
+		if len(sr.buf) == 0 {
+			// Buffer flushed out completely.
+			return len(p), nil
+		}
+
+		idx := bytes.IndexRune(sr.buf, '\n')
+		if idx < 0 {
+			// No line yet, just lie to the caller and tell them we wrote p.
+			return len(p), nil
+		}
+
+		var line []byte
+		line, sr.buf = sr.buf[:idx+1], sr.buf[idx+1:]
+		line = sr.re.ReplaceAll(line, replacement)
+
+		_, err := sr.w.Write(line)
+		if err != nil {
+			// This is not strictly the error related to the incoming `p`, but the best we can do.
+			return 0, fmt.Errorf("cannot filter: %w", err)
+		}
+	}
+}
+
+func (sr *SentryReplacer) Close() error {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	replaced := sr.re.ReplaceAll(sr.buf, replacement)
+	_, err := sr.w.Write(replaced)
+	if err != nil {
+		return fmt.Errorf("cannot close filter: %w", err)
+	}
+
+	sr.closed = true
+	return nil
+}

--- a/internal/logging/sentry_replacer_test.go
+++ b/internal/logging/sentry_replacer_test.go
@@ -1,0 +1,71 @@
+package logging
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewline(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("x\nx\n"))
+	require.Equal(t, "x\nx\n", buf.String())
+}
+
+func TestNoNewline(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("x\nx"))
+	require.Equal(t, "x\n", buf.String())
+}
+
+func TestNoNewlineClose(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("x\nx"))
+	repl.Close()
+	require.Equal(t, "x\nx", buf.String())
+}
+
+func TestBufferFlush(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("a\n"))
+	_, _ = repl.Write([]byte("\n"))
+	require.Equal(t, "a\n\n", buf.String())
+	require.Zero(t, len(repl.buf))
+}
+
+func TestUUID(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("ca767444-d1f9-11ed-afa1-0242ac120002\n"))
+	require.Equal(t, "?\n", buf.String())
+}
+
+func TestUUIDSplit(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("ca767444-d1f9-"))
+	_, _ = repl.Write([]byte("11ed-afa1-"))
+	_, _ = repl.Write([]byte(""))
+	_, _ = repl.Write([]byte("0242ac120002\n"))
+	require.Equal(t, "?\n", buf.String())
+}
+
+func TestARN(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("arn:aws:iam::4328974392798432:role/my-role-123\n"))
+	require.Equal(t, "?\n", buf.String())
+}
+
+func TestARNSplit(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("arn:aws:iam::"))
+	_, _ = repl.Write([]byte("4328974392798432:role/my-role-123\n"))
+	require.Equal(t, "?\n", buf.String())
+}


### PR DESCRIPTION
It looks like AWS SDK does not makes use of error wrapping, we already workaround that in `isAWSOperationError` function. However, errors like `unable to initialize AWS client: cannot assume role operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: 23c69a5e-69bf-439a-a1c5-c2161ce06a8e, api error AccessDenied: User: arn:aws:iam::12333232:user/crc-ephemeral is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::321321213:role/satellite-services-role` makes Sentry to identify these as unique errors.

This patch adds regular expression writer filter that filters out UUIDs and ARNs so errors are no unique by the error message. This will hopefully group up errors in Sentry.