### PR TITLE
chore: add annotation for kube-linter statuser

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -99,6 +99,9 @@ objects:
                 memory: ${MEMORY_REQUESTS}
         - name: statuser
           replicas: 1
+          metadata:
+            annotations:
+              ignore-check.kube-linter.io/minimum-three-replicas: "statuser pod runs in a single instance"
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command:


### PR DESCRIPTION
Another week, another try to silence that pesky linter.

Previous attempts failed but reason was probably something different, our pipeline got stuck so this time let’s just do this simple change alone to see if it works.

https://github.com/RHEnVision/provisioning-backend/pull/464