### PR TITLE
build: drop GHA OpenAPI validation

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -103,9 +103,5 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_SVR }}
-      - uses: openapi-generators/openapitools-generator-action@v1
-        with:
-          generator: python
-          openapi-file: api/openapi.gen.json
       - run: |
           make check-system-go validate GO=go


### PR DESCRIPTION
We use a GHA OpenAPI generation but then we call `make validate` to generate the same files. The use of the GHA is not needed actually.

In fact, it started failing our tests with a weird error recently:

```
Error:  Check the spelling of the generator's name and try again.
202
Error: Process completed with exit code 1.
```

This patch removes that, the `make` utility does perform generation and then `git diff` to check if there is any sort of change. This is all we need.