### PR TITLE
fix(HMS-2002): fix memory request limits

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -192,8 +192,8 @@ objects:
                 value: ${APP_CACHE_TYPE}
             resources:
               limits:
-                cpu: ${{CPU_LIMIT_SMALL}}
-                memory: ${MEMORY_LIMIT_SMALL}
+                cpu: ${{CPU_LIMIT}}
+                memory: ${MEMORY_LIMIT}
               requests:
                 cpu: ${CPU_REQUESTS}
                 memory: ${MEMORY_REQUESTS}
@@ -241,8 +241,8 @@ objects:
                 value: ${APP_CACHE_TYPE}
             resources:
               limits:
-                cpu: ${{CPU_LIMIT_SMALL}}
-                memory: ${MEMORY_LIMIT_SMALL}
+                cpu: ${{CPU_LIMIT}}
+                memory: ${MEMORY_LIMIT}
               requests:
                 cpu: ${CPU_REQUESTS}
                 memory: ${MEMORY_REQUESTS}
@@ -478,24 +478,18 @@ parameters:
   - description: ClowdEnv Name
     name: ENV_NAME
     required: true
-  - description: CPU limit of api and worker services
-    name: CPU_LIMIT
-    value: 500m
-  - description: CPU limit of statuser and stats services
-    name: CPU_LIMIT_SMALL
-    value: 300m
-  - description: CPU request increment
+  - description: CPU request for each pod (placement)
     name: CPU_REQUESTS
     value: 100m
-  - description: Memory limit of api and worker services
-    name: MEMORY_LIMIT
-    value: 400m
-  - description: Memory limit of statuser and stats services
-    name: MEMORY_LIMIT_SMALL
-    value: 300m
-  - description: Memory request increment
+  - description: Memory request for each pod (placement)
     name: MEMORY_REQUESTS
     value: 100Mi
+  - description: CPU limit for each pod (throttling)
+    name: CPU_LIMIT
+    value: 500m
+  - description: Memory limit for each pod (pod restart)
+    name: MEMORY_LIMIT
+    value: 600Mi
   - description: Image tag
     name: IMAGE_TAG
     required: true


### PR DESCRIPTION
I messed up memory limits. CPUs mili-units are "m" but for memiry MiBs are "Mi". Stage is currently no deploying anything, this should fix it. The error was:

`error updating resource Deployment provisioning-backend-worker: Deployment.apps "provisioning-backend-worker" is invalid: [spec.template.spec.containers[0].resources.requests: Invalid value: "100Mi": must be less than or equal to memory limit, spec.template.spec.initContainers[0].resources.requests: Invalid value: "100Mi": must be less than or equal to memory limit]`

This patch also sorts the environment variables to a meaningful order:

* requests.cpu - 700m - 3000m
* requests.memory - 700Mi - 12Gi
* limits.cpu - 3500m - 6000m
* limits.memory - 7Gi - 24Gi

This list also shows our current limits/requests and the cap set by the platform. Now, after reading some docs, it looks like:

* requests - what the apps "wants" and it enables the cluster to find the best runtime
* limits - hard limit when pod gets restarted when it reaches it (memory) or throttled (cpu)

Although it is not clear if clowder sets pod or deployment limits/requests, from the numbers on the dashboard it looks like these are per-pod limits (3500m / 7 = 500m CPU limit): https://docs.openshift.com/online/pro/dev_guide/compute_resources.html

Therefore, new proposal for the total number of pods 8 (was 7):

* requests.cpu: keep **100m** (x8 = 800m with maximum allowed 3000m).
* requests.memory: keep **100Mi** (x8 = 800Mi with maximum allowed 12Gi).
* limits.cpu: keep **500m** (x8 = 4000m with maximum allowed 3000m).
* limits.memory: decrease from 1Gi to **600Mi** (x8 = 4.8Gi with maximum allowed 12Gi). My reasoning is that I want to know earlier if we have a memory bug, the cluster will restart those pods and we will get alerted.

I am also dropping those _SMALL variants as it really seems limits/requests are per-pod not per-deployment. We have plenty of room within our budgets, this makes all calculations significantly easier.
