### PR TITLE
fix(HMS-1675): simplify SAC success metric

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,21 +7,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var TotalSentAvailabilityCheckReqs = prometheus.NewCounterVec(
+var SourceAvailabilityCheck = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Name:        "provisioning_source_availability_check_request_total",
-		Help:        "availability check requests count partitioned by type (aws/gcp/azure), source status, component and error",
+		Name:        "provisioning_source_availability_check",
+		Help:        "availability check requests count partitioned by type (aws/gcp/azure) and result (ok/err)",
 		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName, "component": "statuser"},
 	},
-	[]string{"type", "status", "error"},
-)
-
-var TotalInvalidAvailabilityCheckReqs = prometheus.NewCounter(
-	prometheus.CounterOpts{
-		Name:        "provisioning_invalid_source_availability_check_request_total",
-		Help:        "invalid availability check requests count partitioned by component",
-		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName, "component": "statuser"},
-	},
+	[]string{"type", "result"},
 )
 
 var CacheHits = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -93,16 +85,10 @@ func ObserveBackgroundJobDuration(jobType string, observedFunc func()) {
 	observedFunc()
 }
 
-func IncTotalSentAvailabilityCheckReqs(provider string, statusType string, err error) {
-	errString := "false"
-	if err != nil {
-		errString = "true"
-	}
-	TotalSentAvailabilityCheckReqs.WithLabelValues(provider, string(statusType), errString).Inc()
-}
-
-func IncTotalInvalidAvailabilityCheckReqs() {
-	TotalInvalidAvailabilityCheckReqs.Inc()
+// IncSourceAvailabilityCheck needs provider type and result ("ok" or "err"). Do not set actual
+// go errors!
+func IncSourceAvailabilityCheck(provider string, result string) {
+	SourceAvailabilityCheck.WithLabelValues(provider, result).Inc()
 }
 
 func IncCacheHit(resource string, result string) {

--- a/internal/metrics/registration.go
+++ b/internal/metrics/registration.go
@@ -3,7 +3,7 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 func RegisterStatuserMetrics() {
-	prometheus.MustRegister(TotalSentAvailabilityCheckReqs, AvailabilityCheckReqsDuration, TotalInvalidAvailabilityCheckReqs, CacheHits)
+	prometheus.MustRegister(SourceAvailabilityCheck, AvailabilityCheckReqsDuration, CacheHits)
 }
 
 func RegisterApiMetrics() {


### PR DESCRIPTION
The dashboard success rate sometimes display 101% and this is caused by inflight messages I think. This patch simplifies this, there is no need to make this unnecessary complex, a single counter with proper labels can give us the number.

Let’s merge the change first, then I want to wait and tomorrow I will push a grafana dashboard change, something like (untested):

SAC Success Rate:

    sum(rate(provisioning_source_availability_check{status=="ok"}[$__range]))/sum(rate(provisioning_source_availability_check[$__range]))

I am thinking introducing also number of "in flight" requests (currently enqueued and not yet processed). Basically a "kafka lag" (pseudo query I don’t know yet how to achieve this):

    provisioning_http_request_total{path="/api/provisioning/v1/availability_status/sources/"}[$__range] - provisioning_source_availability_check{status=="ok"}

And total SAC checks in the selected range:

    sum(increase(provisioning_source_availability_check[$__range]))