### PR TITLE
chore: allow non-IB images for GCP

### DIFF
--- a/internal/clients/http/image_builder/image_client.go
+++ b/internal/clients/http/image_builder/image_client.go
@@ -102,14 +102,13 @@ func (c *ibClient) GetAzureImageName(ctx context.Context, composeID string) (str
 
 func (c *ibClient) GetGCPImageName(ctx context.Context, composeID string) (string, error) {
 	logger := logger(ctx)
-	logger.Trace().Msgf("Getting Name of image %v", composeID)
+	logger.Trace().Str("compose_id", composeID).Msgf("Getting Google image id of compose %s", composeID)
 
 	imageStatus, err := c.fetchImageStatus(ctx, composeID)
 	if err != nil {
 		return "", err
 	}
 
-	logger.Trace().Msg("Verifying GCP type")
 	if imageStatus.Type != UploadTypesGcp {
 		return "", fmt.Errorf("%w: expected image type GCP", http.UnknownImageTypeErr)
 	}
@@ -118,7 +117,11 @@ func (c *ibClient) GetGCPImageName(ctx context.Context, composeID string) (strin
 		return "", fmt.Errorf("%w: not a GCP status", http.UploadStatusErr)
 	}
 
-	return fmt.Sprintf("projects/%s/global/images/%s", uploadStatus.ProjectId, uploadStatus.ImageName), nil
+	result := fmt.Sprintf("projects/%s/global/images/%s", uploadStatus.ProjectId, uploadStatus.ImageName)
+	logger.Info().Str("compose_id", composeID).Str("ami", result).
+		Msgf("Translated compose ID %s to AMI %s", composeID, result)
+
+	return result, nil
 }
 
 func (c *ibClient) fetchImageStatus(ctx context.Context, composeID string) (*UploadStatus, error) {

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -120,7 +120,9 @@ type GCPReservation struct {
 	// The ID of the gcp reservation which was created.
 	GCPOperationName string `db:"gcp_operation_name"`
 
-	// The ID of the image from which the instance is created.
+	// The ID of the image from which the instance is created. Can be either UUID
+	// which represents an image-builder compose ID, or Google Image URL which is
+	// passed into the Google API directly.
 	ImageID string `json:"image_id"`
 
 	// Detail information is stored as JSON in DB

--- a/scripts/rest_examples/reservation-create-gcp.http
+++ b/scripts/rest_examples/reservation-create-gcp.http
@@ -4,12 +4,12 @@ Content-Type: application/json
 X-Rh-Identity: {{identity}}
 
 {
-  "name": "gcp-linux-us-east4-a",
-  "zone": "us-east4-a",
+  "name": "gcp-linux-eu-west8-c",
+  "zone": "europe-west8-c",
   "source_id": "3",
-  "image_id": "80967e7f-efef-4eee-85b0-bd4cef4c455d",
+  "image_id": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-9-v20230411",
   "amount": 1,
-  "machine_type": "n1-standard-1",
+  "machine_type": "e2-micro",
   "pubkey_id": {{pubkey_id}},
   "poweroff": true
 }


### PR DESCRIPTION
This allows to launch official images not just UUIDs from image builder. Comes with an example .http file update which defaults to RHEL9 official image: https://imagedirectory.cloud/browser/GCP