### PR TITLE
feat: Fetch Azure image resource group from IB

### DIFF
--- a/internal/clients/http/azure/create_vm.go
+++ b/internal/clients/http/azure/create_vm.go
@@ -47,9 +47,7 @@ func (c *client) BeginCreateVM(ctx context.Context, networkInterface *armnetwork
 		return "", err
 	}
 
-	imageID := c.getImageId(ctx, vmParams.ResourceGroupName, vmParams.ImageName)
-
-	vmAzureParams := c.prepareVirtualMachineParameters(vmParams.Location, armcompute.VirtualMachineSizeTypes(vmParams.InstanceType), networkInterface, imageID, vmParams.Pubkey.Body, vmParams.UserData, vmName)
+	vmAzureParams := c.prepareVirtualMachineParameters(vmParams.Location, armcompute.VirtualMachineSizeTypes(vmParams.InstanceType), networkInterface, vmParams.ImageID, vmParams.Pubkey.Body, vmParams.UserData, vmName)
 
 	poller, err := vmClient.BeginCreateOrUpdate(ctx, vmParams.ResourceGroupName, vmName, *vmAzureParams, nil)
 	if err != nil {
@@ -191,10 +189,6 @@ func (c *client) EnsureResourceGroup(ctx context.Context, name string, location 
 	}
 
 	return resp.ResourceGroup.ID, nil
-}
-
-func (c *client) getImageId(ctx context.Context, resourceGroupName string, imageName string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s", c.subscriptionID, resourceGroupName, imageName)
 }
 
 func (c *client) createVirtualNetwork(ctx context.Context, location string, resourceGroupName string, name string) (*armnetwork.VirtualNetwork, error) {

--- a/internal/clients/http/image_builder_errors.go
+++ b/internal/clients/http/image_builder_errors.go
@@ -8,9 +8,10 @@ import (
 )
 
 var (
-	CloneNotFoundErr    = fmt.Errorf("image clone not found: %w", clients.NotFoundErr)
-	ComposeNotFoundErr  = fmt.Errorf("image compose not found: %w", clients.NotFoundErr)
-	ImageStatusErr      = errors.New("build of requested image has not finished yet")
-	UnknownImageTypeErr = errors.New("unknown image type")
-	UploadStatusErr     = fmt.Errorf("could not fetch upload status: %w", clients.NotFoundErr)
+	CloneNotFoundErr        = fmt.Errorf("image clone not found: %w", clients.NotFoundErr)
+	ComposeNotFoundErr      = fmt.Errorf("image compose not found: %w", clients.NotFoundErr)
+	ImageStatusErr          = errors.New("build of requested image has not finished yet")
+	UnknownImageTypeErr     = errors.New("unknown image type")
+	UploadStatusErr         = fmt.Errorf("could not fetch upload status: %w", clients.NotFoundErr)
+	ImageRequestNotFoundErr = errors.New("image upload request not found in the Compose Request")
 )

--- a/internal/clients/instance_params.go
+++ b/internal/clients/instance_params.go
@@ -53,8 +53,9 @@ type AzureInstanceParams struct {
 	// ResourceGroupName to launch the instance in
 	ResourceGroupName string
 
-	// ImageName - the imageID will be inferred as /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}
-	ImageName string
+	// ImageID - the Image ID in format of full Azure ID as
+	// for example /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}
+	ImageID string
 
 	// Pubkey to use for the instance access
 	Pubkey *models.Pubkey

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -37,8 +37,10 @@ type ImageBuilder interface {
 	// GetAWSAmi returns related AWS image AMI identifier
 	GetAWSAmi(ctx context.Context, composeID string) (string, error)
 
-	// GetAzureImageName returns name of the Azure image, without the subscription and resource group scope
-	GetAzureImageName(ctx context.Context, composeID string) (string, error)
+	// GetAzureImageID returns partial image id, that is missing the subscription prefix
+	// Full name is /subscriptions/<subscription-id>/resourceGroups/<Group>/providers/Microsoft.Compute/images/<ImageName>
+	// GetAzureImageID returns /resourceGroups/<Group>/providers/Microsoft.Compute/images/<ImageName>
+	GetAzureImageID(ctx context.Context, composeID string) (string, error)
 
 	// GetGCPImageName returns GCP image name
 	GetGCPImageName(ctx context.Context, composeID string) (string, error)

--- a/internal/clients/stubs/image_builder_stub.go
+++ b/internal/clients/stubs/image_builder_stub.go
@@ -37,8 +37,8 @@ func (mock *ImageBuilderClientStub) GetAWSAmi(ctx context.Context, composeID str
 	return "ami-0c830793775595d4b-test", nil
 }
 
-func (mock *ImageBuilderClientStub) GetAzureImageName(ctx context.Context, composeID string) (string, error) {
-	return "composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7", nil
+func (mock *ImageBuilderClientStub) GetAzureImageID(ctx context.Context, composeID string) (string, error) {
+	return "/resourceGroups/redhat-deployed/providers/Microsoft.Compute/images/composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7", nil
 }
 
 func (mock *ImageBuilderClientStub) GetGCPImageName(ctx context.Context, composeID string) (string, error) {

--- a/internal/jobs/launch_instance_azure.go
+++ b/internal/jobs/launch_instance_azure.go
@@ -142,7 +142,7 @@ func DoLaunchInstanceAzure(ctx context.Context, args *LaunchInstanceAzureTaskArg
 	vmParams := clients.AzureInstanceParams{
 		Location:          location,
 		ResourceGroupName: resourceGroupName,
-		ImageName:         args.AzureImageID,
+		ImageID:           args.AzureImageID,
 		Pubkey:            pubkey,
 		InstanceType:      clients.InstanceTypeName(reservation.Detail.InstanceSize),
 		UserData:          userData,

--- a/internal/services/azure_reservation_service_test.go
+++ b/internal/services/azure_reservation_service_test.go
@@ -65,7 +65,7 @@ func TestCreateAzureReservationHandler(t *testing.T) {
 		assert.Equal(t, 1, len(stub.EnqueuedJobs(ctx)), "Expected exactly one job to be planned")
 		assert.IsType(t, jobs.LaunchInstanceAzureTaskArgs{}, stub.EnqueuedJobs(ctx)[0].Args, "Unexpected type of arguments for the planned job")
 		jobArgs := stub.EnqueuedJobs(ctx)[0].Args.(jobs.LaunchInstanceAzureTaskArgs)
-		assert.Equal(t, "composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7", jobArgs.AzureImageID, "Expected translated image to real name - one from IB client stub")
+		assert.Equal(t, "/subscriptions/4b9d213f-712f-4d17-a483-8a10bbe9df3a/resourceGroups/redhat-deployed/providers/Microsoft.Compute/images/composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7", jobArgs.AzureImageID, "Expected translated image to real name - one from IB client stub")
 	})
 
 	t.Run("failed reservation with invalid location", func(t *testing.T) {


### PR DESCRIPTION
Support for fetching resource group the image resides in from Image Builder.
This allows for launching images that are build in a different resource group then the Launch one.

Changes the expected identifier in the Azure client.
Now we expect the full ID instead of a name, thus the resolution of name to ID is done in the service now.

Fixes HMS-1691

This was enabled by https://github.com/osbuild/image-builder/pull/707
We need to wait for IB to release for us to release this.