### PR TITLE
feat(HMS-1246): Use permission checks in statuser

### DIFF
--- a/internal/kafka/source_result.go
+++ b/internal/kafka/source_result.go
@@ -10,7 +10,7 @@ type StatusType string
 
 const (
 	StatusUnavailable StatusType = "unavailable"
-	StatusAvaliable   StatusType = "available"
+	StatusAvailable   StatusType = "available"
 )
 
 type SourceResult struct {
@@ -24,6 +24,8 @@ type SourceResult struct {
 	Err error `json:"error"`
 
 	Identity identity.Principal `json:"-"`
+
+	MissingPermissions []string `json:"-"`
 }
 
 func (sr SourceResult) GenericMessage(ctx context.Context) (GenericMessage, error) {

--- a/internal/services/aws_iam_service.go
+++ b/internal/services/aws_iam_service.go
@@ -50,13 +50,13 @@ func ValidatePermissions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logger.Info().Msgf("Listing permissions.")
-	permissions, err := ec2Client.CheckPermission(r.Context(), authentication)
-	if err != nil {
+	missingPermissions, err := ec2Client.CheckPermission(r.Context(), authentication)
+	if err != nil && missingPermissions == nil {
 		renderError(w, r, payloads.NewAWSError(r.Context(), "unable to check aws permissions", err))
 		return
 	}
 
-	if err := render.Render(w, r, payloads.NewPermissionsResponse(permissions)); err != nil {
+	if err := render.Render(w, r, payloads.NewPermissionsResponse(missingPermissions)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render missing permissions", err))
 		return
 	}


### PR DESCRIPTION
This adds permission logging in case of missing permissions. Caching should also be done for this. I feel like the source result should not be flagged as Unavailable or with Error in case of missing permission, as this is neither of these. Therefore, I thought adding the MissingPermission parameter might be suitable, but let me know, what you think.
For testing the missing permission in statuser, you could change iam_client hardcoded struct.