### PR TITLE
feat(HMS-1828): Add listing templates and creating instances from a template

### DIFF
--- a/internal/clients/instance_params.go
+++ b/internal/clients/instance_params.go
@@ -18,6 +18,9 @@ type GCPInstanceParams struct {
 	// UUID for instance that was created in a reservation
 	UUID string
 
+	// The template name to use in order to launch an instance
+	LaunchTemplateName string
+
 	// Zone - to deploy into
 	Zone string
 

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -154,4 +154,6 @@ type GCP interface {
 	ListInstancesIDsByTag(ctx context.Context, uuid string) ([]*string, error)
 
 	GetInstanceDescriptionByID(ctx context.Context, id string) (*InstanceDescription, error)
+
+	ListLaunchTemplates(ctx context.Context) ([]*LaunchTemplate, error)
 }

--- a/internal/clients/stubs/gcp_stub.go
+++ b/internal/clients/stubs/gcp_stub.go
@@ -63,6 +63,10 @@ func (mock *GCPClientStub) GetInstanceDescriptionByID(ctx context.Context, id st
 	return nil, nil
 }
 
+func (mock *GCPClientStub) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchTemplate, error) {
+	return nil, nil
+}
+
 func (mock *GCPClientStub) InsertInstances(ctx context.Context, params *clients.GCPInstanceParams, amount int64) ([]*string, *string, error) {
 	return nil, nil, NotImplementedErr
 }

--- a/internal/jobs/launch_instance_gcp.go
+++ b/internal/jobs/launch_instance_gcp.go
@@ -32,6 +32,9 @@ type LaunchInstanceGCPTaskArgs struct {
 
 	// The project id from Sources which is linked to a specific source
 	ProjectID *clients.Authentication
+
+	// Launch template name or empty string when no template in use
+	LaunchTemplateName string
 }
 
 // Unmarshall arguments and handle error
