### PR TITLE
build: use PATH for golint

### DIFF
--- a/mk/code.mk
+++ b/mk/code.mk
@@ -17,7 +17,7 @@ imports: ## Rearrange imports using `goimports`
 
 .PHONY: lint
 lint: ## Run Go language linter `golangci-lint`
-	GOROOT=$(GOROOT) GOCACHE=$(GOCACHE) $(GOLINT) run
+	GOROOT=$(GOROOT) PATH=$(GOROOT)/bin:${PATH} GOCACHE=$(GOCACHE) $(GOLINT) run
 
 .PHONY: check-migrations
 check-migrations: ## Check migration files for changes


### PR DESCRIPTION
Looks like I misread how golangci-lint handles GOROOT, I thought it would use that variable but looks like it always tries to detect the GOROOT via `go env GOROOT`. Problem is, it uses system Go rather than the specific Go version we want.

https://github.com/golangci/golangci-lint/blob/master/pkg/goutil/env.go

This patch adds PATH for the linter command, so the `go` command resolves to the proper version, this fixes the problem.

