### PR TITLE
fix(HMS-1782): cap job concurrency at 100

### DIFF
--- a/config/api.env.example
+++ b/config/api.env.example
@@ -92,8 +92,8 @@
 #     	job worker implementation (memory, redis, sqs, postgres) (default "memory")
 #   WORKER_POLL_INTERVAL int64
 #     	polling interval (network timeout) (default "5s")
-#   WORKER_MAX_THREADS int
-#     	maximum allowed amount of polling goroutines (CPUs + 1) (default "64")
+#   WORKER_CONCURRENCY int
+#     	amount of worker polling goroutines (effective concurrency) (default "33")
 #   WORKER_TIMEOUT int64
 #     	total timeout for a single job to complete (duration) (default "30m")
 #   UNLEASH_ENABLED bool

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,7 +116,7 @@ var config struct {
 	Worker struct {
 		Queue        string        `env:"QUEUE" env-default:"memory" env-description:"job worker implementation (memory, redis, sqs, postgres)"`
 		PollInterval time.Duration `env:"POLL_INTERVAL" env-default:"5s" env-description:"polling interval (network timeout)"`
-		MaxThreads   int           `env:"MAX_THREADS" env-default:"64" env-description:"maximum allowed amount of polling goroutines (CPUs + 1)"`
+		Concurrency  int           `env:"CONCURRENCY" env-default:"33" env-description:"amount of worker polling goroutines (effective concurrency)"`
 		Timeout      time.Duration `env:"TIMEOUT" env-default:"30m" env-description:"total timeout for a single job to complete (duration)"`
 	} `env-prefix:"WORKER_"`
 	Unleash struct {

--- a/internal/queue/jq/worker.go
+++ b/internal/queue/jq/worker.go
@@ -45,7 +45,7 @@ func Initialize(_ context.Context, logger *zerolog.Logger) error {
 		wk, err := worker.NewRedisWorker(config.RedisHostAndPort(),
 			config.Application.Cache.Redis.User, config.Application.Cache.Redis.Password,
 			config.Application.Cache.Redis.DB, "provisioning-job-queue",
-			config.Worker.PollInterval, config.Worker.MaxThreads)
+			config.Worker.PollInterval, config.Worker.Concurrency)
 		if err != nil {
 			return fmt.Errorf("cannot initialize redis worker queue: %w", err)
 		}


### PR DESCRIPTION
Jobqueue concurrency was uncapped until now, this was a bug. I meant to cap it at 64 per pod, however, the setting was only for pollers which spawn new goroutine on each job received.

This patch removes processing in goroutines per job, every poller executes jobs in the same goroutine which leads to effective concurrency that can be capped by `WORKER_CONCURRENCY` variable (previously maxPollers which was confusing I think).

The default value is set to 33, the idea is that with 3 pods we are at concurrency of 100 (99 actually) which is easy to do math on. For example, AWS bucket for instance launch is 1000 so at "maximum speed" the service can withstand 100 seconds without throttling. We can update the number as we get access to CloudWatch AWS API logs and learn how we can scale the service.