### PR TITLE
chore: do not allow override of GOROOT

### DIFF
--- a/mk/0_initial.mk
+++ b/mk/0_initial.mk
@@ -10,7 +10,7 @@ GIT_TAG?=$(shell git describe --tags --abbrev=0 2>/dev/null)
 GO_VERSION?=1.19.6
 GOBIN:=$(PROJECT_DIR)/bin
 GO?=$(shell go env GOPATH)/bin/go$(GO_VERSION)
-GOROOT?=$(shell $(GO) env GOROOT)
+GOROOT=$(shell $(GO) env GOROOT)
 GOCACHE?=$(shell $(GO) env GOCACHE)
 
 GOLINT?=$(GOBIN)/golangci-lint


### PR DESCRIPTION
When you have GOROOT set in your profile, the makefile would use it instead of wanted GOROOT from the Go 1.19.6 (the current version), this fails the linter because it would use Go version which was set by environmental variable.

We don’t want that, this change will override any previous GOROOT setting from the environment so the proper Go version is ensured.