### PR TITLE
refactor: remove compression

### DIFF
--- a/config/api.env.example
+++ b/config/api.env.example
@@ -6,8 +6,6 @@
 # 
 #   APP_PORT int
 #     	HTTP port of the API service (default "8000")
-#   APP_COMPRESSION bool
-#     	HTTP payload compression (default "false")
 #   APP_INSTANCE_PREFIX string
 #     	prefix for all VMs names (default "")
 #   DATABASE_HOST string

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -219,8 +219,6 @@ objects:
                 value: ${CLOWDER_ENABLED}
               - name: REST_ENDPOINTS_IMAGE_BUILDER_URL
                 value: "${IMAGEBUILDER_URL}/api/image-builder/v1"
-              - name: APP_COMPRESSION
-                value: ${APP_COMPRESSION}
               - name: AWS_KEY
                 valueFrom:
                   secretKeyRef:
@@ -359,9 +357,6 @@ parameters:
     value: "true"
   - description: OpenTelemetry export into the logger
     name: TELEMETRY_LOGGER_ENABLED
-    value: "true"
-  - description: Enable compression of the API responses
-    name: APP_COMPRESSION
     value: "true"
   - description: Determines Clowder deployment
     name: CLOWDER_ENABLED

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,6 @@ type proxy struct {
 var config struct {
 	App struct {
 		Port           int    `env:"PORT" env-default:"8000" env-description:"HTTP port of the API service"`
-		Compression    bool   `env:"COMPRESSION" env-default:"false" env-description:"HTTP payload compression"`
 		InstancePrefix string `env:"INSTANCE_PREFIX" env-default:"" env-description:"prefix for all VMs names"`
 		Cache          struct {
 			Type       string        `env:"TYPE" env-default:"none" env-description:"application cache (none, memory, redis)"`

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -5,12 +5,10 @@ import (
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/api"
-	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/middleware"
 	"github.com/RHEnVision/provisioning-backend/internal/preload"
 	s "github.com/RHEnVision/provisioning-backend/internal/services"
 	"github.com/go-chi/chi/v5"
-	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/render"
 	redoc "github.com/go-openapi/runtime/middleware"
 	"github.com/rs/zerolog/log"
@@ -27,21 +25,6 @@ func redocMiddleware(handler http.Handler) http.Handler {
 func logETags() {
 	for _, etag := range middleware.AllETags() {
 		log.Logger.Trace().Msgf("Calculated '%s' etag '%s' in %dms", etag.Name, etag.Value, etag.HashTime.Milliseconds())
-	}
-}
-
-// Setup optional compressor, chi uses sync.Pool so this is cheap.
-// This setup only uses the default gzip which is widely supported
-// across the globe, including HTTP proxies which do have problems with
-// modern algorithms like brotli or zstd to this day.
-// This middleware must be inserted after Content-Type header is set.
-func useCompression(r chi.Router) {
-	if config.Application.Compression {
-		compressor := chiMiddleware.NewCompressor(5,
-			"application/json",
-			"application/x-yaml",
-			"text/plain")
-		r.Use(compressor.Handler)
 	}
 }
 
@@ -69,11 +52,8 @@ func MountAPI(r *chi.Mux) {
 	r.Get("/azure_offering_template", s.AzureOfferingTemplate)
 
 	r.Group(func(r chi.Router) {
-		// Set Content-Type to JSON for chi renderer. Warning: Non-chi routes
-		// MUST set Content-Type header on their own!
 		r.Use(render.SetContentType(render.ContentTypeJSON))
 
-		useCompression(r)
 		r.Use(middleware.EnforceIdentity)
 		r.Use(middleware.AccountMiddleware)
 


### PR DESCRIPTION
We have figured out that compression for browsers are done by 3scale, there is no point having this feature for in-cluster queries. Removing.