### PR TITLE
feat: store Azure instance's IP address

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -196,7 +196,23 @@
           },
           "instances": {
             "items": {
-              "type": "string"
+              "properties": {
+                "detail": {
+                  "properties": {
+                    "public_dns": {
+                      "type": "string"
+                    },
+                    "public_ipv4": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "instance_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
             },
             "type": "array"
           },

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -558,7 +558,17 @@ components:
         instances:
           type: array
           items:
-            type: string
+            type: object
+            properties:
+              detail:
+                type: object
+                properties:
+                  public_dns:
+                    type: string
+                  public_ipv4:
+                    type: string
+              instance_id:
+                type: string
         location:
           type: string
         name:

--- a/internal/clients/instance_description.go
+++ b/internal/clients/instance_description.go
@@ -1,6 +1,8 @@
 package clients
 
-// InstanceInfo defines a model for an instance description
+type AzureInstanceID string
+
+// InstanceDescription defines a model for an instance description
 type InstanceDescription struct {
 	// The id of the instance
 	ID string `json:"id,omitempty" yaml:"id"`

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -6,8 +6,6 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 )
 
-type AzureInstanceID string
-
 // GetSourcesClient returns Sources interface implementation. There are currently
 // two implementations available: HTTP and stub
 var GetSourcesClient func(ctx context.Context) (Sources, error)
@@ -117,7 +115,7 @@ type Azure interface {
 
 	// CreateVMs creates multiple Azure virtual machines
 	// Returns array of instance IDs and error if something went wrong
-	CreateVMs(ctx context.Context, instanceParams AzureInstanceParams, amount int64, vmNamePrefix string) (vmIds []AzureInstanceID, err error)
+	CreateVMs(ctx context.Context, instanceParams AzureInstanceParams, amount int64, vmNamePrefix string) (vmIds []InstanceDescription, err error)
 
 	ListResourceGroups(ctx context.Context) ([]string, error)
 }

--- a/internal/clients/stubs/azure_stub.go
+++ b/internal/clients/stubs/azure_stub.go
@@ -44,8 +44,8 @@ func (stub *AzureClientStub) Status(ctx context.Context) error {
 	return nil
 }
 
-func (stub *AzureClientStub) CreateVMs(ctx context.Context, vmParams clients.AzureInstanceParams, amount int64, vmNamePrefix string) ([]clients.AzureInstanceID, error) {
-	vmIds := make([]clients.AzureInstanceID, amount)
+func (stub *AzureClientStub) CreateVMs(ctx context.Context, vmParams clients.AzureInstanceParams, amount int64, vmNamePrefix string) ([]clients.InstanceDescription, error) {
+	vmIds := make([]clients.InstanceDescription, amount)
 	resumeTokens := make([]string, amount)
 	var i int64
 	var err error
@@ -57,10 +57,12 @@ func (stub *AzureClientStub) CreateVMs(ctx context.Context, vmParams clients.Azu
 		}
 	}
 	for i = 0; i < amount; i++ {
-		vmIds[i], err = stub.WaitForVM(ctx, resumeTokens[i])
+		instanceID, err := stub.WaitForVM(ctx, resumeTokens[i])
 		if err != nil {
 			return vmIds, err
 		}
+		vmIds[i].ID = string(instanceID)
+		vmIds[i].PublicIPv4 = fmt.Sprintf("198.51.100.%d", i+1)
 	}
 
 	return vmIds, nil

--- a/internal/dao/pgx/reservation_pgx.go
+++ b/internal/dao/pgx/reservation_pgx.go
@@ -143,11 +143,12 @@ func (x *reservationDao) createGenericReservation(ctx context.Context, reservati
 }
 
 func (x *reservationDao) CreateInstance(ctx context.Context, instance *models.ReservationInstance) error {
-	query := `INSERT INTO reservation_instances (reservation_id, instance_id) VALUES ($1, $2)`
+	query := `INSERT INTO reservation_instances (reservation_id, instance_id, detail) VALUES ($1, $2, $3)`
 
 	tag, err := db.Pool.Exec(ctx, query,
 		instance.ReservationID,
-		instance.InstanceID)
+		instance.InstanceID,
+		instance.Detail)
 	if err != nil {
 		return fmt.Errorf("pgx error: %w", err)
 	}

--- a/internal/dao/tests/reservation_test.go
+++ b/internal/dao/tests/reservation_test.go
@@ -30,10 +30,13 @@ func newNoopReservation() *models.NoopReservation {
 	}
 }
 
-func newInstancesReservation(reservationId int64) *models.ReservationInstance {
+func newReservationInstance(reservationId int64) *models.ReservationInstance {
 	return &models.ReservationInstance{
 		ReservationID: reservationId,
 		InstanceID:    "1",
+		Detail: models.ReservationInstanceDetail{
+			PublicIPv4: "198.51.100.1",
+		},
 	}
 }
 
@@ -159,12 +162,15 @@ func TestReservationCreateAWSInstance(t *testing.T) {
 		err := reservationDao.CreateAWS(ctx, reservation)
 		require.NoError(t, err)
 
-		err = reservationDao.CreateInstance(ctx, newInstancesReservation(reservation.ID))
+		instance := newReservationInstance(reservation.ID)
+		err = reservationDao.CreateInstance(ctx, instance)
 		require.NoError(t, err)
 
-		reservations, err := reservationDao.ListInstances(ctx, reservation.ID)
+		instancesList, err := reservationDao.ListInstances(ctx, reservation.ID)
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(reservations))
+		assert.Equal(t, 1, len(instancesList))
+		assert.Equal(t, instance.InstanceID, instancesList[0].InstanceID)
+		assert.Equal(t, instance.Detail.PublicIPv4, instancesList[0].Detail.PublicIPv4)
 	})
 }
 

--- a/internal/jobs/launch_instance_azure_test.go
+++ b/internal/jobs/launch_instance_azure_test.go
@@ -108,4 +108,5 @@ func TestDoLaunchInstanceAzure(t *testing.T) {
 	resultInstances, err := rDao.ListInstances(ctx, res.ID)
 	require.NoError(t, err, "failed to fetch created instances")
 	assert.Equal(t, 2, len(resultInstances))
+	assert.NotEmpty(t, resultInstances[0].Detail.PublicIPv4)
 }

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -113,7 +113,7 @@ type AzureReservationResponsePayload struct {
 	PowerOff bool `json:"poweroff"`
 
 	// Instances IDs, only present for finished reservations.
-	Instances []string `json:"instances,omitempty"`
+	Instances []InstanceResponse `json:"instances,omitempty"`
 }
 
 type GCPReservationResponsePayload struct {
@@ -286,9 +286,9 @@ func NewAWSReservationResponse(reservation *models.AWSReservation, instances []*
 }
 
 func NewAzureReservationResponse(reservation *models.AzureReservation, instances []*models.ReservationInstance) render.Renderer {
-	instanceIds := make([]string, len(instances))
+	instanceIds := make([]InstanceResponse, len(instances))
 	for iter, inst := range instances {
-		instanceIds[iter] = inst.InstanceID
+		instanceIds[iter] = InstanceResponse{InstanceID: inst.InstanceID, Detail: inst.Detail}
 	}
 
 	response := AzureReservationResponsePayload{

--- a/scripts/rest_examples/reservation-create-azure.http
+++ b/scripts/rest_examples/reservation-create-azure.http
@@ -5,7 +5,7 @@ X-Rh-Identity: {{identity}}
 
 {
   "name": "azure-linux-us-east",
-  "source_id": "5",
+  "source_id": "{{azure-source-id}}",
   "image_id": "composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7",
   "amount": 2,
   "instance_size": "Standard_B1ls",


### PR DESCRIPTION
Refactor Azure creation.
Extracts the common networking to be done once for all instances. Extracts Networking preparation to separate method, so we can store info about these.

Adjust Instance storing information to keep the IP address.

Refs HMS-1595