### PR TITLE
fix(HMS-1110): use default region for perm check

### DIFF
--- a/internal/payloads/permissions_payload.go
+++ b/internal/payloads/permissions_payload.go
@@ -7,8 +7,8 @@ import (
 )
 
 type PermissionsResponse struct {
-	Valid           bool
-	MissingEntities []string
+	Valid           bool     `json:"valid"`
+	MissingEntities []string `json:"missing_entities,omitempty"`
 }
 
 func (s *PermissionsResponse) Render(_ http.ResponseWriter, _ *http.Request) error {

--- a/internal/services/aws_iam_service.go
+++ b/internal/services/aws_iam_service.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
@@ -15,8 +16,9 @@ func ValidatePermissions(w http.ResponseWriter, r *http.Request) {
 	logger := ctxval.Logger(r.Context())
 	sourceId := chi.URLParam(r, "ID")
 	region := r.URL.Query().Get("region")
+
 	if region == "" {
-		renderError(w, r, payloads.NewMissingRequestParameterError(r.Context(), "region parameter is missing"))
+		region = config.AWS.DefaultRegion
 	}
 
 	// Get Sources client

--- a/scripts/rest_examples/source-1-permission_check.http
+++ b/scripts/rest_examples/source-1-permission_check.http
@@ -1,0 +1,4 @@
+// @no-log
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources/1/validate_permissions?region=eu-central-1 HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}


### PR DESCRIPTION
When region was not provided, the code was missing a `return` statement which led to incorrect output.

This patch fixes this, instead returning an error, we can use the default region which we have in the configuration. It should ber set to the closest region which is often the fastest.

Also the payload was missing JSON tags, Chi renderer likely uses reflection to pick that up but it makes sense to have it defined correctly.