### PR TITLE
chore: update dashboard SLO latency to 500ms target

### DIFF
--- a/deploy/Provisioning-1674548289785.json
+++ b/deploy/Provisioning-1674548289785.json
@@ -1001,13 +1001,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"200\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
+          "expr": "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"500\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
           "hide": false,
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "HTTP Success Latency 200ms Target",
+      "title": "HTTP Success Latency 500ms Target",
       "type": "stat"
     },
     {
@@ -1675,8 +1675,8 @@
         "auto_min": "10s",
         "current": {
           "selected": false,
-          "text": "12h",
-          "value": "12h"
+          "text": "1h",
+          "value": "1h"
         },
         "hide": 0,
         "name": "interval",
@@ -1692,7 +1692,7 @@
             "value": "30m"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "1h",
             "value": "1h"
           },
@@ -1702,7 +1702,7 @@
             "value": "6h"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "12h",
             "value": "12h"
           },
@@ -1775,7 +1775,7 @@
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {
@@ -1806,6 +1806,6 @@
   "timezone": "",
   "title": "Provisioning",
   "uid": "211",
-  "version": 7,
+  "version": 1,
   "weekStart": ""
 }

--- a/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
@@ -1012,13 +1012,13 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"200\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
+                   "expr" : "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"500\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
                    "hide" : false,
                    "range" : true,
                    "refId" : "A"
                 }
              ],
-             "title" : "HTTP Success Latency 200ms Target",
+             "title" : "HTTP Success Latency 500ms Target",
              "type" : "stat"
           },
           {
@@ -1686,8 +1686,8 @@ data:
                 "auto_min" : "10s",
                 "current" : {
                    "selected" : false,
-                   "text" : "12h",
-                   "value" : "12h"
+                   "text" : "1h",
+                   "value" : "1h"
                 },
                 "hide" : 0,
                 "name" : "interval",
@@ -1703,7 +1703,7 @@ data:
                       "value" : "30m"
                    },
                    {
-                      "selected" : false,
+                      "selected" : true,
                       "text" : "1h",
                       "value" : "1h"
                    },
@@ -1713,7 +1713,7 @@ data:
                       "value" : "6h"
                    },
                    {
-                      "selected" : true,
+                      "selected" : false,
                       "text" : "12h",
                       "value" : "12h"
                    },
@@ -1786,7 +1786,7 @@ data:
           ]
        },
        "time" : {
-          "from" : "now-7d",
+          "from" : "now-24h",
           "to" : "now"
        },
        "timepicker" : {
@@ -1817,6 +1817,6 @@ data:
        "timezone" : "",
        "title" : "Provisioning",
        "uid" : "211",
-       "version" : 7,
+       "version" : 1,
        "weekStart" : ""
     }


### PR DESCRIPTION
SSIA

Also changed the defaults to 1h window last 24 hours which is a bit more relevant I think. Also faster.

The version dropped from 7 to 1 not sure why, I exported this via Grafana, I guess it is just informative number since it is managed by app-interface rather than Grafana's built-in versioning: https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/manage-version-history/