### PR TITLE
build: fix the Azure env variable names

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -248,13 +248,13 @@ objects:
                     name: provisioning-azure-acc
                     key: client_secret
                     optional: true
-              - name: AZURE_PRINCIPAL_ID
+              - name: AZURE_CLIENT_PRINCIPAL_ID
                 valueFrom:
                   secretKeyRef:
                     name: provisioning-azure-acc
                     key: principal_id
                     optional: true
-              - name: AZURE_PRINCIPAL_NAME
+              - name: AZURE_CLIENT_PRINCIPAL_NAME
                 valueFrom:
                   secretKeyRef:
                     name: provisioning-azure-acc


### PR DESCRIPTION
I've adjusted the names on the last rebase, but forgot to adjust the clowdapp as well.