### PR TITLE
chore: add trace id response header

### DIFF
--- a/internal/middleware/trace_id.go
+++ b/internal/middleware/trace_id.go
@@ -25,6 +25,9 @@ func TraceID(next http.Handler) http.Handler {
 			traceId = random.TraceID()
 		}
 
+		// Store in response headers for easier debugging
+		w.Header().Set("X-Trace-Id", traceId.String())
+
 		ctx = ctxval.WithTraceId(ctx, traceId.String())
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}


### PR DESCRIPTION
This adds correlation (trace) id in all response headers. This is useful when debugging success (or looks like success) requests on stage, the header immediately gives something you can search in Kibana.

Although we use trace id from open telemetry, this is not the official header which is [much more complex](https://www.w3.org/TR/trace-context/) and also does not make sense in response headers.

Edit: Initially I used `Correlation-Id` but I think we should stick to what we actually store in logs.