### PR TITLE
chore: log job cancellation to error level (Glitchtip)

### DIFF
--- a/pkg/worker/redis.go
+++ b/pkg/worker/redis.go
@@ -201,7 +201,10 @@ func (w *RedisWorker) processJob(ctx context.Context, job *Job) {
 	ctx = contextLogger(ctx, job)
 	if h, ok := w.handlers[job.Type]; ok {
 		cCtx, cFunc := context.WithTimeout(ctx, config.Worker.Timeout)
-		defer cFunc()
+		defer func() {
+			zerolog.Ctx(ctx).Error().Bool("timeout", true).Msg("Job cancelled")
+			cFunc()
+		}()
 		metrics.ObserveBackgroundJobDuration(job.Type.String(), func() {
 			h(cCtx, job)
 		})


### PR DESCRIPTION
I would like to know when a job expired to be able to easily find it by job id. This will create an error log entry and also sentry error so we can track these easily.