### PR TITLE
fix(HMS-2002): proper launch statistics

### DIFF
--- a/cmd/pbackend/main.go
+++ b/cmd/pbackend/main.go
@@ -37,6 +37,8 @@ func main() {
 		migrate()
 	case "statuser":
 		statuser()
+	case "stats":
+		stats()
 	case "version":
 		ver()
 	default:
@@ -45,7 +47,7 @@ func main() {
 }
 
 func usage() {
-	fmt.Println("Usage: pbackend [migrate|api|worker|statuser|version]")
+	fmt.Println("Usage: pbackend [migrate|api|worker|statuser|stats|version]")
 	os.Exit(1)
 }
 

--- a/cmd/pbackend/stats.go
+++ b/cmd/pbackend/stats.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/RHEnVision/provisioning-backend/internal/background"
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/db"
+	"github.com/RHEnVision/provisioning-backend/internal/logging"
+	"github.com/RHEnVision/provisioning-backend/internal/metrics"
+	"github.com/RHEnVision/provisioning-backend/internal/queue/jq"
+	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog/log"
+)
+
+func stats() {
+	ctx := context.Background()
+	config.Initialize("config/api.env", "config/stats.env")
+
+	// initialize cloudwatch using the AWS clients
+	logger, closeFunc := logging.InitializeLogger()
+	defer closeFunc()
+	logging.DumpConfigForDevelopment()
+
+	// initialize telemetry
+	tel := telemetry.Initialize(&log.Logger)
+	defer tel.Close(ctx)
+
+	// initialize the job queue but don't register any workers
+	err := jq.Initialize(ctx, &logger)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error initializing job queue")
+	}
+
+	// metrics
+	logger.Info().Msgf("Starting new instance on port %d with prometheus on %d", config.Application.Port, config.Prometheus.Port)
+	metricsRouter := chi.NewRouter()
+	metricsRouter.Handle(config.Prometheus.Path, promhttp.Handler())
+	metricsServer := http.Server{
+		Addr:    fmt.Sprintf(":%d", config.Prometheus.Port),
+		Handler: metricsRouter,
+	}
+
+	signalNotify := make(chan struct{})
+	go func() {
+		sigint := make(chan os.Signal, 1)
+		signal.Notify(sigint, syscall.SIGINT, syscall.SIGTERM)
+		<-sigint
+		if shutdownErr := metricsServer.Shutdown(context.Background()); shutdownErr != nil {
+			logger.Warn().Err(shutdownErr).Msg("Metrics service shutdown error")
+		}
+		close(signalNotify)
+	}()
+
+	go func() {
+		if listenErr := metricsServer.ListenAndServe(); listenErr != nil {
+			var errInUse syscall.Errno
+			if errors.As(listenErr, &errInUse) && errInUse == syscall.EADDRINUSE {
+				logger.Warn().Err(listenErr).Msg("Not starting metrics service, port already in use")
+			} else if !errors.Is(listenErr, http.ErrServerClosed) {
+				logger.Warn().Err(listenErr).Msg("Metrics service listen error")
+			}
+		}
+	}()
+
+	metrics.RegisterStatsMetrics()
+
+	// initialize the database
+	logger.Debug().Msg("Initializing database connection")
+	err = db.Initialize(ctx, "public")
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error initializing database")
+	}
+	defer db.Close()
+
+	// initialize background goroutines
+	bgCtx, bgCancel := context.WithCancel(ctx)
+	background.InitializeStats(bgCtx)
+	defer bgCancel()
+
+	logger.Info().Msg("Stats process started")
+	select {
+	case <-signalNotify:
+		logger.Info().Msg("Exiting due to signal")
+	}
+
+	logger.Info().Msg("Stats process shutdown initiated")
+}

--- a/config/api.env.example
+++ b/config/api.env.example
@@ -8,6 +8,10 @@
 #     	HTTP port of the API service (default "8000")
 #   APP_INSTANCE_PREFIX string
 #     	prefix for all VMs names (default "")
