### PR TITLE
build: disable cache for golangci-lint

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -30,14 +30,51 @@ jobs:
           make check-commits
         working-directory: code
 
-  linting:
-    name: "🎯 Code format, imports and style"
+  build:
+    name: "🛠️ Go Build"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_SVR }}
+          cache: true
+      - name: Build all artifacts
+        run: |
+          make check-system-go build GO=go
+
+  lint:
+    name: "🎯 Code format & OpenAPI lint"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_SVR }}
+          # disabled until 'lookup-only' is implemented for setup-go or cache prefix is added
+          cache: false
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: bin
+          key: bin-go${{ env.GO_SVR }}-tools-${{ hashFiles('mk/tools.mk') }}
+      - name: Install Go Tools
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: make install-tools GO=go
+      - name: Generate and validate
+        run: |
+          touch config/_config.yaml
+          make check-system-go check-fmt validate GO=go
+
+  golint:
+    name: "🎯 Go linter"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_SVR }}
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -52,6 +89,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_SVR }}
+          # disabled until 'lookup-only' is implemented for setup-go or cache prefix is added
+          cache: false
       - run: |
           make check-system-go test GO=go
 
@@ -88,6 +127,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_SVR }}
+          # disabled until 'lookup-only' is implemented for setup-go or cache prefix is added
+          cache: false
       - name: "Run tests"
         env:
           DATABASE_USER: postgres
@@ -95,24 +136,3 @@ jobs:
           DATABASE_NAME: provisioning_test
           WORKER_QUEUE: redis
         run: make check-system-go integration-test check-migrations GO=go
-
-  openapi:
-    name: "🪆 Generated code diff check"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_SVR }}
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: bin
-          key: bin-go${{ env.GO_SVR }}-tools-${{ hashFiles('mk/tools.mk') }}
-      - name: Install Go Tools
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: make install-tools GO=go
-      - name: Generate and validate
-        run: |
-          touch config/_config.yaml
-          make check-system-go validate GO=go

--- a/mk/code.mk
+++ b/mk/code.mk
@@ -30,6 +30,10 @@ check-commits: ## Check commit format
 .PHONY: fmt ## Alias to perform all code formatting and linting
 fmt: format imports lint
 
-.PHONY: check ## Alias to perform all checking (commits, migrations)
+.PHONY: check-fmt ## Reformat the code and check git diff
+check-fmt: format imports
+	git diff --exit-code
+
+.PHONY: check ## Alias to perform commit message and migration checking
 check: check-commits check-migrations
 


### PR DESCRIPTION
CI currently fails with

```
/usr/bin/tar -xf /home/runner/work/_temp/9d82feee-0932-4ee7-82bf-2f8f8b676785/cache.tgz -P -C /home/runner/work/provisioning-backend/provisioning-backend -z
  /usr/bin/tar: ../../../go/pkg/mod/go.opentelemetry.io/otel@v1.14.0/VERSIONING.md: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/go.opentelemetry.io/otel@v1.14.0/propagation/trace_context_test.go: Cannot open: File exists
```

This is because cache is stored twice, Go cache and Linter cache. The documentation for the linter explicitly disables the Go cache because it is essentially stored twice. This patch does exactly that.

During editing of the workflow I realized that we do not build the artifacts at all. So there can be a build error in `main.go` and we would not notice until container would fail to build. This adds a new job for that. Unfortunately, build cache for the Go action cannot be shared between build, test and integration test via `setup-go`, so I disabled it for now. There is a workaround but that is a lot of YAML I want rather to keep it simple.