### PR TITLE
 ci(HMS-103): Add testing-integration.yaml for stage post-deploy integration testing

### DIFF
--- a/deploy/testing-integration.yaml
+++ b/deploy/testing-integration.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: provisioning-stage-e2e-test
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: provisioning-stage-e2e-test-${IMAGE_TAG}-${UID}
+    annotations:
+      "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
+      "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+  spec:
+    appName: provisioning-backend
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        imageTag: hms-integration
+        marker: ''
+        plugins: hms_integration
+        ui: 
+          enabled: true
+          selenium:
+            deploy: true
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"


### PR DESCRIPTION
HMS-103

This new CJI template will run end-to-end tests after the post-deploy tests in testing.yaml have run.

(A new testing deployment will need to be added to app-interface before this new template has any effect.)

**Checklist**

- [x] all commit messages follows the policy above
- [x] the change follows our security guidelines
