### PR TITLE
fix(HMS-1884): return 400 on invalid compose ID

### DIFF
--- a/internal/clients/errors.go
+++ b/internal/clients/errors.go
@@ -8,6 +8,7 @@ import (
 var (
 	// Common errors
 	HttpClientErr     = errors.New("HTTP client")
+	BadRequestErr     = fmt.Errorf("%w: backend service returned bad request (400)", HttpClientErr)
 	NotFoundErr       = fmt.Errorf("%w: backend service returned not found (404) or no data", HttpClientErr)
 	UnauthorizedErr   = fmt.Errorf("%w: backend service returned unauthorized (401)", HttpClientErr)
 	ForbiddenErr      = fmt.Errorf("%w: backend service returned forbidden (403)", HttpClientErr)

--- a/internal/clients/http/image_builder/image_client.go
+++ b/internal/clients/http/image_builder/image_client.go
@@ -61,6 +61,9 @@ func (c *ibClient) Ready(ctx context.Context) error {
 
 func (c *ibClient) GetAWSAmi(ctx context.Context, composeID string) (string, error) {
 	logger := logger(ctx)
+	if _, err := uuid.Parse(composeID); err != nil {
+		return "", fmt.Errorf("compose ID '%s' is not valid UUID: %w", composeID, clients.BadRequestErr)
+	}
 	logger.Trace().Str("compose_id", composeID).Msgf("Getting AMI of compose ID %v", composeID)
 
 	imageStatus, err := c.fetchImageStatus(ctx, composeID)

--- a/internal/clients/http/sources_errors.go
+++ b/internal/clients/http/sources_errors.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
@@ -11,7 +10,7 @@ var (
 	ApplicationNotFoundErr              = fmt.Errorf("application not found is sources app: %w", clients.NotFoundErr)
 	ApplicationTypeNotFoundErr          = fmt.Errorf("application type 'provisioning' not found: %w", clients.NotFoundErr)
 	SourceNotFoundErr                   = fmt.Errorf("source not found: %w", clients.NotFoundErr)
-	AuthenticationSourceAssociationErr  = errors.New("authentication associated to source id not found")
+	AuthenticationSourceAssociationErr  = fmt.Errorf("authentication associated to source id not found in sources app: %w", clients.NotFoundErr)
 	AuthenticationForSourcesNotFoundErr = fmt.Errorf("authentications for source weren't found in sources app: %w", clients.NotFoundErr)
 	ApplicationReadErr                  = fmt.Errorf("application read returned no application type in sources: %w", clients.NotFoundErr)
 	SourceTypeNameNotFoundErr           = fmt.Errorf("source type name not found: %w", clients.NotFoundErr)

--- a/internal/payloads/error_payload_test.go
+++ b/internal/payloads/error_payload_test.go
@@ -1,0 +1,38 @@
+package payloads
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	httpClients "github.com/RHEnVision/provisioning-backend/internal/clients/http"
+)
+
+func TestFindUserPayload(t *testing.T) {
+	type test struct {
+		input error
+		want  *userPayload
+	}
+
+	tests := []test{
+		{
+			clients.HttpClientErr,
+			&userPayload{500, "unknown backend client error"},
+		},
+		{
+			httpClients.CloneNotFoundErr,
+			&userPayload{404, "image builder could not find compose clone"},
+		},
+		{
+			clients.MissingProvisioningSources,
+			&userPayload{500, "backend service missing provisioning source"},
+		},
+	}
+
+	for _, tc := range tests {
+		got := findUserPayload(tc.input)
+		if !reflect.DeepEqual(tc.want, got) {
+			t.Fatalf("expected: %v, got: %v", tc.want, got)
+		}
+	}
+}

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -128,6 +128,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 		// Direct AMI or no image were provided (launch template), no need to call image builder
 		ami = reservation.ImageID
 	} else {
+		// Not prefixed with "ami-" therefore this must be a valid UUID
 		// Get Image builder client
 		IBClient, ibErr := clients.GetImageBuilderClient(r.Context())
 		logger.Trace().Msg("Creating IB client")


### PR DESCRIPTION
We need to return 400 not 500 on invalid compose ID.

Also refactors error handling a bit, it is now more generic and straightforward.