### PR TITLE
build: install go tools and cache

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_SVR }}
       - name: golangci-lint
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_SVR }}
       - run: |
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_SVR }}
       - name: "Run tests"
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_SVR }}
       - run: |

--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -1,3 +1,4 @@
+---
 name: checks
 
 on:
@@ -103,5 +104,15 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_SVR }}
-      - run: |
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: bin
+          key: bin-go${{ env.GO_SVR }}-tools-${{ hashFiles('mk/tools.mk') }}
+      - name: Install Go Tools
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: make install-tools GO=go
+      - name: Generate and validate
+        run: |
+          touch config/_config.yaml
           make check-system-go validate GO=go


### PR DESCRIPTION
I noticed that we do run `make validate` which is supposed to generate clients and then validate them. All targets are phony, except `generate-clients` which by default does not do anything since there is no change in the code base.

This patch adds the required `touch` call which causes the clients to be actually regenerated, then `git` is used to compare for changes. Since the OpenAPI generator version if pinned, it should not result in any difference. The tools must be installed from now on, it was working without them because actually nothing was happening.

In addition to that, the `bin` directory is cached so `go install-tools` will be only executed when necessary speeding up the validation.

In a separate commit, I upgraded GHA `setup-go@v4` to version 4 which automatically cache compiled code for quicker compilation. The key for the cache [is Go version and go.sum](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs) so this works out of box without any configuration.