### PR TITLE
build: use single binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tags
 TAGS
 
 # binaries
+/pbackend
 /pbapi
 /pbmigrate
 /pbworker

--- a/build/RedHat.dockerfile
+++ b/build/RedHat.dockerfile
@@ -6,9 +6,6 @@ COPY . .
 RUN make prep build strip GO=go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-COPY --from=build /build/pbapi /pbapi
-COPY --from=build /build/pbworker /pbworker
-COPY --from=build /build/pbstatuser /pbstatuser
-COPY --from=build /build/pbmigrate /pbmigrate
+COPY --from=build /build/pbackend /pbackend
 USER 1001
-CMD ["/pbapi"]
+CMD ["/pbackend", "api"]

--- a/build/Upstream.dockerfile
+++ b/build/Upstream.dockerfile
@@ -5,17 +5,14 @@
 #  https://github.com/quay/claircore/actions/workflows/golang-image.yml
 #  https://github.com/quay/claircore/blob/main/.github/workflows/golang-image.yml
 
-FROM quay.io/projectquay/golang:1.18 as build
+FROM quay.io/projectquay/golang:1.19 as build
 USER 0
 RUN mkdir /build
 WORKDIR /build
 COPY . .
 RUN make prep build strip GO=go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-COPY --from=build /build/pbapi /pbapi
-COPY --from=build /build/pbworker /pbworker
-COPY --from=build /build/pbstatuser /pbstatuser
-COPY --from=build /build/pbmigrate /pbmigrate
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+COPY --from=build /build/pbackend /pbackend
 USER 1001
-CMD ["/pbapi"]
+CMD ["/pbackend", "api"]

--- a/cmd/pbackend/main.go
+++ b/cmd/pbackend/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	// DAO implementation, must be initialized before any database packages
+	_ "github.com/RHEnVision/provisioning-backend/internal/dao/pgx"
+
+	// HTTP client implementations
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/azure"
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/ec2"
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/gcp"
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/image_builder"
+	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/sources"
+
+	"github.com/RHEnVision/provisioning-backend/internal/random"
+	"github.com/RHEnVision/provisioning-backend/internal/version"
+)
+
+func init() {
+	random.SeedGlobal()
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+	}
+
+	switch os.Args[1] {
+	case "api":
+		api()
+	case "worker":
+		worker()
+	case "migrate":
+		migrate()
+	case "statuser":
+		statuser()
+	case "version":
+		ver()
+	default:
+		usage()
+	}
+}
+
+func usage() {
+	fmt.Println("Usage: pbackend [migrate|api|worker|statuser|version]")
+	os.Exit(1)
+}
+
+func ver() {
+	fmt.Printf("Version %s, Go version %s, built %s\n", version.BuildCommit, runtime.Version(), version.BuildTime)
+}

--- a/cmd/pbackend/migrate.go
+++ b/cmd/pbackend/migrate.go
@@ -4,22 +4,14 @@ import (
 	"context"
 	"os"
 
-	// DAO implementation, must be initialized before any database packages.
-	_ "github.com/RHEnVision/provisioning-backend/internal/dao/pgx"
-
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/db"
 	"github.com/RHEnVision/provisioning-backend/internal/logging"
 	"github.com/RHEnVision/provisioning-backend/internal/migrations"
-	"github.com/RHEnVision/provisioning-backend/internal/random"
 	"github.com/rs/zerolog/log"
 )
 
