### PR TITLE
build: route GCP secrets to ENV

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -78,6 +78,12 @@ objects:
                     name: provisioning-azure-acc
                     key: client_secret
                     optional: true
+              - name: GCP_JSON
+                valueFrom:
+                  secretKeyRef:
+                    name: provisioning-gcp-acc
+                    key: json
+                    optional: true
               - name: SENTRY_DSN
                 valueFrom:
                   secretKeyRef:
@@ -154,6 +160,12 @@ objects:
                   secretKeyRef:
                     name: provisioning-azure-acc
                     key: client_secret
+                    optional: true
+              - name: GCP_JSON
+                valueFrom:
+                  secretKeyRef:
+                    name: provisioning-gcp-acc
+                    key: json
                     optional: true
               - name: SENTRY_DSN
                 valueFrom:
@@ -260,6 +272,12 @@ objects:
                   secretKeyRef:
                     name: provisioning-azure-acc
                     key: principal_name
+                    optional: true
+              - name: GCP_JSON
+                valueFrom:
+                  secretKeyRef:
+                    name: provisioning-gcp-acc
+                    key: json
                     optional: true
               - name: SENTRY_DSN
                 valueFrom:


### PR DESCRIPTION
Adds GCP env variable from credentials in k8s

I think the JSON should be enough in prod environments, as `GCP_PROJECT_ID` is consumed only in the service client, but not the customer client, but could you give me a sanity check here @adiabramovitch pls? :)