### PR TITLE
feat(HMS-1550): add notifications service integration

### DIFF
--- a/cmd/pbackend/api.go
+++ b/cmd/pbackend/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/logging"
 	"github.com/RHEnVision/provisioning-backend/internal/metrics"
 	m "github.com/RHEnVision/provisioning-backend/internal/middleware"
+	"github.com/RHEnVision/provisioning-backend/internal/notifications"
 	"github.com/RHEnVision/provisioning-backend/internal/queue/jq"
 	"github.com/RHEnVision/provisioning-backend/internal/routes"
 	s "github.com/RHEnVision/provisioning-backend/internal/services"
@@ -64,12 +65,13 @@ func api() {
 	// initialize cache
 	cache.Initialize()
 
-	// initialize platform kafka
+	// initialize platform kafka and notifications
 	if config.Kafka.Enabled {
 		err = kafka.InitializeKafkaBroker(ctx)
 		if err != nil {
 			logger.Fatal().Err(err).Msg("Unable to initialize the platform kafka")
 		}
+		notifications.Initialize(ctx)
 	}
 
 	// initialize background goroutines

--- a/cmd/pbackend/statuser.go
+++ b/cmd/pbackend/statuser.go
@@ -14,6 +14,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/identity"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/notifications"
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	"github.com/RHEnVision/provisioning-backend/internal/random"
 
@@ -277,6 +278,9 @@ func statuser() {
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Unable to initialize the platform kafka")
 	}
+
+	// initialize notifications
+	notifications.Initialize(ctx)
 
 	// metrics
 	logger.Info().Msgf("Starting new instance on port %d with prometheus on %d", config.Application.Port, config.Prometheus.Port)

--- a/config/api.env.example
+++ b/config/api.env.example
@@ -116,6 +116,8 @@
 #     	kafka authentication type (mtls, sasl or empty) (default "")
 #   KAFKA_CA_CERT string
 #     	kafka TLS CA certificate path (default "")
+#   APP_NOTIFICATIONS_ENABLED bool
+#     	notifications enabled (default "false")
 #   APP_CACHE_TYPE string
 #     	application cache (none, redis) (default "none")
 #   APP_CACHE_EXPIRATION int64

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -51,6 +51,8 @@ objects:
                 value: ${TELEMETRY_LOGGER_ENABLED}
               - name: CLOWDER_ENABLED
                 value: ${CLOWDER_ENABLED}
+              - name: APP_NOTIFICATIONS_ENABLED
+                value: ${APP_NOTIFICATIONS_ENABLED}
               - name: REST_ENDPOINTS_IMAGE_BUILDER_URL
                 value: "${IMAGEBUILDER_URL}/api/image-builder/v1"
               - name: AWS_KEY
@@ -138,6 +140,8 @@ objects:
                 value: ${TELEMETRY_LOGGER_ENABLED}
               - name: CLOWDER_ENABLED
                 value: ${CLOWDER_ENABLED}
+              - name: APP_NOTIFICATIONS_ENABLED
+                value: ${APP_NOTIFICATIONS_ENABLED}
               - name: REST_ENDPOINTS_IMAGE_BUILDER_URL
                 value: "${IMAGEBUILDER_URL}/api/image-builder/v1"
               - name: AWS_KEY
@@ -246,6 +250,8 @@ objects:
                 value: ${CLOWDER_ENABLED}
               - name: REST_ENDPOINTS_IMAGE_BUILDER_URL
                 value: "${IMAGEBUILDER_URL}/api/image-builder/v1"
+              - name: APP_NOTIFICATIONS_ENABLED
+                value: ${APP_NOTIFICATIONS_ENABLED}  
               - name: AWS_KEY
                 valueFrom:
                   secretKeyRef:
@@ -322,13 +328,48 @@ objects:
           replicas: 3
         - topicName: platform.sources.event-stream
         - topicName: platform.sources.status
+        - topicName: platform.notifications.ingress
       inMemoryDb: true
       dependencies:
         - sources-api
         - sources-superkey-worker
+        - notifications-backend
       optionalDependencies:
         - image-builder
 
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: notifications-ephemeral-data
+    data:
+      ephemeral_data.json: |
+        {
+          "bundles": [
+            {
+              "name": "rhel",
+              "display_name": "Red Hat Enterprise Linux",
+              "applications": [
+                {
+                  "name": "image-builder",
+                  "display_name": "Image Builder",
+                  "event_types": [
+                    {
+                      "name": "launch-success",
+                      "display_name": "Launch Success",
+                      "description": "Triggers an notification when a launch is successful"
+                    },
+                    {
+                      "name": "launch-failed",
+                      "display_name": "Launch Failed",
+                      "description": "Triggers an notification when a launch fails"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+  
   - apiVersion: metrics.console.redhat.com/v1alpha1
     kind: FloorPlan
     metadata:
@@ -452,3 +493,6 @@ parameters:
   - description: Internal queue type (memory/sqs/postgres).
     name: WORKER_QUEUE
     value: "redis"
+  - description: Notification service enabled
+    name: APP_NOTIFICATIONS_ENABLED
+    value: "true"

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -126,6 +126,12 @@ Tip: Alternatively, the application supports connecting to the stage environment
 
 Because Image Builder is more complex for installation, we do not recommend installing it on your local machine right now. Configure connection through HTTP proxy to the stage environment in `config/api.env`. See [configuration example](../config/api.env.example) for an example, you will need to ask someone from the company for real URLs for the service and the proxy.
 
+## Notifications
+
+[Notifications](https://github.com/RedHatInsights/notifications-backend) service handles notifications across services and allows email templates, webhooks triggering and 3rd party apps integration (i.e slack)
+For local development, you can use [provisioning-compose](https://github.com/RHEnVision/provisioning-compose) to roll up notifications setup.
+When you just want to verify a notification kafka's messages, you can use `send-notification.http` to send a message directly to stage env, please notice that a cookie session is required, [click here](https://internal.console.stage.redhat.com/api/turnpike/session/) to generate one. 
+
 ## Writing Go code
 
 Ready to write some Go code? Read [contributing guide](../CONTRIBUTING.md).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,10 @@ var config struct {
 	App struct {
 		Port           int    `env:"PORT" env-default:"8000" env-description:"HTTP port of the API service"`
 		InstancePrefix string `env:"INSTANCE_PREFIX" env-default:"" env-description:"prefix for all VMs names"`
-		Cache          struct {
+		Notifications  struct {
+			Enabled bool `env:"ENABLED" env-default:"false" env-description:"notifications enabled"`
+		} `env-prefix:"NOTIFICATIONS_"`
+		Cache struct {
 			Type       string        `env:"TYPE" env-default:"none" env-description:"application cache (none, redis)"`
 			Expiration time.Duration `env:"EXPIRATION" env-default:"1h" env-description:"expiration for both memory and Redis (time interval syntax)"`
 			Redis      struct {

--- a/internal/jobs/common.go
+++ b/internal/jobs/common.go
@@ -45,6 +45,7 @@ func finishWithSuccess(ctx context.Context, reservationId int64) {
 	// if this was the last step, set the success flag
 	if reservation.Step >= reservation.Steps {
 		logger.Info().Msgf("All jobs executed, marking job as success")
+
 		err = rDao.FinishWithSuccess(ctx, reservationId)
 		if err != nil {
 			logger.Warn().Err(err).Msg("unable to update job status: finish")

--- a/internal/jobs/noop_job.go
+++ b/internal/jobs/noop_job.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/RHEnVision/provisioning-backend/internal/notifications"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
 	"github.com/rs/zerolog"
 )
@@ -29,8 +30,14 @@ func HandleNoop(ctx context.Context, job *worker.Job) {
 
 	logger := zerolog.Ctx(ctx).With().Int64("reservation_id", args.ReservationID).Logger()
 	ctx = logger.WithContext(ctx)
+	nc := notifications.GetNotificationClient(ctx)
 
 	jobErr := DoNoop(ctx, &args)
+	if jobErr != nil {
+		nc.FailedLaunch(ctx, args.ReservationID, jobErr)
+	} else {
+		nc.SuccessfulLaunch(ctx, args.ReservationID)
+	}
 
 	finishJob(ctx, args.ReservationID, jobErr)
 }

--- a/internal/kafka/notification_msg.go
+++ b/internal/kafka/notification_msg.go
@@ -1,0 +1,75 @@
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/identity"
+	"github.com/google/uuid"
+)
+
+const (
+	application                  = "image-builder"
+	bundle                       = "rhel"
+	notificationMessageVersion   = "v2.0.0"
+	NotificationSuccessEventType = "launch-success"
+	NotificationFailureEventType = "launch-failed"
+)
+
+type NotificationEvent struct {
+	Payload json.RawMessage `json:"payload"`
+}
+
+type NotificationError struct {
+	Error string `json:"error"`
+}
+
+type notificationRecipients struct {
+	OnlyAdmins            bool     `json:"only_admins"`
+	IgnoreUserPreferences bool     `json:"ignore_user_preferences"`
+	Users                 []string `json:"users"`
+}
+
+type NotificationMessage struct {
+	Version     string                   `json:"version"`
+	Bundle      string                   `json:"bundle"`
+	Application string                   `json:"application"`
+	EventType   string                   `json:"event_type"`
+	Timestamp   string                   `json:"timestamp"`
+	AccountID   string                   `json:"account_id"`
+	OrgId       string                   `json:"org_id"`
+	Context     interface{}              `json:"context"`
+	Events      []NotificationEvent      `json:"events"`
+	Recipients  []notificationRecipients `json:"recipients"`
+	ID          string                   `json:"id"`
+}
+
+func (m NotificationMessage) GenericMessage(ctx context.Context) (GenericMessage, error) {
+	id := identity.Identity(ctx)
+
+	m.Application = application
+	m.Bundle = bundle
+	m.Version = notificationMessageVersion
+	m.OrgId = id.Identity.OrgID
+	m.AccountID = id.Identity.AccountNumber
+	m.Timestamp = time.Now().Format("2006-01-02T15:04:05.000") // ISO 8601 REQUIRED
+	m.ID = uuid.New().String()
+	m.Recipients = []notificationRecipients{}
+
+	payload, err := json.Marshal(m)
+	if err != nil {
+		return GenericMessage{}, fmt.Errorf("unable to marshal notification message: %w", err)
+	}
+
+	return GenericMessage{
+		Topic: NotificationTopic,
+		Key:   nil,
+		Value: payload,
+		Headers: GenericHeaders(
+			"rh-message-id", m.ID,
+			"x-rh-identity", identity.IdentityHeader(ctx),
+		),
+	}, nil
+}

--- a/internal/kafka/topics.go
+++ b/internal/kafka/topics.go
@@ -10,16 +10,19 @@ import (
 var (
 	availabilityStatusRequestTopicReq = "platform.provisioning.internal.availability-check"
 	sendStatusToSourcesTopicReq       = "platform.sources.status"
+	sendNotificationMessage           = "platform.notifications.ingress"
 )
 
 // topics after clowder mapping
 var (
 	AvailabilityStatusRequestTopic string
 	SourcesStatusTopic             string
+	NotificationTopic              string
 )
 
 // InitializeTopicRequests performs clowder mapping of topics.
 func InitializeTopicRequests(ctx context.Context) {
 	AvailabilityStatusRequestTopic = config.TopicName(ctx, availabilityStatusRequestTopicReq)
 	SourcesStatusTopic = config.TopicName(ctx, sendStatusToSourcesTopicReq)
+	NotificationTopic = config.TopicName(ctx, sendNotificationMessage)
 }

--- a/internal/notifications/interface.go
+++ b/internal/notifications/interface.go
@@ -1,0 +1,12 @@
+package notifications
+
+import (
+	"context"
+)
+
+var GetNotificationClient func(ctx context.Context) NotificationClient = getNoopNotificationClient
+
+type NotificationClient interface {
+	SuccessfulLaunch(ctx context.Context, reservationId int64)
+	FailedLaunch(ctx context.Context, reservationId int64, jobError error)
+}

--- a/internal/notifications/noop.go
+++ b/internal/notifications/noop.go
@@ -1,0 +1,26 @@
+package notifications
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
+
+type noopNotificationClient struct{}
+
+var _ NotificationClient = &noopNotificationClient{}
+
+func getNoopNotificationClient(ctx context.Context) NotificationClient {
+	zerolog.Ctx(ctx).Debug().Msg("Using noop notification client")
+	return &noopNotificationClient{}
+}
+
+func (s *noopNotificationClient) SuccessfulLaunch(ctx context.Context, reservationId int64) {
+	logger := zerolog.Ctx(ctx)
+	logger.Warn().Msg("SuccessfulLaunch not started (Notifications not configured)")
+}
+
+func (s *noopNotificationClient) FailedLaunch(ctx context.Context, reservationId int64, jobError error) {
+	logger := zerolog.Ctx(ctx)
+	logger.Warn().Msg("FailedLaunch not started (Notifications not configured)")
+}

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -1,0 +1,93 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/RHEnVision/provisioning-backend/internal/kafka"
+	"github.com/rs/zerolog"
+)
+
+type client struct{}
+
+func getNotificationClient(ctx context.Context) NotificationClient {
+	zerolog.Ctx(ctx).Debug().Msg("Using kafka notification client")
+	return &client{}
+}
+
+func Initialize(ctx context.Context) {
+	if config.Application.Notifications.Enabled {
+		zerolog.Ctx(ctx).Debug().Msg("Initialized kafka notification client")
+		GetNotificationClient = getNotificationClient
+	} else {
+		zerolog.Ctx(ctx).Debug().Msg("Initialized noop notification client")
+	}
+}
+
+func (x *client) SuccessfulLaunch(ctx context.Context, reservationId int64) {
+	logger := zerolog.Ctx(ctx)
+	logger.Debug().Msg("Triggering a successful launch notification")
+	rDao := dao.GetReservationDao(ctx)
+	reservation, err := rDao.GetById(ctx, reservationId)
+	if err != nil {
+		logger.Error().Err(err).Msg("Unable to find reservation by id")
+		return
+	}
+	instances, err := rDao.ListInstances(ctx, reservationId)
+	if err != nil {
+		logger.Warn().Err(err).Msg("Unable to get instances for reservation")
+	}
+	NotificationInstancesEvents := make([]kafka.NotificationEvent, len(instances))
+	for i, instance := range instances {
+		marshalInstance, er := json.Marshal(instance)
+		if er != nil {
+			logger.Error().Err(err).Msg("Unable to marshal instance")
+			return
+		}
+		NotificationInstancesEvents[i] = kafka.NotificationEvent{Payload: marshalInstance}
+	}
+
+	notificationMsg, err := kafka.NotificationMessage{
+		Context:   reservation,
+		EventType: kafka.NotificationSuccessEventType, Events: NotificationInstancesEvents,
+	}.GenericMessage(ctx)
+	if err != nil {
+		logger.Error().Err(err).Msg("Unable to create notification message")
+		return
+	}
+	logger.Info().Msgf("Sending notification message")
+	err = kafka.Send(ctx, &notificationMsg)
+	if err != nil {
+		logger.Error().Err(err).Msg("Unable to send notification message via kafka")
+	}
+}
+
+func (x *client) FailedLaunch(ctx context.Context, reservationId int64, jobError error) {
+	logger := zerolog.Ctx(ctx)
+	logger.Debug().Msg("Triggering a failed launch notification")
+	rDao := dao.GetReservationDao(ctx)
+	reservation, err := rDao.GetById(ctx, reservationId)
+	if err != nil {
+		logger.Error().Err(err).Msg("Unable to find reservation by id")
+		return
+	}
+	marshalError, err := json.Marshal(kafka.NotificationError{Error: jobError.Error()})
+	if err != nil {
+		logger.Error().Err(err).Msg("Unable to marshal error")
+		return
+	}
+
+	notificationEvent := []kafka.NotificationEvent{{Payload: marshalError}}
+	notificationMsg, err := kafka.NotificationMessage{Context: reservation, EventType: kafka.NotificationFailureEventType, Events: notificationEvent}.GenericMessage(ctx)
+	if err != nil {
+		logger.Error().Err(err).Msg("Unable to create notification failure message")
+		return
+	}
+	logger.Info().Msg("Sending notification message")
+	err = kafka.Send(ctx, &notificationMsg)
+	if err != nil {
+		logger.Error().Err(err).Msg("Unable to send notification message via kafka")
+	}
+}

--- a/scripts/kafka.start.sh
+++ b/scripts/kafka.start.sh
@@ -10,6 +10,7 @@ echo "Creating topics..."
 # Start as background shell jobs, they attempt to reconnect until it succeeds
 $BASEDIR/kafka/bin/kafka-topics.sh --create --topic platform.provisioning.internal.availability-check --bootstrap-server $KAFKA_HOST &
 $BASEDIR/kafka/bin/kafka-topics.sh --create --topic platform.sources.status --bootstrap-server $KAFKA_HOST &
+$BASEDIR/kafka/bin/kafka-topics.sh --create --topic platform.notifications.ingress --bootstrap-server $KAFKA_HOST &
 
 echo "Starting Kafka..."
 $BASEDIR/kafka/bin/kafka-server-start.sh $BASEDIR/kafka/config/kraft/server.properties

--- a/scripts/rest_examples/send-notification.http
+++ b/scripts/rest_examples/send-notification.http
@@ -1,0 +1,17 @@
+POST https://internal.cloud.stage.redhat.com/api/notifications-gw/notifications HTTP/1.1
+cookie: session={{sessionCookie}}
+content-type: application/json
+
+{
+    "version":"v2.0.0",
+    "bundle":"rhel",
+    "application":"image-builder",
+    "event_type":"launch-failed",
+    "timestamp":"2023-04-18T21:07:34.935",
+    "account_id":"{{accountId}}",
+    "org_id":"{{orgId}}",
+    "context":{"some":"context"},
+    "events":[{"payload":{"error":"an error"}}],
+    "recipients":[],
+    "id":"{{uuid}}"
+}


### PR DESCRIPTION
This PR adds notification support, and sends a  message via kafka once launch process is finished.

We currently support two event types under Image builder application:
- Launch completed
- Launch failed

**EDIT:
In order to test locally, follow the README.notifications** 

In order to test it under stage env:
1. Go to Notifications -> Integreation 
2.  create a new webhook integration, you can use https://webhook.site/ tool that will provide a unique webhook URL
3. Go to Notifications -> RHEL
4. Create a new behaiver group, assign one of the above event types (i.e `Launch failed`) and the integration you have created.

Please note that only webhooks work ATM,  email templates will be added later.



