### PR TITLE
feat(HMS-1932): Add gcp source upload info

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -372,6 +372,7 @@
             "account_id": "78462784632"
           },
           "azure": null,
+          "gcp": null,
           "provider": "aws"
         }
       },
@@ -386,6 +387,7 @@
             "subscriptionid": "617807e1-e4e0-4855-983c-1e3ce1e49674",
             "tenantid": "617807e1-e4e0-481c-983c-be3ce1e49253"
           },
+          "gcp": null,
           "provider": "azure"
         }
       }
@@ -974,6 +976,9 @@
               }
             },
             "type": "object"
+          },
+          "gcp": {
+            "nullable": true
           },
           "provider": {
             "type": "string"

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -348,6 +348,8 @@ components:
                             type: string
                         tenant_id:
                             type: string
+                gcp:
+                    nullable: true
                 provider:
                     type: string
     responses:
@@ -682,6 +684,7 @@ components:
                 aws:
                     account_id: "78462784632"
                 azure: null
+                gcp: null
                 provider: aws
         v1.SourceUploadInfoAzureResponse:
             value:
@@ -692,6 +695,7 @@ components:
                         - MyGroup 42
                     subscriptionid: 617807e1-e4e0-4855-983c-1e3ce1e49674
                     tenantid: 617807e1-e4e0-481c-983c-be3ce1e49253
+                gcp: null
                 provider: azure
 info:
     title: provisioning-api

--- a/internal/clients/source_upload_info.go
+++ b/internal/clients/source_upload_info.go
@@ -23,3 +23,5 @@ type AccountDetailsAzure struct {
 	SubscriptionID string        `json:"subscription_id"`
 	ResourceGroups []string      `json:"resource_groups"`
 }
+
+type AccountDetailsGCP struct{}

--- a/internal/payloads/sources_payload.go
+++ b/internal/payloads/sources_payload.go
@@ -40,6 +40,7 @@ type SourceUploadInfoResponse struct {
 	Provider  string                       `json:"provider" yaml:"provider"`
 	AwsInfo   *clients.AccountDetailsAWS   `json:"aws" nullable:"true" yaml:"aws"`
 	AzureInfo *clients.AccountDetailsAzure `json:"azure" nullable:"true" yaml:"azure"`
+	GcpInfo   *clients.AccountDetailsGCP   `json:"gcp" nullable:"true" yaml:"gcp"`
 }
 
 func (s SourceUploadInfoResponse) Render(_ http.ResponseWriter, _ *http.Request) error {

--- a/internal/services/sources_service.go
+++ b/internal/services/sources_service.go
@@ -106,7 +106,12 @@ func GetSourceUploadInfo(w http.ResponseWriter, r *http.Request) {
 			renderError(w, r, payloads.NewAzureError(r.Context(), "unable to fetch Azure upload info", err))
 			return
 		}
-	case models.ProviderTypeGCP, models.ProviderTypeNoop, models.ProviderTypeUnknown:
+	case models.ProviderTypeGCP:
+		if payload.GcpInfo, err = getGCPAccountDetails(r.Context(), sourceId, authentication); err != nil {
+			renderError(w, r, payloads.NewGCPError(r.Context(), "unable to get GCP upload info", err))
+			return
+		}
+	case models.ProviderTypeNoop, models.ProviderTypeUnknown:
 		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", ProviderTypeNotImplementedError))
 		return
 	}
@@ -176,4 +181,8 @@ func getAzureAccountDetails(ctx context.Context, sourceId string, authentication
 		SubscriptionID: authentication.Payload,
 		ResourceGroups: groupList,
 	}, nil
+}
+
+func getGCPAccountDetails(ctx context.Context, sourceId string, authentication *clients.Authentication) (*clients.AccountDetailsGCP, error) {
+	return &clients.AccountDetailsGCP{}, nil
 }


### PR DESCRIPTION
For the complete workflow to work from the UI the upload info logic was missing. 
In this PR:
- we are fetching the I am policy from the customer project,
- filtering to get the provisioning service account principal in order to pass into the UI

In the front, we have a validation that the principal we have fetched is equal to the email/principal that was shared with the image. 
