### PR TITLE
chore: improve job timeout logging

### DIFF
--- a/pkg/worker/redis.go
+++ b/pkg/worker/redis.go
@@ -202,7 +202,9 @@ func (w *RedisWorker) processJob(ctx context.Context, job *Job) {
 	if h, ok := w.handlers[job.Type]; ok {
 		cCtx, cFunc := context.WithTimeout(ctx, config.Worker.Timeout)
 		defer func() {
-			zerolog.Ctx(ctx).Error().Bool("timeout", true).Msg("Job cancelled")
+			if c := cCtx.Err(); c != nil {
+				zerolog.Ctx(ctx).Error().Err(c).Msg("Job was either cancelled or timeout occured")
+			}
 			cFunc()
 		}()
 		metrics.ObserveBackgroundJobDuration(job.Type.String(), func() {


### PR DESCRIPTION
It appears that we log "Job cancelled" each time a job finishes. Even for successful jobs. This fixes it.

![image](https://github.com/RHEnVision/provisioning-backend/assets/49752/dc9cf3ff-e05c-4d45-9eb9-ffd416e9e4a4)