+#   STATS_JOBQUEUE_INTERVAL int64
+#     	how often to pull job queue statistics (default "1m")
+#   STATS_RESERVATIONS_INTERVAL int64
+#     	how often to pull reservation statistics (default "30m")
 #   DATABASE_HOST string
 #     	main database hostname (default "localhost")
 #   DATABASE_PORT uint16

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -192,8 +192,57 @@ objects:
                 value: ${APP_CACHE_TYPE}
             resources:
               limits:
-                cpu: ${{CPU_LIMIT}}
-                memory: ${MEMORY_LIMIT}
+                cpu: ${{CPU_LIMIT_SMALL}}
+                memory: ${MEMORY_LIMIT_SMALL}
+              requests:
+                cpu: ${CPU_REQUESTS}
+                memory: ${MEMORY_REQUESTS}
+        - name: stats
+          replicas: 1
+          metadata:
+            annotations:
+              ignore-check.kube-linter.io/minimum-three-replicas: "stats pod runs in a single instance"
+          podSpec:
+            image: ${IMAGE}:${IMAGE_TAG}
+            command:
+              - /pbackend
+              - stats
+            initContainers:
+              - name: run-migrations
+                image: "${IMAGE}:${IMAGE_TAG}"
+                command:
+                  - /pbackend
+                  - migrate
+                inheritEnv: true
+            env:
+              - name: LOGGING_LEVEL
+                value: ${LOGGING_LEVEL}
+              - name: REST_ENDPOINTS_TRACE_DATA
+                value: ${REST_ENDPOINTS_TRACE_DATA}
+              - name: DATABASE_LOGGING_LEVEL
+                value: ${DATABASE_LOGGING_LEVEL}
+              - name: TELEMETRY_ENABLED
+                value: ${TELEMETRY_ENABLED}
+              - name: TELEMETRY_LOGGER_ENABLED
+                value: ${TELEMETRY_LOGGER_ENABLED}
+              - name: CLOWDER_ENABLED
+                value: ${CLOWDER_ENABLED}
+              - name: APP_NOTIFICATIONS_ENABLED
+                value: ${APP_NOTIFICATIONS_ENABLED}
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: provisioning-sentry
+                    key: dsn
+                    optional: true
+              - name: APP_INSTANCE_PREFIX
+                value: ${APP_INSTANCE_PREFIX}
+              - name: APP_CACHE_TYPE
+                value: ${APP_CACHE_TYPE}
+            resources:
+              limits:
+                cpu: ${{CPU_LIMIT_SMALL}}
+                memory: ${MEMORY_LIMIT_SMALL}
               requests:
                 cpu: ${CPU_REQUESTS}
                 memory: ${MEMORY_REQUESTS}
@@ -251,7 +300,7 @@ objects:
               - name: REST_ENDPOINTS_IMAGE_BUILDER_URL
                 value: "${IMAGEBUILDER_URL}/api/image-builder/v1"
               - name: APP_NOTIFICATIONS_ENABLED
-                value: ${APP_NOTIFICATIONS_ENABLED}  
+                value: ${APP_NOTIFICATIONS_ENABLED}
               - name: AWS_KEY
                 valueFrom:
                   secretKeyRef:
@@ -369,7 +418,7 @@ objects:
             }
           ]
         }
-  
+
   - apiVersion: metrics.console.redhat.com/v1alpha1
     kind: FloorPlan
     metadata:
@@ -429,16 +478,22 @@ parameters:
   - description: ClowdEnv Name
     name: ENV_NAME
     required: true
-  - description: Cpu limit of service
+  - description: CPU limit of api and worker services
     name: CPU_LIMIT
     value: 500m
-  - description: Cpu request increment
+  - description: CPU limit of statuser and stats services
+    name: CPU_LIMIT_SMALL
+    value: 300m
+  - description: CPU request increment
     name: CPU_REQUESTS
     value: 100m
-  - description: memory limit of service
+  - description: Memory limit of api and worker services
     name: MEMORY_LIMIT
-    value: 1Gi
-  - description: memory request increment
+    value: 400m
+  - description: Memory limit of statuser and stats services
+    name: MEMORY_LIMIT_SMALL
+    value: 300m
+  - description: Memory request increment
     name: MEMORY_REQUESTS
     value: 100Mi
   - description: Image tag

