### PR TITLE
chore: update http dashboard panels

### DIFF
--- a/deploy/Provisioning-1674548289785.json
+++ b/deploy/Provisioning-1674548289785.json
@@ -661,7 +661,7 @@
             "axisLabel": "milliseconds",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
+            "drawStyle": "points",
             "fillOpacity": 36,
             "gradientMode": "scheme",
             "hideFrom": {
@@ -673,8 +673,8 @@
             "lineStyle": {
               "fill": "solid"
             },
-            "lineWidth": 3,
-            "pointSize": 5,
+            "lineWidth": 0,
+            "pointSize": 7,
             "scaleDistribution": {
               "type": "linear"
             },
@@ -746,7 +746,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "red",
+                  "fixedColor": "orange",
                   "mode": "fixed"
                 }
               }
@@ -755,8 +755,8 @@
         ]
       },
       "gridPos": {
-        "h": 9,
-        "w": 19,
+        "h": 13,
+        "w": 24,
         "x": 0,
         "y": 26
       },
@@ -826,7 +826,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 39
       },
       "id": 24,
       "panels": [],
@@ -847,11 +847,13 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Our SLO target",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
+          "decimals": 0,
           "mappings": [
             {
               "options": {
@@ -864,6 +866,7 @@
             }
           ],
           "max": 1,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -883,16 +886,16 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 5,
+        "w": 7,
         "x": 0,
-        "y": 36
+        "y": 40
       },
       "id": 32,
       "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
@@ -926,6 +929,92 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Our SLO target",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 7,
+        "y": 40
+      },
+      "id": 62,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.8",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"200\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
+          "hide": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Success Latency 200ms Target",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -946,7 +1035,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "blue",
                 "value": null
               }
             ]
@@ -957,9 +1046,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 5,
-        "x": 5,
-        "y": 36
+        "w": 10,
+        "x": 14,
+        "y": 40
       },
       "id": 41,
       "links": [],
@@ -1020,7 +1109,7 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -1046,13 +1135,13 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "ops"
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "success/sec"
+              "options": "success"
             },
             "properties": [
               {
@@ -1067,10 +1156,10 @@
         ]
       },
       "gridPos": {
-        "h": 7,
-        "w": 14,
+        "h": 8,
+        "w": 24,
         "x": 0,
-        "y": 43
+        "y": 47
       },
       "id": 34,
       "links": [],
@@ -1096,7 +1185,7 @@
           "editorMode": "code",
           "exemplar": true,
           "expr": "(sum(rate(provisioning_http_request_total{code!~\"4.*\"}[$interval])) OR on() vector(0)) - (sum(rate(provisioning_http_request_total{code=~\"5.*\"}[$interval])) OR on() vector(0)) ",
-          "legendFormat": "success/sec",
+          "legendFormat": "success",
           "range": true,
           "refId": "A"
         },
@@ -1109,105 +1198,12 @@
           "exemplar": true,
           "expr": "(sum(rate(provisioning_http_request_total{code=~\"5.*\"}[$interval])) OR on() vector(0))",
           "hide": false,
-          "legendFormat": "errors/sec",
+          "legendFormat": "error",
           "range": true,
           "refId": "B"
         }
       ],
       "title": "HTTP  Throughput Rate",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 11,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 14,
-        "x": 0,
-        "y": 50
-      },
-      "id": 43,
-      "links": [],
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.0.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"200\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_count[$__range]))",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "HTTP  Request Latency",
       "type": "timeseries"
     },
     {
@@ -1220,7 +1216,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 55
       },
       "id": 26,
       "panels": [],
@@ -1241,11 +1237,13 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Percentage of source availability checks processed and delivered back to sources.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
+          "decimals": 0,
           "mappings": [
             {
               "options": {
@@ -1279,14 +1277,14 @@
         "h": 7,
         "w": 5,
         "x": 0,
-        "y": 58
+        "y": 56
       },
       "id": 33,
       "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
@@ -1309,7 +1307,7 @@
           "refId": "A"
         }
       ],
