### PR TITLE
feat(HMSPROV-2088): refacor notification's context message

### DIFF
--- a/internal/kafka/notification_msg.go
+++ b/internal/kafka/notification_msg.go
@@ -22,6 +22,11 @@ type NotificationEvent struct {
 	Payload json.RawMessage `json:"payload"`
 }
 
+type NotificationContext struct {
+	LaunchID int64  `json:"launch_id"`
+	Provider string `json:"provider"`
+}
+
 type NotificationError struct {
 	Error string `json:"error"`
 }

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -50,7 +50,7 @@ func (x *client) SuccessfulLaunch(ctx context.Context, reservationId int64) {
 	}
 
 	notificationMsg, err := kafka.NotificationMessage{
-		Context:   reservation,
+		Context:   kafka.NotificationContext{Provider: reservation.Provider.String(), LaunchID: reservationId},
 		EventType: kafka.NotificationSuccessEventType, Events: NotificationInstancesEvents,
 	}.GenericMessage(ctx)
 	if err != nil {


### PR DESCRIPTION
Currently, we send the generic reservation payload as the notification's context. some data is redundant (i.e. step titles, steps/step) others misleading (i.e. success flag), or might confuse - the provider's id (2) instead of the provider's string (aws).

We should send the minimal information that also will be beneficial, 
This PR replaces the reservation's payload with the `NotificationContext` struct which includes the launch_id and the provider's string, both are used in email templates.


