### PR TITLE
refactor: use Gob encoding for cache

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
     - gci # too strict
     - contextcheck # too restrictive
     - gomoddirectives # TODO remove after scany/tern v2 are released
-    - musttag # cache uses JSON for models (Account)
 linters-settings:
   govet:
     check-shadowing: true


### PR DESCRIPTION
The account cache currently use JSON encoding, but the newer version of the linter revealed that we removed JSON tags from models. Cache works, however, the linter error is still correct and I would like to keep this lint warning on.

Instead of adding JSON tags to models, I would like to change behavior of the cache, instead of JSON let’s use Gob (native Go binary encoding) which is not only faster, but it also does not require any tags. Redis is not very transparent and we unlikely need to investigate contents of cache (logging can do the same job if we need to).

The patch changes to Gob encoding, only account is currently stored in cache as a struct. Upgrade path: automatic. When previous cache entry is loaded, Gob decoding fails and NotFound error is returned thus the cache entry is overwritten (or expires).

See https://github.com/RHEnVision/provisioning-backend/pull/523 for the linter change.

This needs to be either merged first and `musttag` linter exception removed from the other patch or rebased and remove the `musttag` in this PR.