### PR TITLE
fix(HMS-1616): OpenAPI cleanup and examples

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -1,6 +1,50 @@
 {
   "components": {
     "examples": {
+      "v1.AvailabilityStatusRequest": {
+        "value": {
+          "sourceid": "463243"
+        }
+      },
+      "v1.InstanceTypesAWSResponse": {
+        "value": [
+          {
+            "arch": "x86_64",
+            "azure": null,
+            "cores": 16,
+            "memory_mib": 65536,
+            "name": "c5a.8xlarge",
+            "storage_gb": 0,
+            "supported": true,
+            "vcpus": 32
+          }
+        ]
+      },
+      "v1.InstanceTypesAzureResponse": {
+        "value": [
+          {
+            "arch": "x86_64",
+            "azure": {
+              "gen_v1": true,
+              "gen_v2": true
+            },
+            "cores": 64,
+            "memory_mib": 2000000,
+            "name": "Standard_M128s",
+            "storage_gb": 4096,
+            "supported": true,
+            "vcpus": 128
+          }
+        ]
+      },
+      "v1.LaunchTemplateListResponse": {
+        "value": [
+          {
+            "id": "lt-9843797432897342",
+            "name": "XXL large backend API"
+          }
+        ]
+      },
       "v1.PubkeyListResponseExample": {
         "value": [
           {
@@ -29,25 +73,43 @@
           "type": "ssh-ed25519"
         }
       },
-      "v1.ResponseErrorGenericExample": {
+      "v1.SourceListResponseExample": {
+        "value": [
+          {
+            "id": "654321",
+            "name": "My AWS account",
+            "source_type_id": "",
+            "uid": ""
+          },
+          {
+            "id": "543621",
+            "name": "My other AWS account",
+            "source_type_id": "",
+            "uid": ""
+          }
+        ]
+      },
+      "v1.SourceUploadInfoAWSResponse": {
         "value": {
-          "build_time": "2023-04-14_17:15:02",
-          "edgeid": "",
-          "environment": "",
-          "error": "error: this can be pretty long string",
-          "trace_id": "b57f7b78c",
-          "version": "df8a489"
+          "aws": {
+            "account_id": "78462784632"
+          },
+          "azure": null,
+          "provider": "aws"
         }
       },
-      "v1.ResponseErrorUserFriendlyExample": {
+      "v1.SourceUploadInfoAzureResponse": {
         "value": {
-          "build_time": "2023-04-14_17:15:02",
-          "edgeid": "",
-          "environment": "",
-          "error": "cannot run instances: cannot run instances: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: af6e10a0-75c9-47e1-a83c-872494250322, VcpuLimitExceeded: You have requested more vCPU capacity than your current vCPU limit of 128 allows for the instance bucket that the specified instance type belongs to. Please visit http://aws.amazon.com/contact-us/ec2-request to request an adjustment to this limit.",
-          "msg": "vCPU limit reached, contact AWS support",
-          "trace_id": "b57f7b78c",
-          "version": "df8a489"
+          "aws": null,
+          "azure": {
+            "resourcegroups": [
+              "MyGroup 1",
+              "MyGroup 42"
+            ],
+            "subscriptionid": "617807e1-e4e0-4855-983c-1e3ce1e49674",
+            "tenantid": "617807e1-e4e0-481c-983c-be3ce1e49253"
+          },
+          "provider": "azure"
         }
       }
     },
@@ -564,6 +626,11 @@
         "requestBody": {
           "content": {
             "application/json": {
+              "examples": {
+                "example": {
+                  "$ref": "#/components/examples/v1.AvailabilityStatusRequest"
+                }
+              },
               "schema": {
                 "$ref": "#/components/schemas/v1.AvailabilityStatusRequest"
               }
@@ -579,7 +646,10 @@
           "500": {
             "$ref": "#/components/responses/InternalError"
           }
-        }
+        },
+        "tags": [
+          "AvailabilityStatus"
+        ]
       }
     },
     "/instance_types/{PROVIDER}": {
@@ -618,6 +688,14 @@
           "200": {
             "content": {
               "application/json": {
+                "examples": {
+                  "aws": {
+                    "$ref": "#/components/examples/v1.InstanceTypesAWSResponse"
+                  },
+                  "azure": {
+                    "$ref": "#/components/examples/v1.InstanceTypesAzureResponse"
+                  }
+                },
                 "schema": {
                   "items": {
                     "$ref": "#/components/schemas/v1.InstanceTypeResponse"
@@ -634,7 +712,10 @@
           "500": {
             "$ref": "#/components/responses/InternalError"
           }
-        }
+        },
+        "tags": [
+          "InstanceType"
+        ]
       }
     },
     "/pubkeys": {
@@ -1005,7 +1086,7 @@
     },
     "/sources": {
       "get": {
-        "description": "Return list of provisioning sources",
+        "description": "Cloud credentials are kept in the sources application. This endpoint lists available sources for the particular account per individual type (AWS, Azure, ...). All the fields in the response are optional and can be omitted if Sources application also omits them.\n",
         "operationId": "getSourceList",
         "parameters": [
           {
@@ -1025,6 +1106,11 @@
           "200": {
             "content": {
               "application/json": {
+                "examples": {
+                  "example": {
+                    "$ref": "#/components/examples/v1.SourceListResponseExample"
+                  }
+                },
                 "schema": {
                   "items": {
                     "$ref": "#/components/schemas/v1.SourceResponse"
@@ -1038,13 +1124,17 @@
           "500": {
             "$ref": "#/components/responses/InternalError"
           }
-        }
+        },
+        "tags": [
+          "Source"
+        ]
       }
     },
     "/sources/{ID}/account_identity": {
       "get": {
         "deprecated": true,
         "description": "This endpoint is deprecated. Please use upload_info instead",
+        "operationId": "getSourceAccountIdentity",
         "parameters": [
           {
             "description": "Source ID from Sources Database",
@@ -1074,12 +1164,16 @@
           "500": {
             "$ref": "#/components/responses/InternalError"
           }
-        }
+        },
+        "tags": [
+          "Source"
+        ]
       }
     },
     "/sources/{ID}/instance_types": {
       "get": {
-        "description": "Return a list of instance types (DEPRECATED: use /instance_types)",
+        "deprecated": true,
+        "description": "Deprecated endpoint, use /instance_types instead.",
         "operationId": "getInstanceTypeList",
         "parameters": [
           {
@@ -1122,12 +1216,15 @@
           "500": {
             "$ref": "#/components/responses/InternalError"
           }
-        }
+        },
+        "tags": [
+          "Source"
+        ]
       }
     },
     "/sources/{ID}/launch_templates": {
       "get": {
-        "description": "Return a list of launch templates",
+        "description": "Return a list of launch templates.\nA launch template is a configuration set with a name that is available through hyperscaler API. When creating reservations, launch template can be provided in order to set additional configuration for instances.\nCurrently only AWS Launch Templates are supported.\n",
         "operationId": "getLaunchTemplatesList",
         "parameters": [
           {
@@ -1154,6 +1251,11 @@
           "200": {
             "content": {
               "application/json": {
+                "examples": {
+                  "example": {
+                    "$ref": "#/components/examples/v1.LaunchTemplateListResponse"
+                  }
+                },
                 "schema": {
                   "items": {
                     "$ref": "#/components/schemas/v1.LaunchTemplatesResponse"
@@ -1170,12 +1272,16 @@
           "500": {
             "$ref": "#/components/responses/InternalError"
           }
-        }
+        },
+        "tags": [
+          "Source"
+        ]
       }
     },
     "/sources/{ID}/upload_info": {
       "get": {
-        "description": "This endpoint provides all necessary information to upload an image for given Source.",
+        "description": "Provides all necessary information to upload an image for given Source. Typically, this is account number, subscription ID but some hyperscaler types also provide additional data.\nThe response contains \"provider\" field which can be one of aws, azure or gcp and then exactly one field named \"aws\", \"azure\" or \"gcp\". Enum is not used due to limitation of the language (Go).\nSome types may perform more than one calls (e.g. Azure) so latency might be increased. Caching of static information is performed to improve latency of consequent calls.\n",
+        "operationId": "getSourceUploadInfo",
         "parameters": [
           {
             "description": "Source ID from Sources Database",
@@ -1192,6 +1298,14 @@
           "200": {
             "content": {
               "application/json": {
+                "examples": {
+                  "aws": {
+                    "$ref": "#/components/examples/v1.SourceUploadInfoAWSResponse"
+                  },
+                  "azure": {
+                    "$ref": "#/components/examples/v1.SourceUploadInfoAzureResponse"
+                  }
+                },
                 "schema": {
                   "$ref": "#/components/schemas/v1.SourceUploadInfoResponse"
                 }
@@ -1205,7 +1319,10 @@
           "500": {
             "$ref": "#/components/responses/InternalError"
           }
-        }
+        },
+        "tags": [
+          "Source"
+        ]
       }
     }
   },

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -126,8 +126,13 @@ paths:
           $ref: '#/components/responses/InternalError'
   /sources:
     get:
-      description: 'Return list of provisioning sources'
+      description: >
+        Cloud credentials are kept in the sources application. This endpoint lists available
+        sources for the particular account per individual type (AWS, Azure, ...). All the fields
+        in the response are optional and can be omitted if Sources application also omits them.
       operationId: getSourceList
+      tags:
+        - Source
       parameters:
       - name: provider
         in: query
@@ -146,12 +151,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.SourceResponse'
+              examples:
+                example:
+                  $ref: '#/components/examples/v1.SourceListResponseExample'
         '500':
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/account_identity:
     get:
       description: 'This endpoint is deprecated. Please use upload_info instead'
       deprecated: true
+      operationId: getSourceAccountIdentity
+      tags:
+        - Source
       parameters:
       - in: path
         name: ID
@@ -173,7 +184,18 @@ paths:
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/upload_info:
     get:
-      description: 'This endpoint provides all necessary information to upload an image for given Source.'
+      operationId: getSourceUploadInfo
+      tags:
+        - Source
+      description: >
+        Provides all necessary information to upload an image for given Source. Typically, this
+        is account number, subscription ID but some hyperscaler types also provide additional data.
+
+        The response contains "provider" field which can be one of aws, azure or gcp and then exactly
+        one field named "aws", "azure" or "gcp". Enum is not used due to limitation of the language (Go).
+
+        Some types may perform more than one calls (e.g. Azure) so latency might be increased. Caching
+        of static information is performed to improve latency of consequent calls.
       parameters:
         - in: path
           name: ID
@@ -189,14 +211,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/v1.SourceUploadInfoResponse'
+              examples:
+                aws:
+                  $ref: '#/components/examples/v1.SourceUploadInfoAWSResponse'
+                azure:
+                  $ref: '#/components/examples/v1.SourceUploadInfoAzureResponse'
         '404':
           $ref: "#/components/responses/NotFound"
         '500':
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/instance_types:
     get:
-      description: 'Return a list of instance types (DEPRECATED: use /instance_types)'
+      description: 'Deprecated endpoint, use /instance_types instead.'
+      deprecated: true
       operationId: getInstanceTypeList
+      tags:
+        - Source
       parameters:
         - in: path
           name: ID
@@ -226,8 +256,17 @@ paths:
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/launch_templates:
     get:
-      description: Return a list of launch templates
+      description: >
+        Return a list of launch templates.
+
+        A launch template is a configuration set with a name that is available through hyperscaler
+        API. When creating reservations, launch template can be provided in order to set additional
+        configuration for instances.
+
+        Currently only AWS Launch Templates are supported.
       operationId: getLaunchTemplatesList
+      tags:
+        - Source
       parameters:
         - in: path
           name: ID
@@ -251,6 +290,9 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.LaunchTemplatesResponse'
+              examples:
+                example:
+                  $ref: '#/components/examples/v1.LaunchTemplateListResponse'
         '404':
           $ref: "#/components/responses/NotFound"
         '500':
@@ -261,6 +303,8 @@ paths:
         Return a list of instance types for particular provider. A region must be provided. A zone must be provided
         for Azure.
       operationId: getInstanceTypeListAll
+      tags:
+        - InstanceType
       parameters:
         - in: path
           name: PROVIDER
@@ -293,6 +337,11 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.InstanceTypeResponse'
+              examples:
+                aws:
+                  $ref: '#/components/examples/v1.InstanceTypesAWSResponse'
+                azure:
+                  $ref: '#/components/examples/v1.InstanceTypesAzureResponse'
         '404':
           $ref: "#/components/responses/NotFound"
         '500':
@@ -454,6 +503,8 @@ paths:
   /availability_status/sources:
     post:
       operationId: availabilityStatus
+      tags:
+        - AvailabilityStatus
       description: >
         Schedules a background operation of Sources availability check. These checks are
         are performed in separate process at it's own pace. Results are sent via Kafka
@@ -464,6 +515,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/v1.AvailabilityStatusRequest'
+            examples:
+              example:
+                $ref: '#/components/examples/v1.AvailabilityStatusRequest'
         description: availability status request with source id
         required: true
       responses:
@@ -804,6 +858,35 @@ components:
                                 build_time: 2023-04-14_17:15:02
                                 environment: ""
     examples:
+        v1.AvailabilityStatusRequest:
+            value:
+                sourceid: "463243"
+        v1.InstanceTypesAWSResponse:
+            value:
+                - name: c5a.8xlarge
+                  vcpus: 32
+                  cores: 16
+                  memory_mib: 65536
+                  storage_gb: 0
+                  supported: true
+                  arch: x86_64
+                  azure: null
+        v1.InstanceTypesAzureResponse:
+            value:
+                - name: Standard_M128s
+                  vcpus: 128
+                  cores: 64
+                  memory_mib: 2000000
+                  storage_gb: 4096
+                  supported: true
+                  arch: x86_64
+                  azure:
+                    gen_v1: true
+                    gen_v2: true
+        v1.LaunchTemplateListResponse:
+            value:
+                - id: lt-9843797432897342
+                  name: XXL large backend API
         v1.PubkeyListResponseExample:
             value:
                 - id: 1
@@ -824,23 +907,32 @@ components:
                 type: ssh-ed25519
                 fingerprint: gL/y6MvNmJ8jDXtsL/oMmK8jUuIefN39BBuvYw/Rndk=
                 fingerprint_legacy: ee:f1:d4:62:99:ab:17:d9:3b:00:66:62:32:b2:55:9e
-        v1.ResponseErrorGenericExample:
+        v1.SourceListResponseExample:
             value:
-                trace_id: b57f7b78c
-                edgeid: ""
-                error: 'error: this can be pretty long string'
-                version: df8a489
-                build_time: 2023-04-14_17:15:02
-                environment: ""
-        v1.ResponseErrorUserFriendlyExample:
+                - id: "654321"
+                  name: My AWS account
+                  source_type_id: ""
+                  uid: ""
+                - id: "543621"
+                  name: My other AWS account
+                  source_type_id: ""
+                  uid: ""
+        v1.SourceUploadInfoAWSResponse:
             value:
-                msg: vCPU limit reached, contact AWS support
-                trace_id: b57f7b78c
-                edgeid: ""
-                error: 'cannot run instances: cannot run instances: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: af6e10a0-75c9-47e1-a83c-872494250322, VcpuLimitExceeded: You have requested more vCPU capacity than your current vCPU limit of 128 allows for the instance bucket that the specified instance type belongs to. Please visit http://aws.amazon.com/contact-us/ec2-request to request an adjustment to this limit.'
-                version: df8a489
-                build_time: 2023-04-14_17:15:02
-                environment: ""
+                provider: aws
+                aws:
+                    account_id: "78462784632"
+                azure: null
+        v1.SourceUploadInfoAzureResponse:
+            value:
+                provider: azure
+                aws: null
+                azure:
+                    tenantid: 617807e1-e4e0-481c-983c-be3ce1e49253
+                    subscriptionid: 617807e1-e4e0-4855-983c-1e3ce1e49674
+                    resourcegroups:
+                        - MyGroup 1
+                        - MyGroup 42
 servers:
     - url: http://0.0.0.0:{port}/api/{applicationName}
       description: Local development

--- a/cmd/spec/example_other.go
+++ b/cmd/spec/example_other.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/RHEnVision/provisioning-backend/internal/payloads"
+
+var AvailabilityStatusRequest = payloads.AvailabilityStatusRequest{
+	SourceID: "463243",
+}

--- a/cmd/spec/example_source.go
+++ b/cmd/spec/example_source.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+)
+
+var SourceListResponse = []payloads.SourceResponse{{
+	ID:   "654321",
+	Name: "My AWS account",
+}, {
+	ID:   "543621",
+	Name: "My other AWS account",
+}}
+
+var SourceUploadInfoAWSResponse = payloads.SourceUploadInfoResponse{
+	Provider: "aws",
+	AwsInfo:  &clients.AccountDetailsAWS{AccountID: "78462784632"},
+}
+
+var SourceUploadInfoAzureResponse = payloads.SourceUploadInfoResponse{
+	Provider: "azure",
+	AzureInfo: &clients.AccountDetailsAzure{
+		TenantID:       "617807e1-e4e0-481c-983c-be3ce1e49253",
+		SubscriptionID: "617807e1-e4e0-4855-983c-1e3ce1e49674",
+		ResourceGroups: []string{"MyGroup 1", "MyGroup 42"},
+	},
+}

--- a/cmd/spec/example_templates.go
+++ b/cmd/spec/example_templates.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/RHEnVision/provisioning-backend/internal/payloads"
+
+var LaunchTemplateListResponse = []payloads.LaunchTemplateResponse{{
+	ID:   "lt-9843797432897342",
+	Name: "XXL large backend API",
+}}

--- a/cmd/spec/example_types.go
+++ b/cmd/spec/example_types.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+)
+
+var InstanceTypesAWSResponse = []payloads.InstanceTypeResponse{{
+	Name:               "c5a.8xlarge",
+	VCPUs:              32,
+	Cores:              16,
+	MemoryMiB:          65536,
+	EphemeralStorageGB: 0,
+	Supported:          true,
+	Architecture:       "x86_64",
+	AzureDetail:        nil,
+}}
+
+var InstanceTypesAzureResponse = []payloads.InstanceTypeResponse{{
+	Name:               "Standard_M128s",
+	VCPUs:              128,
+	Cores:              64,
+	MemoryMiB:          2000000,
+	EphemeralStorageGB: 4096,
+	Supported:          true,
+	Architecture:       "x86_64",
+	AzureDetail: &clients.InstanceTypeDetailAzure{
+		GenV1: true,
+		GenV2: true,
+	},
+}}

--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -33,9 +33,14 @@ func addExamples(gen *APISchemaGen) {
 	gen.addExample("v1.PubkeyRequestExample", PubkeyRequest)
 	gen.addExample("v1.PubkeyResponseExample", PubkeyResponse)
 	gen.addExample("v1.PubkeyListResponseExample", PubkeyListResponse)
+	gen.addExample("v1.SourceListResponseExample", SourceListResponse)
+	gen.addExample("v1.SourceUploadInfoAWSResponse", SourceUploadInfoAWSResponse)
+	gen.addExample("v1.SourceUploadInfoAzureResponse", SourceUploadInfoAzureResponse)
+	gen.addExample("v1.LaunchTemplateListResponse", LaunchTemplateListResponse)
+	gen.addExample("v1.AvailabilityStatusRequest", AvailabilityStatusRequest)
 
-	gen.addExample("v1.ResponseErrorGenericExample", ResponseErrorGenericExample)
-	gen.addExample("v1.ResponseErrorUserFriendlyExample", ResponseErrorUserFriendlyExample)
+	gen.addExample("v1.InstanceTypesAWSResponse", InstanceTypesAWSResponse)
+	gen.addExample("v1.InstanceTypesAzureResponse", InstanceTypesAzureResponse)
 }
 
 // addErrorSchemas all generic errors, that can be returned.

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -126,8 +126,13 @@ paths:
           $ref: '#/components/responses/InternalError'
   /sources:
     get:
-      description: 'Return list of provisioning sources'
+      description: >
+        Cloud credentials are kept in the sources application. This endpoint lists available
+        sources for the particular account per individual type (AWS, Azure, ...). All the fields
+        in the response are optional and can be omitted if Sources application also omits them.
       operationId: getSourceList
+      tags:
+        - Source
       parameters:
       - name: provider
         in: query
@@ -146,12 +151,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.SourceResponse'
+              examples:
+                example:
+                  $ref: '#/components/examples/v1.SourceListResponseExample'
         '500':
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/account_identity:
     get:
       description: 'This endpoint is deprecated. Please use upload_info instead'
       deprecated: true
+      operationId: getSourceAccountIdentity
+      tags:
+        - Source
       parameters:
       - in: path
         name: ID
@@ -173,7 +184,18 @@ paths:
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/upload_info:
     get:
-      description: 'This endpoint provides all necessary information to upload an image for given Source.'
+      operationId: getSourceUploadInfo
+      tags:
+        - Source
+      description: >
+        Provides all necessary information to upload an image for given Source. Typically, this
+        is account number, subscription ID but some hyperscaler types also provide additional data.
+
+        The response contains "provider" field which can be one of aws, azure or gcp and then exactly
+        one field named "aws", "azure" or "gcp". Enum is not used due to limitation of the language (Go).
+
+        Some types may perform more than one calls (e.g. Azure) so latency might be increased. Caching
+        of static information is performed to improve latency of consequent calls.
       parameters:
         - in: path
           name: ID
@@ -189,14 +211,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/v1.SourceUploadInfoResponse'
+              examples:
+                aws:
+                  $ref: '#/components/examples/v1.SourceUploadInfoAWSResponse'
+                azure:
+                  $ref: '#/components/examples/v1.SourceUploadInfoAzureResponse'
         '404':
           $ref: "#/components/responses/NotFound"
         '500':
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/instance_types:
     get:
-      description: 'Return a list of instance types (DEPRECATED: use /instance_types)'
+      description: 'Deprecated endpoint, use /instance_types instead.'
+      deprecated: true
       operationId: getInstanceTypeList
+      tags:
+        - Source
       parameters:
         - in: path
           name: ID
@@ -226,8 +256,17 @@ paths:
           $ref: "#/components/responses/InternalError"
   /sources/{ID}/launch_templates:
     get:
-      description: Return a list of launch templates
+      description: >
+        Return a list of launch templates.
+
+        A launch template is a configuration set with a name that is available through hyperscaler
+        API. When creating reservations, launch template can be provided in order to set additional
+        configuration for instances.
+
+        Currently only AWS Launch Templates are supported.
       operationId: getLaunchTemplatesList
+      tags:
+        - Source
       parameters:
         - in: path
           name: ID
@@ -251,6 +290,9 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.LaunchTemplatesResponse'
+              examples:
+                example:
+                  $ref: '#/components/examples/v1.LaunchTemplateListResponse'
         '404':
           $ref: "#/components/responses/NotFound"
         '500':
@@ -261,6 +303,8 @@ paths:
         Return a list of instance types for particular provider. A region must be provided. A zone must be provided
         for Azure.
       operationId: getInstanceTypeListAll
+      tags:
+        - InstanceType
       parameters:
         - in: path
           name: PROVIDER
@@ -293,6 +337,11 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/v1.InstanceTypeResponse'
+              examples:
+                aws:
+                  $ref: '#/components/examples/v1.InstanceTypesAWSResponse'
+                azure:
+                  $ref: '#/components/examples/v1.InstanceTypesAzureResponse'
         '404':
           $ref: "#/components/responses/NotFound"
         '500':
@@ -454,6 +503,8 @@ paths:
   /availability_status/sources:
     post:
       operationId: availabilityStatus
+      tags:
+        - AvailabilityStatus
       description: >
         Schedules a background operation of Sources availability check. These checks are
         are performed in separate process at it's own pace. Results are sent via Kafka
@@ -464,6 +515,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/v1.AvailabilityStatusRequest'
+            examples:
+              example:
+                $ref: '#/components/examples/v1.AvailabilityStatusRequest'
         description: availability status request with source id
         required: true
       responses:

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/headers"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
@@ -113,10 +114,10 @@ func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, p
 
 		if sourceTypeName == models.ProviderTypeFromString(provider.String()) {
 			newSrc := clients.Source{
-				Id:           src.Id,
-				Name:         src.Name,
-				SourceTypeId: src.SourceTypeId,
-				Uid:          src.Uid,
+				ID:           ptr.From(src.Id),
+				Name:         ptr.From(src.Name),
+				SourceTypeID: ptr.From(src.SourceTypeId),
+				Uid:          ptr.From(src.Uid),
 			}
 			result = append(result, &newSrc)
 		}
@@ -153,17 +154,17 @@ func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clie
 	result := make([]*clients.Source, len(*resp.JSON200.Data))
 	for i, src := range *resp.JSON200.Data {
 		newSrc := clients.Source{
-			Id:           src.Id,
-			Name:         src.Name,
-			SourceTypeId: src.SourceTypeId,
-			Uid:          src.Uid,
+			ID:           ptr.From(src.Id),
+			Name:         ptr.From(src.Name),
+			SourceTypeID: ptr.From(src.SourceTypeId),
+			Uid:          ptr.From(src.Uid),
 		}
 		result[i] = &newSrc
 	}
 	return result, nil
 }
 
-func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId clients.ID) (*clients.Authentication, error) {
+func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId string) (*clients.Authentication, error) {
 	logger := logger(ctx)
 	ctx, span := otel.Tracer(TraceName).Start(ctx, "GetAuthentication")
 	defer span.End()

--- a/internal/clients/http/sources/sources_client_test.go
+++ b/internal/clients/http/sources/sources_client_test.go
@@ -114,8 +114,8 @@ func TestSourcesClient_ListAllProvisioningSources(t *testing.T) {
 	sources, clientErr := client.ListAllProvisioningSources(ctx)
 	assert.NoError(t, clientErr, "Could not list all provisioning sources")
 	assert.Equal(t, 2, len(sources))
-	assert.Equal(t, "1", *sources[0].SourceTypeId)
-	assert.Equal(t, "2", *sources[1].SourceTypeId)
+	assert.Equal(t, "1", sources[0].SourceTypeID)
+	assert.Equal(t, "2", sources[1].SourceTypeID)
 }
 
 func TestSourcesClient_ListProvisioningSourcesByProvider(t *testing.T) {
@@ -152,6 +152,6 @@ func TestSourcesClient_ListProvisioningSourcesByProvider(t *testing.T) {
 		sources, clientErr := client.ListProvisioningSourcesByProvider(ctx, models.ProviderTypeAWS)
 		assert.NoError(t, clientErr, "Could not list all provisioning sources")
 		assert.Equal(t, 1, len(sources))
-		assert.Equal(t, "1", *sources[0].SourceTypeId)
+		assert.Equal(t, "1", sources[0].SourceTypeID)
 	})
 }

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -19,7 +19,7 @@ type Sources interface {
 	ListAllProvisioningSources(ctx context.Context) ([]*Source, error)
 
 	// GetArn returns authentication associated with provisioning app for given sourceId
-	GetAuthentication(ctx context.Context, sourceId ID) (*Authentication, error)
+	GetAuthentication(ctx context.Context, sourceId string) (*Authentication, error)
 
 	// GetProvisioningTypeId returns provisioning type ID
 	GetProvisioningTypeId(ctx context.Context) (string, error)

--- a/internal/clients/launch_template.go
+++ b/internal/clients/launch_template.go
@@ -3,8 +3,8 @@ package clients
 // LaunchTemplate represents a generic launch template for a hyperscaler.
 type LaunchTemplate struct {
 	// ID is an identifier, for example "lt-94397398248932342" for AWS EC2.
-	ID string `json:"id" yaml:"id"`
+	ID string
 
 	// Name describes the launch template, user defined.
-	Name string `json:"name" yaml:"name"`
+	Name string
 }

--- a/internal/clients/source.go
+++ b/internal/clients/source.go
@@ -1,18 +1,16 @@
 package clients
 
-type ID = string
-
-// Source defines model for Source.
+// Source defines model for Source. Maps 1:1 to Source Database.
 type Source struct {
 	// ID of the resource
-	Id *ID `json:"id,omitempty"`
+	ID string
 
 	// The name of the source
-	Name *string `json:"name,omitempty"`
+	Name string
 
-	// ID of the resource
-	SourceTypeId *ID `json:"source_type_id,omitempty"`
+	// Source Type ID (number assigned to AWS source or Azure source)
+	SourceTypeID string
 
-	// Unique ID of the inventory source installation
-	Uid *string `json:"uid,omitempty"`
+	// UUID of the inventory source installation
+	Uid string
 }

--- a/internal/clients/stubs/sources_stub.go
+++ b/internal/clients/stubs/sources_stub.go
@@ -8,7 +8,6 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http/sources"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
-	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 )
 
 type sourcesCtxKeyType string
@@ -58,8 +57,8 @@ func getSourcesClientStub(ctx context.Context) (si *SourcesClientStub, err error
 func (stub *SourcesClientStub) addSource(ctx context.Context, provider models.ProviderType) (*clients.Source, error) {
 	id := strconv.Itoa(len(stub.sources) + 2) // starts at 2 as 1 is reserved - TODO migrate users of the implicit id = 1
 	source := &clients.Source{
-		Id:   ptr.To(id),
-		Name: ptr.To("source-" + id),
+		ID:   id,
+		Name: "source-" + id,
 	}
 	switch provider {
 	case models.ProviderTypeAWS:
@@ -83,7 +82,7 @@ func (*SourcesClientStub) Ready(ctx context.Context) error {
 	return nil
 }
 
-func (stub *SourcesClientStub) GetAuthentication(ctx context.Context, sourceId sources.ID) (*clients.Authentication, error) {
+func (stub *SourcesClientStub) GetAuthentication(ctx context.Context, sourceId string) (*clients.Authentication, error) {
 	if sourceId == "1" {
 		return clients.NewAuthentication("arn:aws:iam::230214684733:role/Test", models.ProviderTypeAWS), nil
 	}
@@ -102,16 +101,16 @@ func (mock *SourcesClientStub) GetProvisioningTypeId(ctx context.Context) (strin
 func (mock *SourcesClientStub) ListAllProvisioningSources(ctx context.Context) ([]*clients.Source, error) {
 	TestSourceData := []*clients.Source{
 		{
-			Id:           ptr.To("1"),
-			Name:         ptr.To("source1"),
-			SourceTypeId: ptr.To("1"),
-			Uid:          ptr.To("5eebe172-7baa-4280-823f-19e597d091e9"),
+			ID:           "1",
+			Name:         "source1",
+			SourceTypeID: "1",
+			Uid:          "5eebe172-7baa-4280-823f-19e597d091e9",
 		},
 		{
-			Id:           ptr.To("2"),
-			Name:         ptr.To("source2"),
-			SourceTypeId: ptr.To("2"),
-			Uid:          ptr.To("31b5338b-685d-4056-ba39-d00b4d7f19cc"),
+			ID:           "2",
+			Name:         "source2",
+			SourceTypeID: "2",
+			Uid:          "31b5338b-685d-4056-ba39-d00b4d7f19cc",
 		},
 	}
 	return TestSourceData, nil
@@ -120,16 +119,16 @@ func (mock *SourcesClientStub) ListAllProvisioningSources(ctx context.Context) (
 func (mock *SourcesClientStub) ListProvisioningSourcesByProvider(ctx context.Context, provider models.ProviderType) ([]*clients.Source, error) {
 	TestSourceData := []*clients.Source{
 		{
-			Id:           ptr.To("1"),
-			Name:         ptr.To("source1"),
-			SourceTypeId: ptr.To("1"),
-			Uid:          ptr.To("5eebe172-7baa-4280-823f-19e597d091e9"),
+			ID:           "1",
+			Name:         "source1",
+			SourceTypeID: "1",
+			Uid:          "5eebe172-7baa-4280-823f-19e597d091e9",
 		},
 		{
-			Id:           ptr.To("2"),
-			Name:         ptr.To("source2"),
-			SourceTypeId: ptr.To("1"),
-			Uid:          ptr.To("31b5338b-685d-4056-ba39-d00b4d7f19cc"),
+			ID:           "2",
+			Name:         "source2",
+			SourceTypeID: "1",
+			Uid:          "31b5338b-685d-4056-ba39-d00b4d7f19cc",
 		},
 	}
 	return TestSourceData, nil

--- a/internal/payloads/instance_types_payload.go
+++ b/internal/payloads/instance_types_payload.go
@@ -7,9 +7,7 @@ import (
 	"github.com/go-chi/render"
 )
 
-type InstanceTypeResponse struct {
-	*clients.InstanceType
-}
+type InstanceTypeResponse clients.InstanceType
 
 func (s *InstanceTypeResponse) Bind(_ *http.Request) error {
 	return nil
@@ -21,8 +19,17 @@ func (s *InstanceTypeResponse) Render(_ http.ResponseWriter, _ *http.Request) er
 
 func NewListInstanceTypeResponse(sl []*clients.InstanceType) []render.Renderer {
 	list := make([]render.Renderer, len(sl))
-	for i, instanceType := range sl {
-		list[i] = &InstanceTypeResponse{instanceType}
+	for i, it := range sl {
+		list[i] = &InstanceTypeResponse{
+			Name:               it.Name,
+			VCPUs:              it.VCPUs,
+			Cores:              it.Cores,
+			MemoryMiB:          it.MemoryMiB,
+			EphemeralStorageGB: it.EphemeralStorageGB,
+			Supported:          it.Supported,
+			Architecture:       it.Architecture,
+			AzureDetail:        it.AzureDetail,
+		}
 	}
 	return list
 }

--- a/internal/payloads/launch_template_payload.go
+++ b/internal/payloads/launch_template_payload.go
@@ -7,8 +7,10 @@ import (
 	"github.com/go-chi/render"
 )
 
+// See clients.LaunchTemplate
 type LaunchTemplateResponse struct {
-	*clients.LaunchTemplate
+	ID   string `json:"id" yaml:"id"`
+	Name string `json:"name" yaml:"name"`
 }
 
 func (s *LaunchTemplateResponse) Bind(_ *http.Request) error {
@@ -22,7 +24,10 @@ func (s *LaunchTemplateResponse) Render(_ http.ResponseWriter, _ *http.Request) 
 func NewListLaunchTemplateResponse(sl []*clients.LaunchTemplate) []render.Renderer {
 	list := make([]render.Renderer, len(sl))
 	for i, instanceType := range sl {
-		list[i] = &LaunchTemplateResponse{instanceType}
+		list[i] = &LaunchTemplateResponse{
+			ID:   instanceType.ID,
+			Name: instanceType.Name,
+		}
 	}
 	return list
 }

--- a/internal/payloads/sources_payload.go
+++ b/internal/payloads/sources_payload.go
@@ -7,11 +7,12 @@ import (
 	"github.com/go-chi/render"
 )
 
-type SourceID struct {
-	SourceId string `json:"source_id"`
-}
+// See clients.Source
 type SourceResponse struct {
-	*clients.Source
+	ID           string `json:"id" yaml:"id"`
+	Name         string `json:"name,omitempty" yaml:"name"`
+	SourceTypeID string `json:"source_type_id" yaml:"source_type_id"`
+	Uid          string `json:"uid" yaml:"uid"`
 }
 
 func (s *SourceResponse) Bind(_ *http.Request) error {
@@ -25,15 +26,20 @@ func (s *SourceResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
 func NewListSourcesResponse(sourceList []*clients.Source) []render.Renderer {
 	list := make([]render.Renderer, len(sourceList))
 	for i, source := range sourceList {
-		list[i] = &SourceResponse{Source: source}
+		list[i] = &SourceResponse{
+			ID:           source.ID,
+			Name:         source.Name,
+			SourceTypeID: source.SourceTypeID,
+			Uid:          source.Uid,
+		}
 	}
 	return list
 }
 
 type SourceUploadInfoResponse struct {
-	Provider  string                       `json:"provider"`
-	AwsInfo   *clients.AccountDetailsAWS   `json:"aws" nullable:"true"`
-	AzureInfo *clients.AccountDetailsAzure `json:"azure" nullable:"true"`
+	Provider  string                       `json:"provider" yaml:"provider"`
+	AwsInfo   *clients.AccountDetailsAWS   `json:"aws" nullable:"true" yaml:"aws"`
+	AzureInfo *clients.AccountDetailsAzure `json:"azure" nullable:"true" yaml:"azure"`
 }
 
 func (s SourceUploadInfoResponse) Render(_ http.ResponseWriter, _ *http.Request) error {

--- a/internal/services/azure_reservation_service_test.go
+++ b/internal/services/azure_reservation_service_test.go
@@ -39,7 +39,7 @@ func TestCreateAzureReservationHandler(t *testing.T) {
 	t.Run("successful reservation with compose ID", func(t *testing.T) {
 		var err error
 		values := map[string]interface{}{
-			"source_id":     source.Id,
+			"source_id":     source.ID,
 			"image_id":      "92ea98f8-7697-472e-80b1-7454fa0e7fa7",
 			"amount":        1,
 			"instance_size": "Basic_A0",
@@ -71,7 +71,7 @@ func TestCreateAzureReservationHandler(t *testing.T) {
 	t.Run("failed reservation with invalid location", func(t *testing.T) {
 		var err error
 		values := map[string]interface{}{
-			"source_id":     source.Id,
+			"source_id":     source.ID,
 			"location":      "blank",
 			"image_id":      "92ea98f8-7697-472e-80b1-7454fa0e7fa7",
 			"amount":        1,

--- a/internal/services/gcp_reservation_service_test.go
+++ b/internal/services/gcp_reservation_service_test.go
@@ -36,7 +36,7 @@ func TestCreateGCPReservationHandler(t *testing.T) {
 	t.Run("successful reservation", func(t *testing.T) {
 		var err error
 		values := map[string]interface{}{
-			"source_id":    source.Id,
+			"source_id":    source.ID,
 			"image_id":     "80967e7f-efef-4eee-85b0-bd4cef4c455d",
 			"amount":       1,
 			"zone":         "us-central1-a",
@@ -64,7 +64,7 @@ func TestCreateGCPReservationHandler(t *testing.T) {
 	t.Run("failed reservation with invalid zone", func(t *testing.T) {
 		var err error
 		values := map[string]interface{}{
-			"source_id":    source.Id,
+			"source_id":    source.ID,
 			"image_id":     "80967e7f-efef-4eee-85b0-bd4cef4c455d",
 			"amount":       1,
 			"zone":         "us-central",

--- a/internal/services/sources_service_test.go
+++ b/internal/services/sources_service_test.go
@@ -59,14 +59,12 @@ func TestListSourcesHandler(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
 
-		var result []sources.Source
+		var result []payloads.SourceResponse
 
 		err = json.NewDecoder(rr.Body).Decode(&result)
 		require.NoError(t, err, "failed to decode response body")
 
 		assert.Equal(t, 2, len(result), "expected two result in response json")
-		assert.Equal(t, "1", *result[0].SourceTypeId, "source is of type aws")
-		assert.Equal(t, "1", *result[1].SourceTypeId, "source is of type aws")
 	})
 
 	t.Run("with invalid provider", func(t *testing.T) {
@@ -97,8 +95,8 @@ func TestGetAzureSourceDetails(t *testing.T) {
 
 		rctx := chi.NewRouteContext()
 		ctx = context.WithValue(ctx, chi.RouteCtxKey, rctx)
-		rctx.URLParams.Add("ID", *sourceStub.Id)
-		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("/api/provisioning/sources/%s/upload_info", *sourceStub.Id), nil)
+		rctx.URLParams.Add("ID", sourceStub.ID)
+		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("/api/provisioning/sources/%s/upload_info", sourceStub.ID), nil)
 		require.NoError(t, err, "failed to create request")
 
 		rr := httptest.NewRecorder()


### PR DESCRIPTION
Continuation of https://github.com/RHEnVision/provisioning-backend/pull/500 for all sources endpoints. I am keeping the deprecated endpoints untouched for now, let’s remove them in a separate PR.

I cannot continue working on upload_info until https://github.com/RHEnVision/provisioning-backend/pull/534 is merged tho, so that is TBD.