--- a/internal/background/db_stats.go
+++ b/internal/background/db_stats.go
@@ -1,0 +1,53 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/RHEnVision/provisioning-backend/internal/metrics"
+	"github.com/rs/zerolog"
+)
+
+func dbStatsLoop(ctx context.Context, sleep time.Duration) {
+	logger := zerolog.Ctx(ctx)
+	logger.Debug().Msgf("Started database statistics routine")
+	defer func() {
+		logger.Debug().Msgf("Database statistics routine exited")
+	}()
+	ticker := time.NewTicker(sleep)
+
+	for {
+		select {
+		case <-ticker.C:
+			metrics.ObserveDbStatsDuration(func() {
+				err := dbStatsTick(ctx)
+				if err != nil {
+					logger.Error().Err(err).Msg("Error while performing database statistics query")
+				}
+			})
+
+		case <-ctx.Done():
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func dbStatsTick(ctx context.Context) error {
+	sdao := dao.GetStatDao(ctx)
+	stats, err := sdao.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("stats error: %w", err)
+	}
+
+	for _, s := range stats.Usage24h {
+		metrics.SetReservations24hCount(s.Result, s.Provider, s.Count)
+	}
+	for _, s := range stats.Usage28d {
+		metrics.SetReservations28dCount(s.Result, s.Provider, s.Count)
+	}
+
+	return nil
+}

--- a/internal/background/initialize.go
+++ b/internal/background/initialize.go
@@ -27,9 +27,18 @@ func InitializeApi(ctx context.Context) {
 // InitializeWorker starts background goroutines for worker processes.
 // Use context cancellation to stop them.
 func InitializeWorker(ctx context.Context) {
+	// no background goroutines at the moment
+}
+
+// InitializeStats starts background goroutines for the statuser process.
+// Use context cancellation to stop it.
+func InitializeStats(ctx context.Context) {
 	logger := zerolog.Ctx(ctx).With().Bool("background", true).Logger()
 	ctx = logger.WithContext(ctx)
 
 	// start job queue telemetry
-	go jobQueueMetricLoop(ctx, 30*time.Second, config.Hostname())
+	go jobQueueMetricLoop(ctx, config.Stats.JobQueue, config.Hostname())
+
+	// start database statistics
+	go dbStatsLoop(ctx, config.Stats.ReservationsInterval)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,10 @@ var config struct {
 			} `env-prefix:"MEM_"`
 		} `env-prefix:"CACHE_"`
 	} `env-prefix:"APP_"`
+	Stats struct {
+		JobQueue             time.Duration `env:"JOBQUEUE_INTERVAL" env-default:"1m" env-description:"how often to pull job queue statistics"`
+		ReservationsInterval time.Duration `env:"RESERVATIONS_INTERVAL" env-default:"30m" env-description:"how often to pull reservation statistics"`
+	} `env-prefix:"STATS_"`
 	Database struct {
 		Host        string        `env:"HOST" env-default:"localhost" env-description:"main database hostname"`
 		Port        uint16        `env:"PORT" env-default:"5432" env-description:"main database port"`
@@ -149,6 +153,7 @@ var config struct {
 // Config shortcuts
 var (
 	Application   = &config.App
+	Stats         = &config.Stats
 	Database      = &config.Database
 	Prometheus    = &config.Prometheus
 	Logging       = &config.Logging

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -110,3 +110,10 @@ type ReservationDao interface {
 	// Delete deletes a reservation. Only used in tests and background cleanup job. UNSCOPED.
 	Delete(ctx context.Context, id int64) error
 }
+
+var GetStatDao func(ctx context.Context) StatDao
+
+// StatDao represents an account (tenant)
+type StatDao interface {
+	Get(ctx context.Context) (*models.Statistics, error)
+}

--- a/internal/dao/pgx/stat_pgx.go
+++ b/internal/dao/pgx/stat_pgx.go
@@ -1,0 +1,67 @@
+package pgx
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/RHEnVision/provisioning-backend/internal/db"
+	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/georgysavva/scany/v2/pgxscan"
+)
+
+func init() {
+	dao.GetStatDao = getStatDao
+}
+
+type statDao struct{}
+
+func getStatDao(ctx context.Context) dao.StatDao {
+	return &statDao{}
+}
+
+func (x *statDao) getUsage(ctx context.Context, interval string) ([]*models.UsageStat, error) {
+	query := `select provider, 'success' as result, count(provider) as count
+	from reservations
+	where created_at >= now() - cast($1 as interval)
+	  and success = true
+	group by provider
+
+	union all
+
+	select provider, 'failure' as result, count(provider) as count
+	from reservations
+	where created_at >= now() - cast($1 as interval)
+	  and (success is null or success = false)
+	group by provider`
+
+	var result []*models.UsageStat
+	rows, err := db.Pool.Query(ctx, query, interval)
+	if err != nil {
+		return nil, fmt.Errorf("pgx error: %w", err)
+	}
+
+	err = pgxscan.ScanAll(&result, rows)
+	if err != nil {
+		return nil, fmt.Errorf("pgx error: %w", err)
+	}
+
+	return result, nil
+}
+
+func (x *statDao) Get(ctx context.Context) (*models.Statistics, error) {
+	usage24h, err := x.getUsage(ctx, "24 hours")
+	if err != nil {
+		return nil, fmt.Errorf("get usage error: %w", err)
+	}
+
+	usage28d, err := x.getUsage(ctx, "28 days")
+	if err != nil {
+		return nil, fmt.Errorf("get usage error: %w", err)
+	}
+
+	return &models.Statistics{
+		Usage24h: usage24h,
+		Usage28d: usage28d,
+	}, nil
+}

--- a/internal/metrics/registration.go
+++ b/internal/metrics/registration.go
@@ -3,13 +3,34 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 func RegisterStatuserMetrics() {
-	prometheus.MustRegister(TotalSentAvailabilityCheckReqs, AvailabilityCheckReqsDuration, TotalInvalidAvailabilityCheckReqs, CacheHits)
+	prometheus.MustRegister(
+		TotalSentAvailabilityCheckReqs,
+		AvailabilityCheckReqsDuration,
+		TotalInvalidAvailabilityCheckReqs,
+		CacheHits,
+	)
+}
+
+func RegisterStatsMetrics() {
+	prometheus.MustRegister(
+		JobQueueSize,
+		JobQueueInFlight,
+		BackgroundJobDuration,
+		DbStatsDuration,
+		Reservations24hCount,
+		Reservations28dCount,
+	)
 }
 
 func RegisterApiMetrics() {
-	prometheus.MustRegister(CacheHits)
+	prometheus.MustRegister(
+		CacheHits,
+	)
 }
 
 func RegisterWorkerMetrics() {
-	prometheus.MustRegister(JobQueueSize, JobQueueInFlight, BackgroundJobDuration, ReservationCount, CacheHits)
+	prometheus.MustRegister(
+		ReservationCount,
+		CacheHits,
+	)
 }

--- a/internal/models/statistics.go
+++ b/internal/models/statistics.go
@@ -1,0 +1,12 @@
+package models
+
+type Statistics struct {
+	Usage24h []*UsageStat
+	Usage28d []*UsageStat
+}
+
+type UsageStat struct {
+	Provider ProviderType `db:"provider"`
+	Result   string       `db:"result"`
+	Count    int64        `db:"count"`
+}


### PR DESCRIPTION
Numbers are pretty much unusable for the next 24 hours after deployment. On stage, this is almost every day, on prod this skews the numbers.

Let’s calculate these numbers properly via a background job on regular intervals and export those values as prometheus gauges.

This patch adds database connection and a goroutine to the statuser (which we only have single instance of) which performs two DB queries in every 30 minutes and updates prometheus gauges with the numbers. It will allow us to see:

* Number of success/failed launches per hyperscaler in the last 24 hours
* Number of success/failed launches per hyperscaler in the last 28 days
* Duration of the statistics routine (just in case it gets slower in the future)
