### PR TITLE
chore: add azure and templates to floorist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ TAGS
 /pbmigrate
 /pbworker
 /pbstatuser
+/cmd/pbackend/pbackend
 /generate_spec
 /vendor/
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -345,16 +345,42 @@ objects:
       queries:
         - prefix: ${FLOORIST_QUERY_PREFIX}/reservations
           query: >-
-            select r.created_at, r.finished_at, r.success,
-                   a.account_number, a.org_id, d.source_id,
-                   d.detail->'instance_type' as type,
-                   d.detail->'region' as region,
-                   d.detail->'amount' as amount
+            (select 'aws'                                        as provider,
+            r.created_at,
+            r.finished_at,
+            r.success,
+            a.account_number,
+            a.org_id,
+            d.source_id,
+            d.detail -> 'instance_type'                  as type,
+            d.detail -> 'region'                         as region,
+            d.detail -> 'amount'                         as amount,
+            d.detail -> 'launch_template_id' is not null as template
             from reservations r
             join aws_reservation_details d on r.id = d.reservation_id
             join accounts a on r.account_id = a.id
             where provider = provider_type_aws()
-            order by r.created_at;
+            order by r.created_at)
+
+            union all
+
+            (select 'azure'                     as provider,
+            r.created_at,
+            r.finished_at,
+            r.success,
+            a.account_number,
+            a.org_id,
+            d.source_id,
+            d.detail -> 'instance_size' as type,
+            d.detail -> 'location'      as region,
+            d.detail -> 'amount'        as amount,
+            false                       as template
+            from reservations r
+            join azure_reservation_details d on r.id = d.reservation_id
+            join accounts a on r.account_id = a.id
+            where provider = provider_type_azure()
+            order by r.created_at);
+
 
 # possible application ENV variables are in config/api.env.example
 parameters:


### PR DESCRIPTION
This patch adds a new column called "template" which is a boolean with the meaning if a Launch Template was used during operation.

It also adds Azure data to the same template merging data into single dataset. A new column called "provider" with either "aws" or "azure" values was added so we can perform some common statistics on top of all providers. Note that those providers have different regions/locations and instance types and since the terminology and our database fields differ, I propose to simply use the current column names which come from AWS terminology.

In addition, the "template" is currently always "false" as Azure not yet support Launch Templates.

Example output:

| provider | created\_at | finished\_at | success | account\_number | org\_id | source\_id | type | region | amount | template |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| aws | 2023-05-31 11:24:03.757727 | 2023-05-31 11:24:09.891890 | true | 6395343 | 13446659 | 1 | "t2.nano" | "us-east-1" | 1 | true |
| azure | 2023-05-31 11:25:37.505962 | 2023-05-31 11:25:37.953646 | false | 6395343 | 13446659 | 2 | "Standard\_B1ls" | "eastus\_1" | 1 | false |