-      "title": "Source Availability Success Rate",
+      "title": "Source Availability Delivery Rate",
       "type": "stat"
     },
     {
@@ -1337,7 +1335,7 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -1363,13 +1361,28 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "opm"
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "success/sec"
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "success"
             },
             "properties": [
               {
@@ -1384,7 +1397,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "success/hour"
+              "options": "total"
             },
             "properties": [
               {
@@ -1400,9 +1413,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 14,
+        "w": 19,
         "x": 5,
-        "y": 58
+        "y": 56
       },
       "id": 42,
       "interval": "1h",
@@ -1429,7 +1442,7 @@
           "editorMode": "code",
           "exemplar": true,
           "expr": "(sum(rate(provisioning_source_availability_check_request_total{error=\"false\"}[$__interval])) OR on() vector(0))",
-          "legendFormat": "success/sec",
+          "legendFormat": "success",
           "range": true,
           "refId": "A"
         },
@@ -1442,9 +1455,22 @@
           "exemplar": true,
           "expr": "(sum(rate(provisioning_source_availability_check_request_total{error=\"true\"}[$__interval])) OR on() vector(0))",
           "hide": false,
-          "legendFormat": "errors/sec",
+          "legendFormat": "error",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "(sum(rate(provisioning_source_availability_check_request_total[$__interval])) OR on() vector(0))",
+          "hide": false,
+          "legendFormat": "total",
+          "range": true,
+          "refId": "C"
         }
       ],
       "title": "Source Availability Throughput Rate",
@@ -1455,6 +1481,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "The latency (p99, p90, p50) for source checks.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1463,35 +1490,39 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "milliseconds",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 11,
-            "gradientMode": "none",
+            "drawStyle": "points",
+            "fillOpacity": 36,
+            "gradientMode": "scheme",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 0,
+            "pointSize": 7,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "always",
             "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "off"
+              "mode": "line"
             }
           },
           "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1501,17 +1532,63 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "ms"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 7,
-        "w": 14,
-        "x": 1,
-        "y": 65
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 63
       },
-      "id": 44,
+      "id": 63,
       "links": [],
       "options": {
         "legend": {
@@ -1534,13 +1611,37 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(provisioning_source_availability_check_request_duration_ms_bucket{le=\"5000\"}[$__range])) / sum(rate(provisioning_source_availability_check_request_duration_ms_count[$__range]))",
-          "legendFormat": "__auto",
+          "expr": "histogram_quantile(0.99, sum(rate(provisioning_source_availability_check_request_duration_ms_bucket[$__interval])) by (le))",
+          "legendFormat": "p99",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(provisioning_source_availability_check_request_duration_ms_bucket[$__interval]))by (le))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum(rate(provisioning_source_availability_check_request_duration_ms_bucket[$__interval]))by (le))",
+          "hide": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Source Availability Request Latency",
+      "title": "Source Availability Check Latency",
       "type": "timeseries"
     }
   ],
@@ -1574,8 +1675,8 @@
         "auto_min": "10s",
         "current": {
           "selected": false,
-          "text": "1d",
-          "value": "1d"
+          "text": "12h",
+          "value": "12h"
         },
         "hide": 0,
         "name": "interval",
@@ -1601,12 +1702,12 @@
             "value": "6h"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "12h",
             "value": "12h"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "1d",
             "value": "1d"
           },

--- a/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
@@ -672,7 +672,7 @@ data:
                       "axisLabel" : "milliseconds",
                       "axisPlacement" : "auto",
                       "barAlignment" : 0,
-                      "drawStyle" : "line",
+                      "drawStyle" : "points",
                       "fillOpacity" : 36,
                       "gradientMode" : "scheme",
                       "hideFrom" : {
@@ -684,8 +684,8 @@ data:
                       "lineStyle" : {
                          "fill" : "solid"
                       },
-                      "lineWidth" : 3,
-                      "pointSize" : 5,
+                      "lineWidth" : 0,
+                      "pointSize" : 7,
                       "scaleDistribution" : {
                          "type" : "linear"
                       },
@@ -757,7 +757,7 @@ data:
                          {
                             "id" : "color",
                             "value" : {
-                               "fixedColor" : "red",
+                               "fixedColor" : "orange",
                                "mode" : "fixed"
                             }
                          }
@@ -766,8 +766,8 @@ data:
                 ]
              },
              "gridPos" : {
-                "h" : 9,
-                "w" : 19,
+                "h" : 13,
+                "w" : 24,
                 "x" : 0,
                 "y" : 26
              },
