### PR TITLE
chore: replace IPv4 for i/o timeout errors

### DIFF
--- a/internal/logging/sentry_replacer.go
+++ b/internal/logging/sentry_replacer.go
@@ -14,6 +14,7 @@ var filters = []string{
 	`[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}`,
 	// Example (AWS SDK): arn:aws:iam::4328974392798432:role/my-role-123
 	`arn:aws:[[:word:]]+::\d+:[[:word:]\*-]+/[[:word:]\*-]+`,
+	`\d+\.\d+\.\d+\.\d+:\d+`,
 }
 
 var replacement = []byte{'?'}

--- a/internal/logging/sentry_replacer_test.go
+++ b/internal/logging/sentry_replacer_test.go
@@ -69,3 +69,10 @@ func TestARNSplit(t *testing.T) {
 	_, _ = repl.Write([]byte("4328974392798432:role/my-role-123\n"))
 	require.Equal(t, "?\n", buf.String())
 }
+
+func TestIPv4(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("read tcp 10.128.24.14:42094->10.0.217.126:6379: i/o timeout\n"))
+	require.Equal(t, "read tcp ?->?: i/o timeout\n", buf.String())
+}


### PR DESCRIPTION
Solves sentry error:

```
:read tcp 10.128.24.14:42094->10.0.217.126:6379: i/o timeout
Module "github.com/RHEnVision/provisioning-backend/pkg/worker", line 183, in (*RedisWorker).fetchJob
Module "github.com/RHEnVision/provisioning-backend/pkg/worker", line 154, in (*RedisWorker).dequeueLoop
```