@@ -92,13 +95,14 @@ func DoLaunchInstanceGCP(ctx context.Context, args *LaunchInstanceGCPTaskArgs) e
 	logger.Trace().Bool("userdata", true).Msg(string(userData))
 
 	params := &clients.GCPInstanceParams{
-		NamePattern:   ptr.To("inst-####"),
-		ImageName:     args.ImageName,
-		MachineType:   args.Detail.MachineType,
-		Zone:          args.Zone,
-		KeyBody:       pk.Body,
-		StartupScript: string(userData),
-		UUID:          args.Detail.UUID,
+		NamePattern:        ptr.To("inst-####"),
+		ImageName:          args.ImageName,
+		MachineType:        args.Detail.MachineType,
+		Zone:               args.Zone,
+		KeyBody:            pk.Body,
+		StartupScript:      string(userData),
+		UUID:               args.Detail.UUID,
+		LaunchTemplateName: args.LaunchTemplateName,
 	}
 
 	instances, opName, err := gcpClient.InsertInstances(ctx, params, args.Detail.Amount)

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -107,6 +107,9 @@ type GCPDetail struct {
 	// UUID of instances created in the same reservation
 	UUID string `json:"uuid"`
 
+	// Optional launch template name global/instanceTemplates/NAME or empty string
+	LaunchTemplateName string `json:"launch_template_name"`
+
 	// Immediately power off the system after initialization
 	PowerOff bool `json:"poweroff"`
 }

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -140,6 +140,9 @@ type GCPReservationResponsePayload struct {
 	// The name of the gcp operation which was created.
 	GCPOperationName string `json:"gcp_operation_name,omitempty"`
 
+	// Optional launch template name global/instanceTemplates/NAME or empty string
+	LaunchTemplateName string `json:"launch_template_name,omitempty"`
+
 	// Immediately power off the system after initialization
 	PowerOff bool `json:"poweroff"`
 
@@ -210,6 +213,9 @@ type GCPReservationRequestPayload struct {
 
 	// Source ID.
 	SourceID string `json:"source_id"`
+
+	// Optional launch template name global/instanceTemplates/NAME or empty string
+	LaunchTemplateName string `json:"launch_template_name,omitempty"`
 
 	// GCP zone.
 	Zone string `json:"zone"`

--- a/internal/services/gcp_reservation_service.go
+++ b/internal/services/gcp_reservation_service.go
@@ -42,11 +42,12 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 
 	resUUID := uuid.New().String()
 	detail := &models.GCPDetail{
-		Zone:        payload.Zone,
-		MachineType: payload.MachineType,
-		Amount:      payload.Amount,
-		PowerOff:    payload.PowerOff,
-		UUID:        resUUID,
+		Zone:               payload.Zone,
+		MachineType:        payload.MachineType,
+		Amount:             payload.Amount,
+		PowerOff:           payload.PowerOff,
+		UUID:               resUUID,
+		LaunchTemplateName: payload.LaunchTemplateName,
 	}
 	reservation := &models.GCPReservation{
 		PubkeyID: payload.PubkeyID,
@@ -96,8 +97,6 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: upload key job if needed
-
 	// Get Image builder client
 	ibc, ibErr := clients.GetImageBuilderClient(r.Context())
 	logger.Trace().Msg("Creating IB client")
@@ -127,12 +126,13 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 		AccountID: accountId,
 		Identity:  id,
 		Args: jobs.LaunchInstanceGCPTaskArgs{
-			ReservationID: reservation.ID,
-			Zone:          reservation.Detail.Zone,
-			PubkeyID:      reservation.PubkeyID,
-			Detail:        reservation.Detail,
-			ImageName:     name,
-			ProjectID:     authentication,
+			ReservationID:      reservation.ID,
+			Zone:               reservation.Detail.Zone,
+			PubkeyID:           reservation.PubkeyID,
+			Detail:             reservation.Detail,
+			ImageName:          name,
+			ProjectID:          authentication,
+			LaunchTemplateName: reservation.Detail.LaunchTemplateName,
 		},
 	}
 

--- a/internal/services/launch_templates_service.go
+++ b/internal/services/launch_templates_service.go
@@ -4,12 +4,41 @@ import (
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 )
 
+//nolint:exhaustive
 func ListLaunchTemplates(w http.ResponseWriter, r *http.Request) {
+	sourceId := chi.URLParam(r, "ID")
+
+	sourcesClient, err := clients.GetSourcesClient(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	auth, err := sourcesClient.GetAuthentication(r.Context(), sourceId)
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	switch auth.ProviderType {
+	case models.ProviderTypeAWS:
+		ListLaunchTemplateAWS(w, r)
+	case models.ProviderTypeAzure:
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "azure reservation is not implemented", ProviderTypeNotImplementedError))
+	case models.ProviderTypeGCP:
+		ListLaunchTemplateGCP(w, r)
+	default:
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", UnknownProviderTypeError))
+	}
+}
+
+func ListLaunchTemplateAWS(w http.ResponseWriter, r *http.Request) {
 	sourceId := chi.URLParam(r, "ID")
 	region := r.URL.Query().Get("region")
 	if region == "" {
@@ -41,7 +70,39 @@ func ListLaunchTemplates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := render.RenderList(w, r, payloads.NewListLaunchTemplateResponse(templates)); err != nil {
-		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render instance types list", err))
+		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render launch templates list", err))
+		return
+	}
+}
+
+func ListLaunchTemplateGCP(w http.ResponseWriter, r *http.Request) {
+	sourceId := chi.URLParam(r, "ID")
+	sourcesClient, err := clients.GetSourcesClient(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	authentication, err := sourcesClient.GetAuthentication(r.Context(), sourceId)
+	if err != nil {
+		renderError(w, r, payloads.NewClientError(r.Context(), err))
+		return
+	}
+
+	gcpClient, err := clients.GetGCPClient(r.Context(), authentication)
+	if err != nil {
+		renderError(w, r, payloads.NewGCPError(r.Context(), "unable to get GCP client", err))
+		return
+	}
+
+	templates, err := gcpClient.ListLaunchTemplates(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewGCPError(r.Context(), "unable to list GCP launch templates", err))
+		return
+	}
+
+	if err := render.RenderList(w, r, payloads.NewListLaunchTemplateResponse(templates)); err != nil {
+		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render launch templates list", err))
 		return
 	}
 }

--- a/scripts/rest_examples/launchtemlates-gcp-list.http
+++ b/scripts/rest_examples/launchtemlates-gcp-list.http
@@ -1,0 +1,4 @@
+
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources/3/launch_templates HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/reservation-create-gcp.http
+++ b/scripts/rest_examples/reservation-create-gcp.http
@@ -10,6 +10,7 @@ X-Rh-Identity: {{identity}}
   "image_id": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-9-v20230411",
   "amount": 1,
   "machine_type": "e2-micro",
+  "launch_template_name": "{{launch_template_name}}",
   "pubkey_id": {{pubkey_id}},
   "poweroff": true
 }


### PR DESCRIPTION
Adding support for listing launch templates in GCP and launching instances from a specific template name. 
GCP works with launch template names rather than launch template IDs. 

