### PR TITLE
chore: improve glitchtip error handling

### DIFF
--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -15,11 +15,17 @@ import (
 	"github.com/go-chi/render"
 )
 
+var ErrMissingNameOrBody = errors.New("name or body missing")
+
 func CreatePubkey(w http.ResponseWriter, r *http.Request) {
 	payload := &payloads.PubkeyRequest{}
 	if err := render.Bind(r, payload); err != nil {
 		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "create pubkey", err))
 		return
+	}
+
+	if payload.Name == "" || payload.Body == "" {
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), ErrMissingNameOrBody.Error(), ErrMissingNameOrBody))
 	}
 
 	pkDao := dao.GetPubkeyDao(r.Context())

--- a/pkg/worker/redis.go
+++ b/pkg/worker/redis.go
@@ -158,7 +158,7 @@ func (w *RedisWorker) dequeueLoop(ctx context.Context, i, total int) {
 
 func recoverAndLog(ctx context.Context) {
 	if rec := recover(); rec != nil {
-		logger := ctxval.Logger(ctx).Error().Stack()
+		logger := ctxval.Logger(ctx).Error()
 
 		if err, ok := rec.(error); ok {
 			logger.Err(err).Stack().Msg("Job queue panic")


### PR DESCRIPTION
I did a full review of all our Sentry errors, I noticed one that is ugly when pubkey is not valid (name/body), this fixes it returning a better error.

Also when there is a panic in worker, I saw nil exception this hopefully fixes it.