### PR TITLE
fix(HMS-1800): fix a typo in upload info

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -118,12 +118,13 @@ func Find(ctx context.Context, key string, value Cacheable) error {
 	err = dec.Decode(value)
 	if err != nil {
 		// decode error can be thrown if previous cache entry was JSON-encoded, return not found to overwrite it
-		ctxval.Logger(ctx).Warn().Err(err).Bool("cache", true).Msgf("redis cache decode error: %s", err.Error())
+		ctxval.Logger(ctx).Warn().Err(err).Bool("cache", true).Msgf("Redis cache decode error: %s", err.Error())
 		metrics.IncCacheHit(prefix, "err")
 		return ErrNotFound
 	}
 
 	metrics.IncCacheHit(prefix, "hit")
+	ctxval.Logger(ctx).Trace().Bool("cache", true).Msgf("Cache hit for key '%s' type %T", key, value)
 	return nil
 }
 

--- a/internal/services/sources_service.go
+++ b/internal/services/sources_service.go
@@ -94,7 +94,7 @@ func GetSourceUploadInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	payload := payloads.SourceUploadInfoResponse{Provider: models.ProviderTypeAzure.String()}
+	payload := payloads.SourceUploadInfoResponse{Provider: authentication.ProviderType.String()}
 	switch authentication.ProviderType {
 	case models.ProviderTypeAWS:
 		if payload.AwsInfo, err = getAWSAccountDetails(r.Context(), sourceId, authentication); err != nil {


### PR DESCRIPTION
The provider field was hardcoded to "azure" for some reason. I noticed this today.

```
{"provider":"azure","aws":{"account_id":"399777895069"},"azure":null}
```