### PR TITLE
fix(HMS-1830): improve concurrency of account creation

### DIFF
--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -21,11 +21,11 @@ var GetAccountDao func(ctx context.Context) AccountDao
 
 // AccountDao represents an account (tenant)
 type AccountDao interface {
+	// Create is meant for integration tests, use GetOrCreateByIdentity instead.
 	Create(ctx context.Context, pk *models.Account) error
 	GetById(ctx context.Context, id int64) (*models.Account, error)
 	GetOrCreateByIdentity(ctx context.Context, orgId string, accountNumber string) (*models.Account, error)
 	GetByOrgId(ctx context.Context, orgId string) (*models.Account, error)
-	GetByAccountNumber(ctx context.Context, number string) (*models.Account, error)
 	List(ctx context.Context, limit, offset int64) ([]*models.Account, error)
 }
 

--- a/internal/dao/stubs/account_dao.go
+++ b/internal/dao/stubs/account_dao.go
@@ -70,7 +70,7 @@ func (stub *accountDaoStub) GetOrCreateByIdentity(ctx context.Context, orgId str
 	if err == nil {
 		return acc, nil
 	}
-	acc, err = stub.GetByAccountNumber(ctx, accountNumber)
+	acc, err = stub.getByAccountNumber(ctx, accountNumber)
 	if err == nil {
 		return acc, nil
 	}
@@ -90,7 +90,7 @@ func (stub *accountDaoStub) GetByOrgId(ctx context.Context, orgId string) (*mode
 	return nil, dao.ErrNoRows
 }
 
-func (stub *accountDaoStub) GetByAccountNumber(ctx context.Context, number string) (*models.Account, error) {
+func (stub *accountDaoStub) getByAccountNumber(ctx context.Context, number string) (*models.Account, error) {
 	for _, acc := range stub.store {
 		if acc.AccountNumber.Valid && acc.AccountNumber.String == number {
 			return acc, nil

--- a/internal/dao/tests/account_test.go
+++ b/internal/dao/tests/account_test.go
@@ -113,22 +113,6 @@ func TestAccountGetById(t *testing.T) {
 	})
 }
 
-func TestAccountGetByAccountNumber(t *testing.T) {
-	accDao, ctx := setupAccount(t)
-	defer reset()
-
-	t.Run("success", func(t *testing.T) {
-		account, err := accDao.GetByAccountNumber(ctx, "1")
-		require.NoError(t, err)
-		assert.Equal(t, "1", account.OrgID)
-	})
-
-	t.Run("success", func(t *testing.T) {
-		_, err := accDao.GetByAccountNumber(ctx, "0")
-		require.ErrorIs(t, err, dao.ErrNoRows)
-	})
-}
-
 func TestAccountGetByOrgId(t *testing.T) {
 	accDao, ctx := setupAccount(t)
 	defer reset()
@@ -155,8 +139,6 @@ func TestAccountGetOrCreateByIdentity(t *testing.T) {
 		require.NoError(t, err)
 		account, err = accDao.GetByOrgId(ctx, "101")
 		assert.Equal(t, "101", account.OrgID)
-		account, err = accDao.GetByAccountNumber(ctx, "101")
-		assert.Equal(t, "101", account.AccountNumber.String)
 	})
 
 	t.Run("already exists by org id", func(t *testing.T) {


### PR DESCRIPTION
We made a conscious decision not to use transactions when creating accounts because it would be too slow. There are cases when user that don’t have account created in our database yet comes and performs operation that does many requests, this can lead to this error.

We now saw this once in production, so let’s fix this. Instead of using transactions, which are slow, this patch uses "UPSERT" technique which in Postgres is available through "ON CONFLICT". Here is when not having ORM is a really powerful.

I think we should open up discussion if we can remove account_number from the database. Handling of empty/null values is extra work and it makes the query more complex than it needs to be.