### PR TITLE
refactor: deprecate ctxval.Logger

### DIFF
--- a/cmd/pbackend/statuser.go
+++ b/cmd/pbackend/statuser.go
@@ -33,6 +33,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -61,7 +62,7 @@ func init() {
 }
 
 func processMessage(origCtx context.Context, message *kafka.GenericMessage) {
-	logger := ctxval.Logger(origCtx)
+	logger := zerolog.Ctx(origCtx)
 
 	// Get source id
 	asm, err := kafka.NewAvailabilityStatusMessage(message)
@@ -75,7 +76,7 @@ func processMessage(origCtx context.Context, message *kafka.GenericMessage) {
 
 	// Set source id as logging field
 	logger = ptr.To(logger.With().Str("source_id", sourceId).Logger())
-	ctx := ctxval.WithLogger(origCtx, logger)
+	ctx := logger.WithContext(origCtx)
 
 	// Get sources client
 	sourcesClient, err := clients.GetSourcesClient(ctx)
@@ -116,7 +117,7 @@ func processMessage(origCtx context.Context, message *kafka.GenericMessage) {
 }
 
 func checkSourceAvailabilityAzure(ctx context.Context) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	defer processingWG.Done()
 
 	for s := range chAzure {
@@ -139,7 +140,7 @@ func checkSourceAvailabilityAzure(ctx context.Context) {
 }
 
 func checkSourceAvailabilityAWS(ctx context.Context) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	defer processingWG.Done()
 
 	for s := range chAws {
@@ -168,7 +169,7 @@ func checkSourceAvailabilityAWS(ctx context.Context) {
 }
 
 func checkSourceAvailabilityGCP(ctx context.Context) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	defer processingWG.Done()
 
 	for s := range chGcp {
@@ -205,7 +206,7 @@ func checkSourceAvailabilityGCP(ctx context.Context) {
 }
 
 func sendResults(ctx context.Context, batchSize int, tickDuration time.Duration) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	messages := make([]*kafka.GenericMessage, 0, batchSize)
 	ticker := time.NewTicker(tickDuration)
 	defer senderWG.Done()

--- a/internal/background/availability_queue.go
+++ b/internal/background/availability_queue.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/kafka"
+	"github.com/rs/zerolog"
 )
 
 // buffered channel for incoming requests
@@ -22,13 +22,13 @@ func EnqueueAvailabilityStatusRequest(msg *kafka.GenericMessage) {
 func send(ctx context.Context, messages ...*kafka.GenericMessage) {
 	err := kafka.Send(ctx, messages...)
 	if err != nil {
-		ctxval.Logger(ctx).Warn().Err(err).Msg("Unable to send availability check messages")
+		zerolog.Ctx(ctx).Warn().Err(err).Msg("Unable to send availability check messages")
 	}
 }
 
 // main sending loop: takes messages enqueued via EnqueueAvailabilityStatusRequest and sends them to the kafka
 func sendAvailabilityRequestMessages(ctx context.Context, batchSize int, tickDuration time.Duration) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	ticker := time.NewTicker(tickDuration)
 	messageBuffer := make([]*kafka.GenericMessage, 0, batchSize)
 

--- a/internal/background/initialize.go
+++ b/internal/background/initialize.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/rs/zerolog"
 )
 
 // Maximum batch size for each batch send, also an incoming buffered channel size to prevent
@@ -17,8 +17,8 @@ const availabilityStatusBatchSize = 1024
 // InitializeApi starts background goroutines for REST API processes.
 // Use context cancellation to stop them.
 func InitializeApi(ctx context.Context) {
-	logger := ctxval.Logger(ctx).With().Bool("background", true).Logger()
-	ctx = ctxval.WithLogger(ctx, &logger)
+	logger := zerolog.Ctx(ctx).With().Bool("background", true).Logger()
+	ctx = logger.WithContext(ctx)
 
 	// start availability request batch sender
 	go sendAvailabilityRequestMessages(ctx, availabilityStatusBatchSize, 5*time.Second)
@@ -27,8 +27,8 @@ func InitializeApi(ctx context.Context) {
 // InitializeWorker starts background goroutines for worker processes.
 // Use context cancellation to stop them.
 func InitializeWorker(ctx context.Context) {
-	logger := ctxval.Logger(ctx).With().Bool("background", true).Logger()
-	ctx = ctxval.WithLogger(ctx, &logger)
+	logger := zerolog.Ctx(ctx).With().Bool("background", true).Logger()
+	ctx = logger.WithContext(ctx)
 
 	// start job queue telemetry
 	go jobQueueMetricLoop(ctx, 30*time.Second, config.Hostname())

--- a/internal/background/queue_metrics.go
+++ b/internal/background/queue_metrics.go
@@ -5,9 +5,9 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/metrics"
 	"github.com/RHEnVision/provisioning-backend/internal/queue/jq"
+	"github.com/rs/zerolog"
 )
 
 // jobQueueMetricLoop is a background function that runs for all workers.
@@ -17,7 +17,7 @@ import (
 //
 //nolint:gosec
 func jobQueueMetricLoop(ctx context.Context, sleep time.Duration, name string) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 
 	// spread polling intervals
 	randSleep := rand.Int63() % sleep.Milliseconds()

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/metrics"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -118,13 +118,13 @@ func Find(ctx context.Context, key string, value Cacheable) error {
 	err = dec.Decode(value)
 	if err != nil {
 		// decode error can be thrown if previous cache entry was JSON-encoded, return not found to overwrite it
-		ctxval.Logger(ctx).Warn().Err(err).Bool("cache", true).Msgf("Redis cache decode error: %s", err.Error())
+		zerolog.Ctx(ctx).Warn().Err(err).Bool("cache", true).Msgf("Redis cache decode error: %s", err.Error())
 		metrics.IncCacheHit(prefix, "err")
 		return ErrNotFound
 	}
 
 	metrics.IncCacheHit(prefix, "hit")
-	ctxval.Logger(ctx).Trace().Bool("cache", true).Msgf("Cache hit for key '%s' type %T", key, value)
+	zerolog.Ctx(ctx).Trace().Bool("cache", true).Msgf("Cache hit for key '%s' type %T", key, value)
 	return nil
 }
 

--- a/internal/clients/authentication.go
+++ b/internal/clients/authentication.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/rs/zerolog"
 )
 
 type Authentication struct {
@@ -32,7 +32,7 @@ func NewAuthenticationFromSourceAuthType(ctx context.Context, str, authType, app
 	case "provisioning_project_id":
 		a.ProviderType = models.ProviderTypeGCP
 	default:
-		ctxval.Logger(ctx).Warn().Msgf("Unknown auth type returned from sources: %s", authType)
+		zerolog.Ctx(ctx).Warn().Msgf("Unknown auth type returned from sources: %s", authType)
 		a.ProviderType = models.ProviderTypeUnknown
 	}
 	return &a

--- a/internal/clients/http/azure/azure_common.go
+++ b/internal/clients/http/azure/azure_common.go
@@ -3,7 +3,6 @@ package azure
 import (
 	"context"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	"github.com/rs/zerolog"
 )
@@ -11,5 +10,5 @@ import (
 const TraceName = telemetry.TracePrefix + "internal/clients/http/azure"
 
 func logger(ctx context.Context) zerolog.Logger {
-	return ctxval.Logger(ctx).With().Str("client", "azure").Logger()
+	return zerolog.Ctx(ctx).With().Str("client", "azure").Logger()
 }

--- a/internal/clients/http/common_http_errors.go
+++ b/internal/clients/http/common_http_errors.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/rs/zerolog"
 )
 
 func IsHTTPStatus2xx(status int) bool {
@@ -37,7 +37,7 @@ func HandleHTTPResponses(ctx context.Context, statusCode int) error {
 		return clients.ForbiddenErr
 	}
 	if !IsHTTPStatus2xx(statusCode) {
-		ctxval.Logger(ctx).Warn().Msgf("Non-200 HTTP response seen: %v", statusCode)
+		zerolog.Ctx(ctx).Warn().Msgf("Non-200 HTTP response seen: %v", statusCode)
 		return clients.Non2xxResponseErr
 	}
 	return nil

--- a/internal/clients/http/ec2/aws_supported_types.go
+++ b/internal/clients/http/ec2/aws_supported_types.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/supported"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/rs/zerolog"
 )
 
 func NewInstanceTypes(ctx context.Context, types []types.InstanceTypeInfo) ([]*clients.InstanceType, error) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	list := make([]*clients.InstanceType, 0, len(types))
 	for i := range types {
 		architectures := types[i].ProcessorInfo.SupportedArchitectures

--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
@@ -40,7 +39,7 @@ func init() {
 }
 
 func logger(ctx context.Context) *zerolog.Logger {
-	logger := ctxval.Logger(ctx).With().Str("client", "ec2").Logger()
+	logger := zerolog.Ctx(ctx).With().Str("client", "ec2").Logger()
 	return &logger
 }
 

--- a/internal/clients/http/gcp/gcp_commons.go
+++ b/internal/clients/http/gcp/gcp_commons.go
@@ -3,10 +3,9 @@ package gcp
 import (
 	"context"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/rs/zerolog"
 )
 
 func logger(ctx context.Context) zerolog.Logger {
-	return ctxval.Logger(ctx).With().Str("client", "gcp").Logger()
+	return zerolog.Ctx(ctx).With().Str("client", "gcp").Logger()
 }

--- a/internal/clients/http/image_builder/image_client.go
+++ b/internal/clients/http/image_builder/image_client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/headers"
 	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	"github.com/google/uuid"
@@ -27,7 +26,7 @@ func init() {
 }
 
 func logger(ctx context.Context) zerolog.Logger {
-	return ctxval.Logger(ctx).With().Str("client", "ib").Logger()
+	return zerolog.Ctx(ctx).With().Str("client", "ib").Logger()
 }
 
 func newImageBuilderClient(ctx context.Context) (clients.ImageBuilder, error) {

--- a/internal/clients/http/logging_doer.go
+++ b/internal/clients/http/logging_doer.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/rs/zerolog"
 )
 
@@ -20,7 +19,7 @@ type LoggingDoer struct {
 func NewLoggingDoer(ctx context.Context, doer HttpRequestDoer) *LoggingDoer {
 	client := LoggingDoer{
 		ctx:  ctx,
-		log:  ctxval.Logger(ctx),
+		log:  zerolog.Ctx(ctx),
 		doer: doer,
 	}
 	return &client

--- a/internal/clients/http/platform_client.go
+++ b/internal/clients/http/platform_client.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/rs/zerolog"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
@@ -20,9 +20,9 @@ func NewPlatformClient(ctx context.Context, proxy string) HttpRequestDoer {
 
 	if proxy != "" {
 		if config.InClowder() {
-			ctxval.Logger(ctx).Warn().Msgf("Unable to use HTTP client proxy in clowder environment: %s", proxy)
+			zerolog.Ctx(ctx).Warn().Msgf("Unable to use HTTP client proxy in clowder environment: %s", proxy)
 		} else {
-			ctxval.Logger(ctx).Warn().Msgf("Creating HTTP client with proxy %s", proxy)
+			zerolog.Ctx(ctx).Warn().Msgf("Creating HTTP client with proxy %s", proxy)
 			rt = &http.Transport{Proxy: http.ProxyURL(config.StringToURL(proxy))}
 		}
 	}

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/headers"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
@@ -30,7 +29,7 @@ func init() {
 }
 
 func logger(ctx context.Context) zerolog.Logger {
-	return ctxval.Logger(ctx).With().Str("client", "sources").Logger()
+	return zerolog.Ctx(ctx).With().Str("client", "sources").Logger()
 }
 
 func newSourcesClient(ctx context.Context) (clients.Sources, error) {

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -31,7 +31,7 @@ func LaunchEnabled(ctx context.Context) bool {
 }
 
 func unleashLogger(ctx context.Context) *zerolog.Logger {
-	logger := ctxval.Logger(ctx).With().Bool("unleash", true).Logger()
+	logger := zerolog.Ctx(ctx).With().Bool("unleash", true).Logger()
 	return &logger
 }
 

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/rs/zerolog"
 )
@@ -52,7 +51,7 @@ func TopicName(ctx context.Context, topic string) string {
 		return t.Name
 	}
 	if InClowder() {
-		ctxval.Logger(ctx).Warn().Msgf("Tried to get TopicName for %s, but clowder doesn't know such topic", topic)
+		zerolog.Ctx(ctx).Warn().Msgf("Tried to get TopicName for %s, but clowder doesn't know such topic", topic)
 	}
 
 	return topic

--- a/internal/ctxval/keys.go
+++ b/internal/ctxval/keys.go
@@ -4,7 +4,6 @@ package ctxval
 type commonKeyId int
 
 const (
-	loggerCtxKey         commonKeyId = iota
 	requestIdCtxKey      commonKeyId = iota
 	accountIdCtxKey      commonKeyId = iota
 	unleashContextCtxKey commonKeyId = iota

--- a/internal/ctxval/logger.go
+++ b/internal/ctxval/logger.go
@@ -4,20 +4,20 @@ import (
 	"context"
 
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 // Logger returns the main logger with context fields or the standard global logger
-// when the main logger was not set. Never returns nil.
+// when the main logger was not set. When nil is passed, returns noop logger.
+// Never returns nil.
+//
+// Deprecated: Use zerolog.Ctx or log.Ctx alias instead.
 func Logger(ctx context.Context) *zerolog.Logger {
-	value := ctx.Value(loggerCtxKey)
-	if ctx == nil || value == nil {
-		return &log.Logger
-	}
-	return value.(*zerolog.Logger)
+	return zerolog.Ctx(ctx)
 }
 
 // WithLogger returns context copy with logger.
+//
+// Deprecated: Use log.Logger.WithContext(ctx) instead.
 func WithLogger(ctx context.Context, logger *zerolog.Logger) context.Context {
-	return context.WithValue(ctx, loggerCtxKey, logger)
+	return logger.WithContext(ctx)
 }

--- a/internal/dao/dao_transaction.go
+++ b/internal/dao/dao_transaction.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/db"
 	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
 )
 
 // A TxFn is a function that will be called with an initialized `Transaction` object
@@ -16,7 +16,7 @@ type TxFn func(tx pgx.Tx) error
 // WithTransaction creates a new transaction and handles rollback/commit based on the
 // error object returned by the `TxFn` or when it panics.
 func WithTransaction(ctx context.Context, fn TxFn) error {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	tx, beginErr := db.Pool.Begin(ctx)
 	if beginErr != nil {
 		logger.Warn().Err(beginErr).Msg("Cannot begin database transaction")

--- a/internal/dao/pgx/service_pgx.go
+++ b/internal/dao/pgx/service_pgx.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/db"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/georgysavva/scany/v2/pgxscan"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -47,7 +47,7 @@ func UnscopedUpdatePubkey(ctx context.Context, pubkey *models.Pubkey) error {
 func (x *serviceDao) RecalculatePubkeyFingerprints(ctx context.Context) (int, error) {
 	total := 0
 	query := `SELECT * FROM pubkeys WHERE type = '' OR type = 'test' OR fingerprint LIKE 'SHA256:%' OR fingerprint = '' OR fingerprint_legacy = ''`
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 
 	rows, err := db.Pool.Query(ctx, query)
 	if err != nil {

--- a/internal/headers/headers.go
+++ b/internal/headers/headers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/rs/zerolog"
 )
 
 func basicAuth(username, password string) string {
@@ -17,7 +18,7 @@ func basicAuth(username, password string) string {
 
 func addIdentityHeader(ctx context.Context, req *http.Request, username, password string) error {
 	if username != "" && password != "" {
-		ctxval.Logger(ctx).Warn().Msgf("Username/password authentication: %s", username)
+		zerolog.Ctx(ctx).Warn().Msgf("Username/password authentication: %s", username)
 		req.Header.Add("Authorization", "Basic "+basicAuth(username, password))
 	} else {
 		req.Header.Set("X-RH-Identity", identity.GetIdentityHeader(ctx))

--- a/internal/jobs/common.go
+++ b/internal/jobs/common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/metrics"
 	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
+	"github.com/rs/zerolog"
 )
 
 const TraceName = telemetry.TracePrefix + "internal/jobs"
@@ -25,7 +26,7 @@ func finishJob(ctx context.Context, reservationId int64, jobErr error) {
 }
 
 func finishWithSuccess(ctx context.Context, reservationId int64) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		// the original context is expired and unusable at this point
 		ctx = ctxval.Copy(ctx)
@@ -55,7 +56,7 @@ func finishWithSuccess(ctx context.Context, reservationId int64) {
 // finishWithError closes a reservation and sets it into error state. Error message is also
 // stored into the reservation.
 func finishWithError(ctx context.Context, reservationId int64, jobError error) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		// the original context is expired and unusable at this point
 		ctx = ctxval.Copy(ctx)
@@ -87,7 +88,7 @@ func updateStatusBefore(ctx context.Context, id int64, status string) {
 // updateStatusAfter is called after every step function within a job. It updates reservation status
 // message and step counter. When context deadline was exceeded, it sets the status message to "Timeout".
 func updateStatusAfter(ctx context.Context, id int64, status string, addSteps int) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		status = "Timeout"
 		// the original context is expired and unusable at this point

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/userdata"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/rs/zerolog"
 )
 
 type LaunchInstanceAWSTaskArgs struct {
@@ -47,12 +47,12 @@ func HandleLaunchInstanceAWS(ctx context.Context, job *worker.Job) {
 	args, ok := job.Args.(LaunchInstanceAWSTaskArgs)
 	if !ok {
 		err := fmt.Errorf("%w: job %s, reservation: %#v", ErrTypeAssertion, job.ID, job.Args)
-		ctxval.Logger(ctx).Error().Err(err).Msg("Type assertion error for job")
+		zerolog.Ctx(ctx).Error().Err(err).Msg("Type assertion error for job")
 		return
 	}
 
-	logger := ctxval.Logger(ctx).With().Int64("reservation_id", args.ReservationID).Logger()
-	ctx = ctxval.WithLogger(ctx, &logger)
+	logger := zerolog.Ctx(ctx).With().Int64("reservation_id", args.ReservationID).Logger()
+	ctx = logger.WithContext(ctx)
 
 	jobErr := DoEnsurePubkeyOnAWS(ctx, &args)
 	if jobErr != nil {
@@ -72,7 +72,7 @@ func HandleLaunchInstanceAWS(ctx context.Context, job *worker.Job) {
 
 // Job logic, when error is returned the job status is updated accordingly
 func DoEnsurePubkeyOnAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) error {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Started pubkey upload AWS job")
 
 	logger.Info().Interface("args", args).Msg("Processing pubkey upload AWS job")
@@ -155,7 +155,7 @@ func DoEnsurePubkeyOnAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) e
 }
 
 func DoLaunchInstanceAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) error {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Started launch instance AWS job")
 
 	logger.Info().Interface("args", args).Msg("Processing launch instance AWS job")
@@ -225,7 +225,7 @@ func DoLaunchInstanceAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) e
 }
 
 func FetchInstancesDescriptionAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) error {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Started fetch instances description")
 
 	updateStatusBefore(ctx, args.ReservationID, "Fetching instance(s) description")

--- a/internal/jobs/launch_instance_gcp.go
+++ b/internal/jobs/launch_instance_gcp.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/gcp"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	"github.com/RHEnVision/provisioning-backend/internal/userdata"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
+	"github.com/rs/zerolog"
 )
 
 type LaunchInstanceGCPTaskArgs struct {
@@ -39,12 +39,12 @@ func HandleLaunchInstanceGCP(ctx context.Context, job *worker.Job) {
 	args, ok := job.Args.(LaunchInstanceGCPTaskArgs)
 	if !ok {
 		err := fmt.Errorf("%w: job %s, reservation: %#v", ErrTypeAssertion, job.ID, job.Args)
-		ctxval.Logger(ctx).Error().Err(err).Msg("Type assertion error for job")
+		zerolog.Ctx(ctx).Error().Err(err).Msg("Type assertion error for job")
 		return
 	}
 
-	logger := ctxval.Logger(ctx).With().Int64("reservation_id", args.ReservationID).Logger()
-	ctx = ctxval.WithLogger(ctx, &logger)
+	logger := zerolog.Ctx(ctx).With().Int64("reservation_id", args.ReservationID).Logger()
+	ctx = logger.WithContext(ctx)
 
 	jobErr := DoLaunchInstanceGCP(ctx, &args)
 
@@ -53,7 +53,7 @@ func HandleLaunchInstanceGCP(ctx context.Context, job *worker.Job) {
 
 // Job logic, when error is returned the job status is updated accordingly
 func DoLaunchInstanceGCP(ctx context.Context, args *LaunchInstanceGCPTaskArgs) error {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Started launch instance GCP job")
 	logger.Info().Interface("args", args).Msg("Processing launch instance GCP job")
 

--- a/internal/jobs/noop_job.go
+++ b/internal/jobs/noop_job.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
+	"github.com/rs/zerolog"
 )
 
 type NoopJobArgs struct {
@@ -23,12 +23,12 @@ func HandleNoop(ctx context.Context, job *worker.Job) {
 	args, ok := job.Args.(NoopJobArgs)
 	if !ok {
 		err := fmt.Errorf("%w: job %s, reservation: %#v", ErrTypeAssertion, job.ID, job.Args)
-		ctxval.Logger(ctx).Error().Err(err).Msg("Type assertion error for job")
+		zerolog.Ctx(ctx).Error().Err(err).Msg("Type assertion error for job")
 		return
 	}
 
-	logger := ctxval.Logger(ctx).With().Int64("reservation_id", args.ReservationID).Logger()
-	ctx = ctxval.WithLogger(ctx, &logger)
+	logger := zerolog.Ctx(ctx).With().Int64("reservation_id", args.ReservationID).Logger()
+	ctx = logger.WithContext(ctx)
 
 	jobErr := DoNoop(ctx, &args)
 
@@ -37,7 +37,7 @@ func HandleNoop(ctx context.Context, job *worker.Job) {
 
 // Job logic, when error is returned the job status is updated accordingly
 func DoNoop(ctx context.Context, args *NoopJobArgs) error {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 
 	// status updates before and after the code logic
 	updateStatusBefore(ctx, args.ReservationID, "No operation started")

--- a/internal/kafka/noop.go
+++ b/internal/kafka/noop.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/rs/zerolog"
 )
 
 // Broker that does nothing
@@ -13,12 +13,12 @@ type noopBroker struct{}
 var _ Broker = &noopBroker{}
 
 func (s *noopBroker) Consume(ctx context.Context, topic string, since time.Time, handler func(ctx context.Context, message *GenericMessage)) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	logger.Warn().Msg("Consume loop not started (Kafka not configured)")
 }
 
 func (s *noopBroker) Send(ctx context.Context, messages ...*GenericMessage) error {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	logger.Warn().Msgf("Throwing away %d messages (Kafka not configured)", len(messages))
 
 	return nil

--- a/internal/middleware/account.go
+++ b/internal/middleware/account.go
@@ -11,6 +11,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/version"
 	ucontext "github.com/Unleash/unleash-client-go/v3/context"
+	"github.com/rs/zerolog/log"
 )
 
 func AccountMiddleware(next http.Handler) http.Handler {
@@ -18,8 +19,7 @@ func AccountMiddleware(next http.Handler) http.Handler {
 		rhId := ctxval.Identity(r.Context())
 		orgID := rhId.Identity.OrgID
 		accountNumber := rhId.Identity.AccountNumber
-		logger := ctxval.Logger(r.Context()).With().Str("account_number", accountNumber).
-			Str("org_id", orgID).Logger()
+		logger := log.Ctx(r.Context()).With().Str("account_number", accountNumber).Str("org_id", orgID).Logger()
 
 		cachedAccount := &models.Account{}
 		err := cache.Find(r.Context(), orgID+accountNumber, cachedAccount)

--- a/internal/middleware/account.go
+++ b/internal/middleware/account.go
@@ -58,7 +58,7 @@ func AccountMiddleware(next http.Handler) http.Handler {
 			Str("org_id", cachedAccount.OrgID).
 			Str("account_number", cachedAccount.AccountNumber.String).
 			Logger()
-		ctx = ctxval.WithLogger(ctx, &newLogger)
+		ctx = newLogger.WithContext(ctx)
 
 		// unleash context
 		uctx := ucontext.Context{

--- a/internal/middleware/correlation_id.go
+++ b/internal/middleware/correlation_id.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/rs/zerolog"
 )
 
 func CorrelationID(next http.Handler) http.Handler {
@@ -15,9 +16,9 @@ func CorrelationID(next http.Handler) http.Handler {
 			ctx = ctxval.WithCorrelationId(ctx, corrId)
 			// Store in response headers for easier debugging
 			w.Header().Set("X-Correlation-Id", corrId)
-			logger := ctxval.Logger(ctx).With().Str("correlation_id", corrId).Logger()
+			logger := zerolog.Ctx(ctx).With().Str("correlation_id", corrId).Logger()
 			logger.Trace().Msgf("Added correlation id %s to logger", corrId)
-			ctx = ctxval.WithLogger(ctx, &logger)
+			ctx = logger.WithContext(ctx)
 		}
 
 		next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/middleware/enforce_identity.go
+++ b/internal/middleware/enforce_identity.go
@@ -10,8 +10,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/rs/zerolog"
 )
 
 var (
@@ -20,7 +20,7 @@ var (
 )
 
 func doError(ctx context.Context, w http.ResponseWriter, code int, reason string) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	logger.Warn().Msgf("Failed to enforce the Identity header: %s", reason)
 	http.Error(w, reason, code)
 }
@@ -29,7 +29,7 @@ func doError(ctx context.Context, w http.ResponseWriter, code int, reason string
 // request context.  If the Identity is invalid, the request will be aborted.
 func EnforceIdentity(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger := ctxval.Logger(r.Context())
+		logger := zerolog.Ctx(r.Context())
 		rawHeaders := r.Header["X-Rh-Identity"]
 
 		// must have an x-rh-id header

--- a/internal/middleware/etag_middleware.go
+++ b/internal/middleware/etag_middleware.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/rs/zerolog"
 )
 
 // An InstanceTypeExpiration represents the default expiration time for instance types
@@ -50,7 +50,7 @@ func ETagMiddleware(etagFunc ETagValueFunc) func(next http.Handler) http.Handler
 			cc := etag.CacheControlHeader()
 			w.Header().Set("ETag", etag.Header())
 			w.Header().Set("Cache-Control", cc)
-			logger := ctxval.Logger(r.Context()).With().Str("etag", etag.Value).Str("etag_name", etag.Name).Logger()
+			logger := zerolog.Ctx(r.Context()).With().Str("etag", etag.Value).Str("etag_name", etag.Name).Logger()
 			logger.Trace().Msgf("Returned etag with Cache-Control '%s'", cc)
 
 			if match := r.Header.Get("If-None-Match"); match != "" {

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -63,7 +63,8 @@ func LoggerMiddleware(rootLogger *zerolog.Logger) func(next http.Handler) http.H
 						r.Method, r.URL.Path, duration.Round(time.Millisecond).String(), ww.Status())
 			}()
 
-			ctx := ctxval.WithLogger(r.Context(), &logger)
+			// store logger under zerolog context key
+			ctx := logger.WithContext(r.Context())
 			next.ServeHTTP(ww, r.WithContext(ctx))
 		}
 		return http.HandlerFunc(fn)

--- a/internal/migrations/code/update_fingerprints.go
+++ b/internal/migrations/code/update_fingerprints.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/rs/zerolog"
 )
 
 // UpdateFingerprints calls appropriate DAO function, see the DAO interface for docs.
@@ -15,6 +15,6 @@ func UpdateFingerprints(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error when updating fingerprints: %w", err)
 	}
-	ctxval.Logger(ctx).Info().Msgf("Total number of updated pubkey records: %d", count)
+	zerolog.Ctx(ctx).Info().Msgf("Total number of updated pubkey records: %d", count)
 	return nil
 }

--- a/internal/models/pubkey_model.go
+++ b/internal/models/pubkey_model.go
@@ -3,8 +3,8 @@ package models
 import (
 	"context"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/ssh"
+	"github.com/rs/zerolog"
 )
 
 // Pubkey represents SSH public key that can be deployed to clients.
@@ -45,7 +45,7 @@ func (pk *Pubkey) FindAwsFingerprint(ctx context.Context) string {
 	case "ssh-rsa":
 		fp, err := ssh.GenerateAWSFingerprint([]byte(pk.Body))
 		if err != nil {
-			ctxval.Logger(ctx).Warn().Err(err).Msg("Unable to generate AWS fingerprint for pubkey")
+			zerolog.Ctx(ctx).Warn().Err(err).Msg("Unable to generate AWS fingerprint for pubkey")
 			return ""
 		}
 		return string(fp)

--- a/internal/models/transformer.go
+++ b/internal/models/transformer.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/ssh"
 	"github.com/go-playground/mold/v4"
+	"github.com/rs/zerolog"
 )
 
 var transform *mold.Transformer
@@ -31,7 +31,7 @@ func generateFingerprints(ctx context.Context, sl mold.StructLevel) error {
 
 	pkf, err := ssh.GenerateOpenSSHFingerprints([]byte(pk.Body))
 	if err != nil {
-		ctxval.Logger(ctx).Warn().Err(err).Str("pubkey", pk.Body).Msg("OpenSSH fingerprint generation error")
+		zerolog.Ctx(ctx).Warn().Err(err).Str("pubkey", pk.Body).Msg("OpenSSH fingerprint generation error")
 		return fmt.Errorf("key generate error %s: %w", pk.Name, err)
 	}
 
@@ -55,7 +55,7 @@ func validateAWS(ctx context.Context, sl mold.StructLevel) error {
 
 	_, err := ssh.GenerateAWSFingerprint([]byte(pk.Body))
 	if err != nil {
-		ctxval.Logger(ctx).Warn().Err(err).Str("pubkey", pk.Body).Msg("AWS fingerprint validation error")
+		zerolog.Ctx(ctx).Warn().Err(err).Str("pubkey", pk.Body).Msg("AWS fingerprint validation error")
 		return fmt.Errorf("invalid public key type (only ed25519 and rsa keys are supported): %w", err)
 	}
 	sl.Struct().Set(reflect.ValueOf(pk))

--- a/internal/models/validator.go
+++ b/internal/models/validator.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/go-playground/validator/v10"
+	"github.com/rs/zerolog"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -24,7 +24,7 @@ func Validate(ctx context.Context, model interface{}) validator.ValidationErrors
 	err := validate.StructCtx(ctx, model)
 	var validationError validator.ValidationErrors
 	if err != nil && !errors.As(err, &validationError) {
-		ctxval.Logger(ctx).Fatal().Msgf("Invalid model passed for validation: %v", model)
+		zerolog.Ctx(ctx).Fatal().Msgf("Invalid model passed for validation: %v", model)
 		panic(err)
 	}
 	return validationError

--- a/internal/payloads/error_payload.go
+++ b/internal/payloads/error_payload.go
@@ -53,9 +53,9 @@ func NewResponseError(ctx context.Context, status int, userMsg string, err error
 	var strError string
 
 	if status < 500 {
-		event = ctxval.Logger(ctx).Warn().Stack()
+		event = zerolog.Ctx(ctx).Warn().Stack()
 	} else {
-		event = ctxval.Logger(ctx).Error().Stack()
+		event = zerolog.Ctx(ctx).Error().Stack()
 	}
 	if err != nil {
 		event = event.Err(err)

--- a/internal/queue/jq/worker.go
+++ b/internal/queue/jq/worker.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/jobs"
 	"github.com/RHEnVision/provisioning-backend/internal/queue"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
@@ -59,13 +58,13 @@ func Initialize(_ context.Context, logger *zerolog.Logger) error {
 }
 
 func StartDequeueLoop(ctx context.Context) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Starting dequeue loop")
 	workers.DequeueLoop(ctx)
 }
 
 func StopDequeueLoop(ctx context.Context) {
-	logger := ctxval.Logger(ctx)
+	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Stopping dequeue loop")
 	workers.Stop(ctx)
 }
@@ -73,7 +72,7 @@ func StopDequeueLoop(ctx context.Context) {
 func Stats(ctx context.Context) worker.Stats {
 	stats, err := workers.Stats(ctx)
 	if err != nil {
-		ctxval.Logger(ctx).Error().Err(err).Msg("Unable to get queue stats")
+		zerolog.Ctx(ctx).Error().Err(err).Msg("Unable to get queue stats")
 		return worker.Stats{}
 	}
 

--- a/internal/services/aws_iam_service.go
+++ b/internal/services/aws_iam_service.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
+	"github.com/rs/zerolog"
 )
 
 func ValidatePermissions(w http.ResponseWriter, r *http.Request) {
-	logger := ctxval.Logger(r.Context())
+	logger := zerolog.Ctx(r.Context())
 	sourceId := chi.URLParam(r, "ID")
 	region := r.URL.Query().Get("region")
 

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -18,10 +18,11 @@ import (
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
 	"github.com/go-chi/render"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/rs/zerolog"
 )
 
 func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
-	logger := *ctxval.Logger(r.Context())
+	logger := *zerolog.Ctx(r.Context())
 
 	var accountId int64 = ctxval.AccountId(r.Context())
 	var id identity.XRHID = ctxval.Identity(r.Context())

--- a/internal/services/azure_reservation_service.go
+++ b/internal/services/azure_reservation_service.go
@@ -17,10 +17,11 @@ import (
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
 	"github.com/go-chi/render"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 )
 
 func CreateAzureReservation(w http.ResponseWriter, r *http.Request) {
-	logger := *ctxval.Logger(r.Context())
+	logger := *zerolog.Ctx(r.Context())
 
 	payload := &payloads.AzureReservationRequestPayload{}
 	if err := render.Bind(r, payload); err != nil {

--- a/internal/services/builtin_types_service.go
+++ b/internal/services/builtin_types_service.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/render"
+	"github.com/rs/zerolog"
 )
 
 type InstanceTypesForZoneFunc func(region, zone string, supported *bool) ([]*clients.InstanceType, error)
@@ -30,7 +30,7 @@ func ListBuiltinInstanceTypes(typeFunc InstanceTypesForZoneFunc) func(w http.Res
 
 		start := time.Now()
 		instances, err := typeFunc(region, zone, supported)
-		logger := ctxval.Logger(r.Context())
+		logger := zerolog.Ctx(r.Context())
 		logger.Trace().TimeDiff("duration", time.Now(), start).Msg("Listed instance types")
 		if err != nil {
 			renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "instance types not found for selected region and zone", err))

--- a/internal/services/error_renderer.go
+++ b/internal/services/error_renderer.go
@@ -9,12 +9,13 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/render"
+	"github.com/rs/zerolog"
 )
 
 // writeBasicError returns an error code without utilizing the Chi rendering stack. It can
 // be used for fatal errors which happens during rendering pipeline (e.g. JSON errors).
 func writeBasicError(w http.ResponseWriter, r *http.Request, err error) {
-	if logger := ctxval.Logger(r.Context()); logger != nil {
+	if logger := zerolog.Ctx(r.Context()); logger != nil {
 		logger.Error().Err(err).Msg("Unable to render error")
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/internal/services/gcp_reservation_service.go
+++ b/internal/services/gcp_reservation_service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/preload"
 	"github.com/google/uuid"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/rs/zerolog"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
@@ -20,7 +21,7 @@ import (
 )
 
 func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
-	logger := *ctxval.Logger(r.Context())
+	logger := *zerolog.Ctx(r.Context())
 
 	var accountId int64 = ctxval.AccountId(r.Context())
 	var id identity.XRHID = ctxval.Identity(r.Context())

--- a/internal/services/noop_reservation_service.go
+++ b/internal/services/noop_reservation_service.go
@@ -11,12 +11,13 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/queue"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
 	"github.com/go-chi/render"
+	"github.com/rs/zerolog"
 )
 
 // CreateNoopReservation is used to create empty reservation that is processed without any operation
 // being made. This is useful when testing the job queue. The endpoint has no payload.
 func CreateNoopReservation(w http.ResponseWriter, r *http.Request) {
-	logger := ctxval.Logger(r.Context())
+	logger := zerolog.Ctx(r.Context())
 	accountId := ctxval.AccountId(r.Context())
 	identity := ctxval.Identity(r.Context())
 	rDao := dao.GetReservationDao(r.Context())

--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	httpClients "github.com/RHEnVision/provisioning-backend/internal/clients/http"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/db"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/render"
+	"github.com/rs/zerolog"
 )
 
 var ErrMissingNameOrBody = errors.New("name or body missing")
@@ -83,7 +83,7 @@ func GetPubkey(w http.ResponseWriter, r *http.Request) {
 }
 
 func DeletePubkey(w http.ResponseWriter, r *http.Request) {
-	logger := ctxval.Logger(r.Context())
+	logger := zerolog.Ctx(r.Context())
 	sourcesClient, err := clients.GetSourcesClient(r.Context())
 	if err != nil {
 		renderError(w, r, payloads.NewClientError(r.Context(), err))

--- a/internal/testing/integration/config_env.go
+++ b/internal/testing/integration/config_env.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/RHEnVision/provisioning-backend/internal/logging"
 	"github.com/rs/zerolog/log"
 )
@@ -12,5 +11,5 @@ import (
 func InitConfigEnvironment(ctx context.Context, envPath string) context.Context {
 	config.Initialize("config/test.env", envPath)
 	logging.InitializeStdout()
-	return ctxval.WithLogger(ctx, &log.Logger)
+	return log.Logger.WithContext(ctx)
 }

--- a/pkg/worker/job.go
+++ b/pkg/worker/job.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
+	"github.com/rs/zerolog"
 
 	"github.com/google/uuid"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
@@ -75,12 +76,12 @@ type Stats struct {
 func contextLogger(ctx context.Context, job *Job) context.Context {
 	accountId := job.AccountID
 	id := job.Identity
-	logger := ctxval.Logger(ctx).With().
+	logger := zerolog.Ctx(ctx).With().
 		Str("job_id", job.ID.String()).
 		Int64("account_id", accountId).
 		Str("account_number", id.Identity.AccountNumber).
 		Str("org_id", id.Identity.OrgID).Logger()
-	newContext := ctxval.WithLogger(ctx, &logger)
+	newContext := logger.WithContext(ctx)
 	newContext = ctxval.WithIdentity(newContext, id)
 	newContext = ctxval.WithAccountId(newContext, accountId)
 

--- a/pkg/worker/memory.go
+++ b/pkg/worker/memory.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/RHEnVision/provisioning-backend/internal/config"
-	"github.com/RHEnVision/provisioning-backend/internal/ctxval"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 )
 
 type MemoryWorker struct {
@@ -44,7 +44,7 @@ func (w *MemoryWorker) Stop(_ context.Context) {
 }
 
 func (w *MemoryWorker) DequeueLoop(ctx context.Context) {
-	ctxval.Logger(ctx).Info().Msg("Starting memory dequeuer")
+	zerolog.Ctx(ctx).Info().Msg("Starting memory dequeuer")
 	go w.dequeueLoop(ctx)
 }
 
@@ -61,7 +61,7 @@ func (w *MemoryWorker) processJob(ctx context.Context, job *Job) {
 		defer cFunc()
 		h(cCtx, job)
 	} else {
-		ctxval.Logger(ctx).Warn().Msgf("Memory worker handler not found for job type: %s", job.Type)
+		zerolog.Ctx(ctx).Warn().Msgf("Memory worker handler not found for job type: %s", job.Type)
 	}
 }
 


### PR DESCRIPTION
I made a terrible mistake with introducing `ctxval` package. Context function should have been part of package they belong to, this creates unnecessary import hell and cycles around the codebase because pretty much every function uses `ctxval.Logger` function.

Turns out this function is not needed at all, because zerolog provides the way to do the exactly the same:

    logger := zerolog.Ctx(ctx)

is the same as 

    logger := zerolog.Ctx(ctx)

To create a new context (we do this in the middleware) it is also easy:

    ctx := zerolog.WIthContext(ctx)

This patch is a proposal to deprecate the `ctxval.Logger` function pair so we can slowly and gradually get rid of it. I do not plan any "big bang" patch that would replace all the occurances across the codebase, this would create unnecessary conflicts.