@@ -837,7 +837,7 @@ data:
                 "h" : 1,
                 "w" : 24,
                 "x" : 0,
-                "y" : 35
+                "y" : 39
              },
              "id" : 24,
              "panels" : [],
@@ -858,11 +858,13 @@ data:
                 "type" : "prometheus",
                 "uid" : "${datasource}"
              },
+             "description" : "Our SLO target",
              "fieldConfig" : {
                 "defaults" : {
                    "color" : {
                       "mode" : "thresholds"
                    },
+                   "decimals" : 0,
                    "mappings" : [
                       {
                          "options" : {
@@ -875,6 +877,7 @@ data:
                       }
                    ],
                    "max" : 1,
+                   "min" : 0,
                    "thresholds" : {
                       "mode" : "absolute",
                       "steps" : [
@@ -894,16 +897,16 @@ data:
              },
              "gridPos" : {
                 "h" : 7,
-                "w" : 5,
+                "w" : 7,
                 "x" : 0,
-                "y" : 36
+                "y" : 40
              },
              "id" : 32,
              "links" : [],
              "maxDataPoints" : 100,
              "options" : {
                 "colorMode" : "value",
-                "graphMode" : "none",
+                "graphMode" : "area",
                 "justifyMode" : "auto",
                 "orientation" : "horizontal",
                 "reduceOptions" : {
@@ -937,6 +940,92 @@ data:
                 "type" : "prometheus",
                 "uid" : "${datasource}"
              },
+             "description" : "Our SLO target",
+             "fieldConfig" : {
+                "defaults" : {
+                   "color" : {
+                      "mode" : "thresholds"
+                   },
+                   "decimals" : 0,
+                   "mappings" : [
+                      {
+                         "options" : {
+                            "match" : "null",
+                            "result" : {
+                               "text" : "N/A"
+                            }
+                         },
+                         "type" : "special"
+                      }
+                   ],
+                   "max" : 1,
+                   "min" : 0,
+                   "thresholds" : {
+                      "mode" : "percentage",
+                      "steps" : [
+                         {
+                            "color" : "red",
+                            "value" : null
+                         },
+                         {
+                            "color" : "#EAB839",
+                            "value" : 90
+                         },
+                         {
+                            "color" : "green",
+                            "value" : 95
+                         }
+                      ]
+                   },
+                   "unit" : "percentunit"
+                },
+                "overrides" : []
+             },
+             "gridPos" : {
+                "h" : 7,
+                "w" : 7,
+                "x" : 7,
+                "y" : 40
+             },
+             "id" : 62,
+             "links" : [],
+             "maxDataPoints" : 100,
+             "options" : {
+                "colorMode" : "value",
+                "graphMode" : "area",
+                "justifyMode" : "auto",
+                "orientation" : "horizontal",
+                "reduceOptions" : {
+                   "calcs" : [
+                      "lastNotNull"
+                   ],
+                   "fields" : "",
+                   "values" : false
+                },
+                "textMode" : "auto"
+             },
+             "pluginVersion" : "9.3.8",
+             "targets" : [
+                {
+                   "datasource" : {
+                      "type" : "prometheus",
+                      "uid" : "${datasource}"
+                   },
+                   "editorMode" : "code",
+                   "expr" : "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"200\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
+                   "hide" : false,
+                   "range" : true,
+                   "refId" : "A"
+                }
+             ],
+             "title" : "HTTP Success Latency 200ms Target",
+             "type" : "stat"
+          },
+          {
+             "datasource" : {
+                "type" : "prometheus",
+                "uid" : "${datasource}"
+             },
              "fieldConfig" : {
                 "defaults" : {
                    "color" : {
@@ -957,7 +1046,7 @@ data:
                       "mode" : "absolute",
                       "steps" : [
                          {
-                            "color" : "green",
+                            "color" : "blue",
                             "value" : null
                          }
                       ]
@@ -968,9 +1057,9 @@ data:
              },
              "gridPos" : {
                 "h" : 7,
-                "w" : 5,
-                "x" : 5,
-                "y" : 36
+                "w" : 10,
+                "x" : 14,
+                "y" : 40
              },
              "id" : 41,
              "links" : [],
@@ -1031,7 +1120,7 @@ data:
                          "viz" : false
                       },
                       "lineInterpolation" : "linear",
-                      "lineWidth" : 1,
+                      "lineWidth" : 2,
                       "pointSize" : 5,
                       "scaleDistribution" : {
                          "type" : "linear"
@@ -1057,13 +1146,13 @@ data:
                          }
                       ]
                    },
-                   "unit" : "none"
+                   "unit" : "ops"
                 },
                 "overrides" : [
                    {
                       "matcher" : {
                          "id" : "byName",
-                         "options" : "success/sec"
+                         "options" : "success"
                       },
                       "properties" : [
                          {
@@ -1078,10 +1167,10 @@ data:
                 ]
              },
              "gridPos" : {
-                "h" : 7,
-                "w" : 14,
+                "h" : 8,
+                "w" : 24,
                 "x" : 0,
-                "y" : 43
+                "y" : 47
              },
              "id" : 34,
              "links" : [],
@@ -1107,7 +1196,7 @@ data:
                    "editorMode" : "code",
                    "exemplar" : true,
                    "expr" : "(sum(rate(provisioning_http_request_total{code!~\"4.*\"}[$interval])) OR on() vector(0)) - (sum(rate(provisioning_http_request_total{code=~\"5.*\"}[$interval])) OR on() vector(0)) ",
-                   "legendFormat" : "success/sec",
+                   "legendFormat" : "success",
                    "range" : true,
                    "refId" : "A"
                 },
@@ -1120,105 +1209,12 @@ data:
                    "exemplar" : true,
                    "expr" : "(sum(rate(provisioning_http_request_total{code=~\"5.*\"}[$interval])) OR on() vector(0))",
                    "hide" : false,
-                   "legendFormat" : "errors/sec",
+                   "legendFormat" : "error",
                    "range" : true,
                    "refId" : "B"
                 }
              ],
              "title" : "HTTP  Throughput Rate",
-             "type" : "timeseries"
-          },
-          {
-             "datasource" : {
-                "type" : "prometheus",
-                "uid" : "${datasource}"
-             },
-             "fieldConfig" : {
-                "defaults" : {
-                   "color" : {
-                      "mode" : "thresholds"
-                   },
-                   "custom" : {
-                      "axisCenteredZero" : false,
-                      "axisColorMode" : "text",
-                      "axisLabel" : "",
-                      "axisPlacement" : "auto",
-                      "barAlignment" : 0,
-                      "drawStyle" : "line",
-                      "fillOpacity" : 11,
-                      "gradientMode" : "none",
-                      "hideFrom" : {
-                         "legend" : false,
-                         "tooltip" : false,
-                         "viz" : false
-                      },
-                      "lineInterpolation" : "linear",
-                      "lineWidth" : 1,
-                      "pointSize" : 5,
-                      "scaleDistribution" : {
-                         "type" : "linear"
-                      },
-                      "showPoints" : "auto",
-                      "spanNulls" : false,
-                      "stacking" : {
-                         "group" : "A",
-                         "mode" : "none"
-                      },
-                      "thresholdsStyle" : {
-                         "mode" : "off"
-                      }
-                   },
-                   "links" : [],
-                   "mappings" : [],
-                   "thresholds" : {
-                      "mode" : "absolute",
-                      "steps" : [
-                         {
-                            "color" : "green",
-                            "value" : null
-                         }
-                      ]
-                   },
-                   "unit" : "none"
-                },
-                "overrides" : []
-             },
-             "gridPos" : {
-                "h" : 7,
-                "w" : 14,
-                "x" : 0,
-                "y" : 50
-             },
-             "id" : 43,
-             "links" : [],
-             "options" : {
-                "legend" : {
-                   "calcs" : [],
-                   "displayMode" : "list",
-                   "placement" : "bottom",
-                   "showLegend" : true
-                },
-                "tooltip" : {
-                   "mode" : "single",
-                   "sort" : "none"
-                }
-             },
-             "pluginVersion" : "9.0.3",
-             "targets" : [
-                {
-                   "datasource" : {
-                      "type" : "prometheus",
-                      "uid" : "${datasource}"
-                   },
-                   "editorMode" : "code",
-                   "exemplar" : true,
-                   "expr" : "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"200\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_count[$__range]))",
-                   "legendFormat" : "__auto",
-                   "range" : true,
-                   "refId" : "A"
-                }
-             ],
-             "title" : "HTTP  Request Latency",
              "type" : "timeseries"
           },
           {
@@ -1231,7 +1227,7 @@ data:
                 "h" : 1,
                 "w" : 24,
                 "x" : 0,
-                "y" : 57
+                "y" : 55
              },
              "id" : 26,
              "panels" : [],