-func init() {
-	random.SeedGlobal()
-}
-
-func main() {
+func migrate() {
 	ctx := context.Background()
 	config.Initialize("config/api.env", "config/migrate.env")
 
@@ -34,7 +26,7 @@ func main() {
 	}
 	defer db.Close()
 
-	if len(os.Args[1:]) > 0 && os.Args[1] == "purgedb" {
+	if len(os.Args[2:]) > 0 && os.Args[2] == "purgedb" {
 		logger.Warn().Msg("Database purge: all data is being dropped")
 		err = migrations.Seed(ctx, "drop_all")
 		if err != nil {

--- a/cmd/pbackend/statuser.go
+++ b/cmd/pbackend/statuser.go
@@ -258,7 +258,7 @@ func sendResults(ctx context.Context, batchSize int, tickDuration time.Duration)
 	}
 }
 
-func main() {
+func statuser() {
 	ctx := context.Background()
 	config.Initialize("config/api.env", "config/statuser.env")
 

--- a/cmd/pbackend/worker.go
+++ b/cmd/pbackend/worker.go
@@ -11,33 +11,18 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/background"
 	"github.com/RHEnVision/provisioning-backend/internal/cache"
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/db"
+	"github.com/RHEnVision/provisioning-backend/internal/logging"
 	"github.com/RHEnVision/provisioning-backend/internal/metrics"
 	"github.com/RHEnVision/provisioning-backend/internal/queue/jq"
-	"github.com/RHEnVision/provisioning-backend/internal/random"
 	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	"github.com/RHEnVision/provisioning-backend/internal/config"
-
-	// HTTP client implementations
-	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/azure"
-	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/ec2"
-	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/gcp"
-
-	// Performs initialization of DAO implementation, must be initialized before any database packages.
-	_ "github.com/RHEnVision/provisioning-backend/internal/dao/pgx"
-
-	"github.com/RHEnVision/provisioning-backend/internal/db"
-	"github.com/RHEnVision/provisioning-backend/internal/logging"
 	"github.com/rs/zerolog/log"
 )
 
-func init() {
-	random.SeedGlobal()
-}
-
-func main() {
+func worker() {
 	ctx := context.Background()
 	config.Initialize("config/api.env", "config/worker.env")
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -28,12 +28,14 @@ objects:
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command:
-              - /pbworker
+              - /pbackend
+              - worker
             initContainers:
               - name: run-migrations
                 image: "${IMAGE}:${IMAGE_TAG}"
                 command:
-                  - /pbmigrate
+                  - /pbackend
+                  - migrate
                 inheritEnv: true
             env:
               - name: LOGGING_LEVEL
@@ -105,12 +107,14 @@ objects:
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
             command:
-              - /pbstatuser
+              - /pbackend
+              - statuser
             initContainers:
               - name: run-migrations
                 image: "${IMAGE}:${IMAGE_TAG}"
                 command:
-                  - /pbmigrate
+                  - /pbackend
+                  - migrate
                 inheritEnv: true
             env:
               - name: LOGGING_LEVEL
@@ -180,11 +184,15 @@ objects:
               apiPath: provisioning
           podSpec:
             image: ${IMAGE}:${IMAGE_TAG}
+            command:
+              - /pbackend
+              - api
             initContainers:
               - name: run-migrations
                 image: "${IMAGE}:${IMAGE_TAG}"
                 command:
-                  - /pbmigrate
+                  - /pbackend
+                  - migrate
                 inheritEnv: true
             livenessProbe:
               failureThreshold: 3

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -300,7 +300,10 @@ func Initialize(configFiles ...string) {
 }
 
 func BinaryName() string {
-	return path.Base(os.Args[0])
+	if len(os.Args) < 2 {
+		return "unknown"
+	}
+	return path.Base(os.Args[1])
 }
 
 func Hostname() string {

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"runtime"
 	"strings"
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
@@ -115,7 +114,4 @@ func DumpConfig(logger zerolog.Logger) {
 		configCopy.Sentry.Dsn = replacement
 	}
 	logger.Info().Msgf("Configuration: %+v", configCopy)
-
-	gmp := runtime.GOMAXPROCS(0)
-	logger.Info().Int("gomaxproc", gmp).Msgf("GOMAXPROC value: %d", gmp)
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,11 +1,16 @@
 package version
 
+import "runtime/debug"
+
 var (
-	// Git SHA commit set via -ldflags
+	// Git SHA commit (first 4 characters)
 	BuildCommit string
 
-	// Build date and time in UTC set via -ldflags
+	// Build date and time
 	BuildTime string
+
+	// BuildGoVersion carries Go version the binary was built with
+	BuildGoVersion string
 )
 
 const (
@@ -32,11 +37,23 @@ const (
 )
 
 func init() {
-	if BuildTime == "" {
+	bi, ok := debug.ReadBuildInfo()
+
+	if !ok {
 		BuildTime = "N/A"
+		BuildCommit = "HEAD"
 	}
 
-	if BuildCommit == "" {
-		BuildCommit = "HEAD"
+	BuildGoVersion = bi.GoVersion
+
+	for _, bs := range bi.Settings {
+		switch bs.Key {
+		case "vcs.revision":
+			if len(bs.Value) > 4 {
+				BuildCommit = bs.Value[0:4]
+			}
+		case "vcs.time":
+			BuildTime = bs.Value
+		}
 	}
 }

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -4,36 +4,33 @@ SRC_GO := $(shell find . -name \*.go -print)
 SRC_SQL := $(shell find . -name \*.sql -print)
 SRC_YAML := $(shell find . -name \*.yaml -print)
 
-PACKAGE_BASE = github.com/RHEnVision/provisioning-backend/internal
-LDFLAGS = "-X $(PACKAGE_BASE)/version.BuildCommit=$(shell git rev-parse --short HEAD) -X $(PACKAGE_BASE)/version.BuildTime=$(shell date +'%Y-%m-%d_%T')"
-
-build: pbapi pbmigrate pbworker pbstatuser ## Build all binaries
+build: pbackend ## Build all binaries
 
 all-deps: $(SRC_GO) $(SRC_SQL) $(SRC_YAML)
 
-pbapi: check-go all-deps ## Build backend API service
-	CGO_ENABLED=0 $(GO) build -ldflags $(LDFLAGS) -o pbapi ./cmd/pbapi
-
-pbworker: check-go all-deps ## Build worker service
-	CGO_ENABLED=0 $(GO) build -ldflags $(LDFLAGS) -o pbworker ./cmd/pbworker
-
-pbstatuser: check-go all-deps ## Build status worker command
-	CGO_ENABLED=0 $(GO) build -o pbstatuser ./cmd/pbstatuser
-
-pbmigrate: check-go all-deps ## Build migration command
-	CGO_ENABLED=0 $(GO) build -o pbmigrate ./cmd/pbmigrate
+pbackend: check-go all-deps ## Build backend
+	CGO_ENABLED=0 $(GO) build -o pbackend ./cmd/pbackend
 
 .PHONY: strip
 strip: build ## Strip debug information
-	strip pbapi pbworker pbmigrate
+	strip pbackend
 
-.PHONY: run-go
-run-go: check-go ## Run backend API using `go run`
-	$(GO) run ./cmd/pbapi
+.PHONY: run-api
+run-api: check-go ## Run backend API using `go run`
+	$(GO) run ./cmd/pbackend api
 
+.PHONY: run-worker
+run-worker: check-go ## Run backend API using `go run`
+	$(GO) run ./cmd/pbackend worker
+
+.PHONY: run-statuser
+run-statuser: check-go ## Run backend API using `go run`
+	$(GO) run ./cmd/pbackend statuser
+
+CMD?=version
 .PHONY: run
-run: pbapi ## Build and run backend API
-	./pbapi
+run: pbackend ## Build and run backend API
+	./pbackend $(CMD)
 
 .PHONY: clean
 clean: ## Clean build artifacts and cache


### PR DESCRIPTION
We build four different binary files: pbapi, pbworker, pbstatuser and pbmigrate. Each about 70MiB in size, we copy them into the container. The most of the size comes with libraries (dependencies), if we only could ship just one binary.

This patch introduces a new binary called `pbackend` which replaces all of the four saving 70% of the old size and trimming compilation time in half (without Go cache). It takes an argument which means which program to start:

```
[lzap@nuc provisioning-backend]$ ./pbackend 
Usage: pbackend [migrate|api|worker|statuser|version]

[lzap@nuc provisioning-backend]$ ./pbackend version
Version 4f2e, Go version go1.19.6, built 2023-05-23T13:09:37Z

[lzap@nuc provisioning-backend]$ ./pbackend migrate
...migrates database...
```

This patch is changing container entrypoints as well as k8s configuration in order to start correct processes. Everything should work as previously without any change. Except one:

We use the `BinaryName` function in logger, it is used for log "stream". So after this is merged, logs will change "stream" from "pbapi" to more human-readable "api". Luckily, we do not use these in prometheus or k8s directly so no monitoring/alert changes should be necessary.

With this change, new feature of Go 1.18 can be used to report build time, go version and sha number. Previously we used build flags, this is no longer necessary.