### PR TITLE
chore: use tabs for mk files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 
-[{Makefile,go.mod,go.sum,*.go,.gitmodules}]
+[{Makefile,*.mk,go.mod,go.sum,*.go,.gitmodules}]
 indent_style = tab
 indent_size = 4
 


### PR DESCRIPTION
JetBrains Fleet does spaces by default. This should fix it.