@@ -1252,11 +1248,13 @@ data:
                 "type" : "prometheus",
                 "uid" : "${datasource}"
              },
+             "description" : "Percentage of source availability checks processed and delivered back to sources.",
              "fieldConfig" : {
                 "defaults" : {
                    "color" : {
                       "mode" : "thresholds"
                    },
+                   "decimals" : 0,
                    "mappings" : [
                       {
                          "options" : {
@@ -1290,14 +1288,14 @@ data:
                 "h" : 7,
                 "w" : 5,
                 "x" : 0,
-                "y" : 58
+                "y" : 56
              },
              "id" : 33,
              "links" : [],
              "maxDataPoints" : 100,
              "options" : {
                 "colorMode" : "value",
-                "graphMode" : "none",
+                "graphMode" : "area",
                 "justifyMode" : "auto",
                 "orientation" : "horizontal",
                 "reduceOptions" : {
@@ -1320,7 +1318,7 @@ data:
                    "refId" : "A"
                 }
              ],
-             "title" : "Source Availability Success Rate",
+             "title" : "Source Availability Delivery Rate",
              "type" : "stat"
           },
           {
@@ -1348,7 +1346,7 @@ data:
                          "viz" : false
                       },
                       "lineInterpolation" : "linear",
-                      "lineWidth" : 1,
+                      "lineWidth" : 2,
                       "pointSize" : 5,
                       "scaleDistribution" : {
                          "type" : "linear"
@@ -1374,13 +1372,28 @@ data:
                          }
                       ]
                    },
-                   "unit" : "none"
+                   "unit" : "opm"
                 },
                 "overrides" : [
                    {
                       "matcher" : {
                          "id" : "byName",
-                         "options" : "success/sec"
+                         "options" : "error"
+                      },
+                      "properties" : [
+                         {
+                            "id" : "color",
+                            "value" : {
+                               "fixedColor" : "red",
+                               "mode" : "fixed"
+                            }
+                         }
+                      ]
+                   },
+                   {
+                      "matcher" : {
+                         "id" : "byName",
+                         "options" : "success"
                       },
                       "properties" : [
                          {
@@ -1395,7 +1408,7 @@ data:
                    {
                       "matcher" : {
                          "id" : "byName",
-                         "options" : "success/hour"
+                         "options" : "total"
                       },
                       "properties" : [
                          {
@@ -1411,9 +1424,9 @@ data:
              },
              "gridPos" : {
                 "h" : 7,
-                "w" : 14,
+                "w" : 19,
                 "x" : 5,
-                "y" : 58
+                "y" : 56
              },
              "id" : 42,
              "interval" : "1h",
@@ -1440,7 +1453,7 @@ data:
                    "editorMode" : "code",
                    "exemplar" : true,
                    "expr" : "(sum(rate(provisioning_source_availability_check_request_total{error=\"false\"}[$__interval])) OR on() vector(0))",
-                   "legendFormat" : "success/sec",
+                   "legendFormat" : "success",
                    "range" : true,
                    "refId" : "A"
                 },
@@ -1453,9 +1466,22 @@ data:
                    "exemplar" : true,
                    "expr" : "(sum(rate(provisioning_source_availability_check_request_total{error=\"true\"}[$__interval])) OR on() vector(0))",
                    "hide" : false,
-                   "legendFormat" : "errors/sec",
+                   "legendFormat" : "error",
                    "range" : true,
                    "refId" : "B"
+                },
+                {
+                   "datasource" : {
+                      "type" : "prometheus",
+                      "uid" : "${datasource}"
+                   },
+                   "editorMode" : "code",
+                   "exemplar" : true,
+                   "expr" : "(sum(rate(provisioning_source_availability_check_request_total[$__interval])) OR on() vector(0))",
+                   "hide" : false,
+                   "legendFormat" : "total",
+                   "range" : true,
+                   "refId" : "C"
                 }
              ],
              "title" : "Source Availability Throughput Rate",
@@ -1466,6 +1492,7 @@ data:
                 "type" : "prometheus",
                 "uid" : "${datasource}"
              },
+             "description" : "The latency (p99, p90, p50) for source checks.",
              "fieldConfig" : {
                 "defaults" : {
                    "color" : {
@@ -1474,35 +1501,39 @@ data:
                    "custom" : {
                       "axisCenteredZero" : false,
                       "axisColorMode" : "text",
-                      "axisLabel" : "",
+                      "axisLabel" : "milliseconds",
                       "axisPlacement" : "auto",
                       "barAlignment" : 0,
-                      "drawStyle" : "line",
-                      "fillOpacity" : 11,
-                      "gradientMode" : "none",
+                      "drawStyle" : "points",
+                      "fillOpacity" : 36,
+                      "gradientMode" : "scheme",
                       "hideFrom" : {
                          "legend" : false,
                          "tooltip" : false,
                          "viz" : false
                       },
                       "lineInterpolation" : "linear",
-                      "lineWidth" : 1,
-                      "pointSize" : 5,
+                      "lineStyle" : {
+                         "fill" : "solid"
+                      },
+                      "lineWidth" : 0,
+                      "pointSize" : 7,
                       "scaleDistribution" : {
                          "type" : "linear"
                       },
-                      "showPoints" : "auto",
+                      "showPoints" : "always",
                       "spanNulls" : false,
                       "stacking" : {
                          "group" : "A",
                          "mode" : "none"
                       },
                       "thresholdsStyle" : {
-                         "mode" : "off"
+                         "mode" : "line"
                       }
                    },
                    "links" : [],
                    "mappings" : [],
+                   "min" : 0,
                    "thresholds" : {
                       "mode" : "absolute",
                       "steps" : [
@@ -1512,17 +1543,63 @@ data:
                          }
                       ]
                    },
-                   "unit" : "none"
+                   "unit" : "ms"
                 },
-                "overrides" : []
+                "overrides" : [
+                   {
+                      "matcher" : {
+                         "id" : "byName",
+                         "options" : "p99"
+                      },
+                      "properties" : [
+                         {
+                            "id" : "color",
+                            "value" : {
+                               "fixedColor" : "blue",
+                               "mode" : "fixed"
+                            }
+                         }
+                      ]
+                   },
+                   {
+                      "matcher" : {
+                         "id" : "byName",
+                         "options" : "p95"
+                      },
+                      "properties" : [
+                         {
+                            "id" : "color",
+                            "value" : {
+                               "fixedColor" : "yellow",
+                               "mode" : "fixed"
+                            }
+                         }
+                      ]
+                   },
+                   {
+                      "matcher" : {
+                         "id" : "byName",
+                         "options" : "p50"
+                      },
+                      "properties" : [
+                         {
+                            "id" : "color",
+                            "value" : {
+                               "fixedColor" : "orange",
+                               "mode" : "fixed"
+                            }
+                         }
+                      ]
+                   }
+                ]
              },
              "gridPos" : {
-                "h" : 7,
-                "w" : 14,
-                "x" : 1,
-                "y" : 65
+                "h" : 9,
+                "w" : 24,
+                "x" : 0,
+                "y" : 63
              },
-             "id" : 44,
+             "id" : 63,
              "links" : [],
              "options" : {
                 "legend" : {
@@ -1545,13 +1622,37 @@ data:
                    },
                    "editorMode" : "code",
                    "exemplar" : true,
-                   "expr" : "sum(rate(provisioning_source_availability_check_request_duration_ms_bucket{le=\"5000\"}[$__range])) / sum(rate(provisioning_source_availability_check_request_duration_ms_count[$__range]))",
-                   "legendFormat" : "__auto",
+                   "expr" : "histogram_quantile(0.99, sum(rate(provisioning_source_availability_check_request_duration_ms_bucket[$__interval])) by (le))",
+                   "legendFormat" : "p99",
                    "range" : true,
                    "refId" : "A"
+                },
+                {
+                   "datasource" : {
+                      "type" : "prometheus",
+                      "uid" : "${datasource}"
+                   },
+                   "editorMode" : "code",
+                   "expr" : "histogram_quantile(0.95, sum(rate(provisioning_source_availability_check_request_duration_ms_bucket[$__interval]))by (le))",
+                   "hide" : false,
+                   "legendFormat" : "p95",
+                   "range" : true,
+                   "refId" : "B"
+                },
+                {
+                   "datasource" : {
+                      "type" : "prometheus",
+                      "uid" : "${datasource}"
+                   },
+                   "editorMode" : "code",
+                   "expr" : "histogram_quantile(0.5, sum(rate(provisioning_source_availability_check_request_duration_ms_bucket[$__interval]))by (le))",
+                   "hide" : false,
+                   "legendFormat" : "p50",
+                   "range" : true,
+                   "refId" : "C"
                 }
              ],
-             "title" : "Source Availability Request Latency",
+             "title" : "Source Availability Check Latency",
              "type" : "timeseries"
           }
        ],
