### PR TITLE
feat(HMS-#1804): add compose file for containerizing dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ TAGS
 # envdir/envrc (https://direnv.net)
 /.envrc
 /bin
+/compose-data/*

--- a/build/Dockerfile.dev
+++ b/build/Dockerfile.dev
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19
+USER 0
+ENV PROJECT_DIR=/backend \
+    GO111MODULE=on \
+    CGO_ENABLED=0
+
+WORKDIR /backend
+RUN mkdir "/build"
+
+COPY . .
+RUN go get github.com/githubnemo/CompileDaemon
+RUN go install github.com/githubnemo/CompileDaemon
+RUN make prep GO=go
+
+ENTRYPOINT $HOME/go/bin/CompileDaemon -build=" go build -o /build/pbackend ./cmd/pbackend" -command="/build/pbackend api"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,174 @@
+version: '3.7'
+services:
+  provisioning-db:
+    restart: on-failure
+    image: docker.io/postgres:13.1
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=provisioning
+    volumes:
+      - ./compose-data/postgres/backend:/var/lib/postgresql/data
+    expose:
+      - 5432
+    
+  redis:
+    image: registry.redhat.io/rhel8/redis-6
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+    expose:
+      - 6379
+    volumes:
+      - ./compose-data/redis:/data
+  
+  zookeeper:
+    profiles:
+      - "kafka"
+    container_name: zookeeper
+    image: quay.io/strimzi/kafka:latest-kafka-3.4.0
+    command: [
+      "sh", "-c",
+      "bin/zookeeper-server-start.sh config/zookeeper.properties"
+    ]
+    expose:
+      - "2181"
+    environment:
+      LOG_DIR: /tmp/logs
+    volumes:
+      - ./compose-data/zookeeper:/tmp/logs
+  
+  kafka:
+    profiles:
+     - "kafka"
+    image: quay.io/strimzi/kafka:latest-kafka-3.4.0
+    command: [
+      "sh", "-c",
+      "bin/kafka-server-start.sh config/server.properties  --override inter.broker.listener.name=$${KAFKA_INTER_BROKER_LISTENER_NAME} --override listener.security.protocol.map=$${KAFKA_LISTENER_SECURITY_PROTOCOL_MAP} --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
+    ]
+    expose:
+      - 9092
+      - 29092
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
+      LOG_DIR: "/tmp/logs"
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_INTER_BROKER_LISTENER_NAME: DOCKER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: DOCKER:PLAINTEXT,LOCALHOST:PLAINTEXT
+      KAFKA_LISTENERS: DOCKER://kafka:29092,LOCALHOST://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: DOCKER://kafka:29092,LOCALHOST://localhost:9092
+    volumes:
+      - ./compose-data/kafka:/tmp/logs
+
+  init-kafka:
+    profiles:
+      - "kafka"
+    image: quay.io/strimzi/kafka:latest-kafka-3.4.0
+    entrypoint: [ '/bin/sh', '-c' ]
+    command: |
+      "
+      # blocks until kafka is reachable
+      bin/kafka-topics.sh --bootstrap-server kafka:29092 --list
+
+      echo -e 'Creating kafka topics'
+      bin/kafka-topics.sh --bootstrap-server kafka:29092 --create --if-not-exists --topic platform.sources.status --replication-factor 1 --partitions 1
+      bin/kafka-topics.sh --bootstrap-server kafka:29092 --create --if-not-exists --topic platform.provisioning.internal.availability-check --replication-factor 1 --partitions 1
+
+      echo -e 'Successfully created the following topics:'
+      bin/kafka-topics.sh --bootstrap-server kafka:29092 --list
+      "
+    depends_on:
+      - kafka
+      - zookeeper
+  
+  backend:
+    env_file:
+      - scripts/compose/api.compose.env
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      provisioning-db:
+        condition: service_healthy
+      init-kafka:
+        condition: service_completed_successfully
+    build:
+      context: .
+      dockerfile: build/Dockerfile.dev
+    ports:
+      - ${APP_PORT:-8000}:${APP_PORT:-8000}
+      - ${PROMETHEUS_PORT:-9000}:${PROMETHEUS_PORT:-9000}
+    volumes:
+      - ./:/backend
+
+  migrate: # This service is used to run migrations
+    profiles:
+      - "migrate"
+    build:
+      context: .
+      dockerfile: build/Dockerfile.dev
+    env_file:
+      - config/api.env
+    depends_on:
+      provisioning-db:
+        condition: service_healthy
+    entrypoint: [go,run,/build/cmd/pbackend migrate]
+
+  frontend:
+    profiles:
+      - "frontend"
+    environment:
+      - PROV_API_HOST=backend
+      - WATCHPACK_POLLING=true
+    build:
+      context: ../provisioning-frontend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ../provisioning-frontend/:/prov-frontend
+    ports: 
+      - 1337:1337
+    depends_on:
+    - backend
+
+  sources:
+    profiles:
+      - "sources"
+    build:
+      context: ../sources-api-go
+    ports: 
+      - 8131:8131
+    env_file:
+      - scripts/compose/sources.compose.env
+    depends_on:
+      redis:
+        condition: service_healthy
+      sources-db:
+        condition: service_healthy
+  sources-db:
+    restart: on-failure
+    profiles:
+      - "sources"
+    image: docker.io/postgres:13.1
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=sources_devel
+    volumes:
+      - ./compose-data/postgres/sources:/var/lib/postgresql/data
+    expose:
+      - 5432

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -126,6 +126,52 @@ Tip: Alternatively, the application supports connecting to the stage environment
 
 Because Image Builder is more complex for installation, we do not recommend installing it on your local machine right now. Configure connection through HTTP proxy to the stage environment in `config/api.env`. See [configuration example](../config/api.env.example) for an example, you will need to ask someone from the company for real URLs for the service and the proxy.
 
+## Containerized environment
+
+A `docker-compose.yml` file helps rolling up the provisioning application, including frontend and other services such as sources locally for development purpose or demo with no extra setup.
+
+Please notice that the compose file use a dedicated dev Dockerfile.dev both for backend and frontend, it uses [CompileDaemon](github.com/githubnemo/CompileDaemon) for live reloading, it watches for changes and re-build using `go build` command when a change occurs, no need to build the container after code changes.
+
+### Install
+A docker or podman (with [podman-compose](https://github.com/containers/podman-compose)) is needed, the folder structure should be:
+```
+.
+├── provisioning-backend
+├── provisioning-frontend
+├── sources-api-go
+└── image-builder-frontend
+```
+
+Edit [app.env](/config/api.env.example) to fit containerized services (i.e db, redis, kafka), these are not exposed directly to your localhost ports.
+
+Run 
+```sh
+$ COMPOSE_PROFILES=migrate docker compose up 
+```
+This command also migrates data to postgres db, using the `migrate` profile.
+
+Alternatively do:
+```sh
+$ COMPOSE_PROFILES=migrate podman-compose up 
+```
+
+
+### Profiles
+A compose profile allows you to run a subset of containers. When no profile is given, 
+the provisioning backend, postgres and redis will run by default.
+
+Currently there are a few profiles:
+- migrate: migrate provisioning backend, terminates after migration
+- kafka: run kafka with zookeeper, register topics
+- frontend: run local provisioning frontend
+- sources: run local sources with postgres db, on first use notice that you will need to run `/script/sources.seed.sh` for seeding your local sources data.
+
+For example, in order to run sources, kafka and frontend profiles, run
+```sh
+# using docker
+$ COMPOSE_PROFILES=frontend,kafka,sources docker compose up 
+```
+
 ## Writing Go code
 
 Ready to write some Go code? Read [contributing guide](../CONTRIBUTING.md).

--- a/scripts/compose/api.compose.env
+++ b/scripts/compose/api.compose.env
@@ -1,0 +1,9 @@
+# Minimum required variables for compose file
+# This file is used for local development and testing
+# Edit this file to match your environment and rename it for safety
+
+KAFKA_BROKERS="kafka:29092"
+KAFKA_ENABLED="true"
+REST_ENDPOINTS_SOURCES_URL="http://sources:8131/api/sources/v3.1"
+DATABASE_PASSWORD="postgres"
+DATABASE_HOST='provisioning-db'

--- a/scripts/compose/sources.compose.env
+++ b/scripts/compose/sources.compose.env
@@ -1,0 +1,17 @@
+# Minimum required variables for compose file
+# This file is used for local development and testing
+# It is not used for production deployment
+
+PORT=8131
+METRICS_PORT=9131
+DATABASE_HOST=sources-db
+DATABASE_PORT=5432
+DATABASE_NAME=sources_devel
+DATABASE_USER=postgres
+DATABASE_PASSWORD=postgres
+BYPASS_RBAC=true
+REDIS_CACHE_HOST=redis
+REDIS_CACHE_PORT=6379
+# used in seeding script
+SOURCES_API_HOST=http://sources
+SOURCES_API_PORT=$PORT


### PR DESCRIPTION

a `docker-compose.yml` file help you to roll up the Provisioning application, including frontend and other services such as sources locally for dev or demo with no extra setup.

### Install
a docker or podman (with [podman-compose](https://github.com/containers/podman-compose)) is needed, the folder structure should be:
```
.
├── provisioning-backend
├── provisioning-frontend
├── sources-api-go
└── image-builder-frontend
```
Run 
```sh
$ COMPOSE_PROFILES=migrate docker compose up 
```

### Profiles
a compose profile allows you to run a subset of containers. When no profile is given, only provisioning-backend, frontend, postgres and redis will run, in this case use staged sources.

Currently there are a few profiles:
- migrate: migrate provisioning backend, terminates after migration
- kafka: run kafka with zookeeper, register topics
- sources: run local sources with postgres db, on first use notice that you will need to run `/script/sources.seed.sh` for seeding your local sources data.

For running sources and kafka profiles, run
```sh
$ COMPOSE_PROFILES=kafka,sources docker compose up 
```