### PR TITLE
chore: change SLO on the dashboard back

### DIFF
--- a/deploy/Provisioning-1674548289785.json
+++ b/deploy/Provisioning-1674548289785.json
@@ -24,6 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 114514,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1001,13 +1002,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"500\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
+          "expr": "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"750\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
           "hide": false,
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "HTTP Success Latency 500ms Target",
+      "title": "HTTP Success Latency 750ms Target",
       "type": "stat"
     },
     {

--- a/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
@@ -35,6 +35,7 @@ data:
        "editable" : true,
        "fiscalYearStartMonth" : 0,
        "graphTooltip" : 0,
+       "id" : 114514,
        "links" : [],
        "liveNow" : false,
        "panels" : [
@@ -1012,13 +1013,13 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"500\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
+                   "expr" : "sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"750\"}[$__range])) / sum(rate(provisioning_http_request_duration_ms_bucket{code=~\"2.*\", le=\"+Inf\"}[$__range]))",
                    "hide" : false,
                    "range" : true,
                    "refId" : "A"
                 }
              ],
-             "title" : "HTTP Success Latency 500ms Target",
+             "title" : "HTTP Success Latency 750ms Target",
              "type" : "stat"
           },
           {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -57,7 +57,7 @@ var BackgroundJobDuration = prometheus.NewHistogramVec(
 		Name:        "provisioning_background_job_duration",
 		Help:        "task queue job duration (in seconds) by type",
 		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName, "component": "worker"},
-		Buckets:     []float64{1, 4, 5, 10, 30, 60 * 2, 60 * 5, 60 * 10, 60 * 20, 60 * 30, 60 * 60},
+		Buckets:     []float64{0.5, 1, 2, 3, 4, 5, 7, 10, 30, 60 * 2, 60 * 10, 60 * 30},
 	},
 	[]string{"type"},
 )


### PR DESCRIPTION
We increased it to 5000ms for Summit but now that we have pushed to prod and new buckets include 750, 1000 and 2000ms we can lower it back.

I propose 750ms it has been 100% for last 24 hours. I will raise app-interface change once this is merged.