@@ -1585,8 +1686,8 @@ data:
                 "auto_min" : "10s",
                 "current" : {
                    "selected" : false,
-                   "text" : "1d",
-                   "value" : "1d"
+                   "text" : "12h",
+                   "value" : "12h"
                 },
                 "hide" : 0,
                 "name" : "interval",
@@ -1612,12 +1713,12 @@ data:
                       "value" : "6h"
                    },
                    {
-                      "selected" : false,
+                      "selected" : true,
                       "text" : "12h",
                       "value" : "12h"
                    },
                    {
-                      "selected" : true,
+                      "selected" : false,
                       "text" : "1d",
                       "value" : "1d"
                    },


### PR DESCRIPTION
I took a closer look on our SLO target (200ms successful requests) and because it way way bellow 95% I investigated, looks like the query we have there is not correct. Also took the opportunity to slightly enhance all other HTTP-related panels:

* Removed HTTP Success Latency graph and created a new one named HTTP Success Latency 200ms Target which is now the "big number" with background line graph for history.
* The expression `sum(rate(provisioning_http_request_duration_ms_bucket{code=~"2.*", le="200"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_count[$__range]))` does divide by all requests, but we need to divide only by successful counts. This was giving us quite low number under our current SLO (95%). The correct expression is `sum(rate(provisioning_http_request_duration_ms_bucket{code=~"2.*", le="200"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~"2.*", le="+Inf"}[$__range]))` which divides 200ms successful requests by all successful requests. Either infinity bucket or `_count` can be used, this is equal.
* Updated HTTP requests color to blue (it is informative only).
* Removed decimals from HTTP Success Rate, added background line graph for history.
* Renamed legends in HTTP Throughtput Rate, updated y-axis to ops/m and made line 2px width for better visibility of the red line.
* Changed the Request Latency to point graph (it was already sort of point with lines).
* Renamed Source Avail Success Rate to Source Avail Delivery rate, that represents the number in a more correct way.
* Rewritten Source Availability Check Latency to be dot graph similarly to the HTTP Request Latency.

Before the patch:

![image](https://user-images.githubusercontent.com/49752/235897763-88c48b3c-f93f-41ee-a38a-76d89d2c52a2.png)

After the patch:

![image](https://user-images.githubusercontent.com/49752/235897682-d8d41525-7886-4190-8e99-a9f5b65956fb.png)
