### PR TITLE
fix: Azure image check

### DIFF
--- a/internal/clients/http/image_builder/image_client.go
+++ b/internal/clients/http/image_builder/image_client.go
@@ -62,14 +62,13 @@ func (c *ibClient) Ready(ctx context.Context) error {
 
 func (c *ibClient) GetAWSAmi(ctx context.Context, composeID string) (string, error) {
 	logger := logger(ctx)
-	logger.Trace().Msgf("Getting AMI of image %v", composeID)
+	logger.Trace().Str("compose_id", composeID).Msgf("Getting AMI of compose ID %v", composeID)
 
 	imageStatus, err := c.fetchImageStatus(ctx, composeID)
 	if err != nil {
 		return "", err
 	}
 
-	logger.Trace().Msgf("Verifying AWS type")
 	if imageStatus.Type != UploadTypesAws {
 		return "", fmt.Errorf("%w: expected image type AWS", http.UnknownImageTypeErr)
 	}
@@ -77,6 +76,10 @@ func (c *ibClient) GetAWSAmi(ctx context.Context, composeID string) (string, err
 	if err != nil {
 		return "", fmt.Errorf("%w: not an AWS status", http.UploadStatusErr)
 	}
+
+	logger.Info().Str("compose_id", composeID).Str("ami", uploadStatus.Ami).
+		Msgf("Translated compose ID %s to AMI %s", composeID, uploadStatus.Ami)
+
 	return uploadStatus.Ami, nil
 }
 

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -152,7 +152,7 @@ type AzureReservation struct {
 	// Source ID.
 	SourceID string `db:"source_id" json:"source_id"`
 
-	// The ID of the image from which the instance is created.
+	// The image-builder compose ID of the image or valid Azure Image ID from Azure Marketplace.
 	ImageID string `json:"image_id"`
 
 	// Detail information is stored as JSON in DB

--- a/internal/services/azure_reservation_service_test.go
+++ b/internal/services/azure_reservation_service_test.go
@@ -36,7 +36,7 @@ func TestCreateAzureReservationHandler(t *testing.T) {
 	source, err := Clientstubs.AddSource(ctx, models.ProviderTypeAzure)
 	require.NoError(t, err, "failed to generate Azure source")
 
-	t.Run("successful reservation", func(t *testing.T) {
+	t.Run("successful reservation with compose ID", func(t *testing.T) {
 		var err error
 		values := map[string]interface{}{
 			"source_id":     source.Id,

--- a/scripts/rest_examples/http-client.env.json
+++ b/scripts/rest_examples/http-client.env.json
@@ -9,6 +9,7 @@
     "pubkey_id": "1",
     "region": "us-east-1",
     "launch_template_id": "",
-    "reservation-get-id": "1"
+    "reservation-get-id": "1",
+    "azure-source-id": "2"
   }
 }

--- a/scripts/rest_examples/reservation-create-azure.http
+++ b/scripts/rest_examples/reservation-create-azure.http
@@ -5,9 +5,10 @@ X-Rh-Identity: {{identity}}
 
 {
   "name": "azure-linux-us-east",
+  "location": "eastus_1",
   "source_id": "{{azure-source-id}}",
-  "image_id": "composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7",
-  "amount": 2,
+  "image_id": "RedHat:RHEL:8_7:8.7.2023022801",
+  "amount": 1,
   "instance_size": "Standard_B1ls",
   "pubkey_id": {{pubkey_id}},
   "poweroff": true


### PR DESCRIPTION
Azure image IB ID check had a typo in the if statement, so it was actually never performed. I realized that when I started testing Azure on my dev setup and wanted to spawn a RHEL generic image from the Azure marketplace.

The patch also updates the http testing file with more sane defaults including the RHEL, btw image IDs are here: https://imagedirectory.cloud/browser/Azure (searching is not yet possible).