### PR TITLE
ci(HMS-1947): Parameterize post-deploy tests for both stage and prod

### DIFF
--- a/deploy/testing.yaml
+++ b/deploy/testing.yaml
@@ -2,12 +2,12 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: provisioning-stage-test
+  name: provisioning-test
 objects:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation
   metadata:
-    name: provisioning-stage-test-${IMAGE_TAG}-${UID}
+    name: provisioning-test-${IMAGE_TAG}-${UID}
     annotations:
       "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
       "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
@@ -16,9 +16,8 @@ objects:
     testing:
       iqe:
         debug: false
-        dynaconfEnvName: stage_post_deploy
-        filter: ''
-        marker: 'stage'
+        dynaconfEnvName: ${IQE_ENV}
+        marker: ${IQE_MARKER}
 parameters:
 - name: IMAGE_TAG
   value: ''
@@ -27,3 +26,7 @@ parameters:
   description: "Unique CJI name suffix"
   generate: expression
   from: "[a-z0-9]{6}"
+- name: IQE_ENV
+  value: 'stage_post_deploy'
+- name: IQE_MARKER
+  value: 'stage'


### PR DESCRIPTION
In preparation for adding prod post-deploy tests, this PR parameterizes the post-deploy test template to support both stage and prod environments. Currently the only parameters are the dynaconf environment and the pytest marker expression used by pytest to determine both the environment and the tests to run against it.

***
Thanks for the contribution, make sure your commit message follows this subject style:

        type: brief summary up to 70 characters or
        type(scope): brief summary up to 70 characters

Type is required, scope is optional. Prefer lower-case and avoid dot at the end.

Find more info about types and scopes at:

https://github.com/RHEnVision/provisioning-backend#contributing

Take a moment to read our contributing and security guidelines:

https://github.com/RedHatInsights/secure-coding-checklist

**Checklist**

- [x] all commit messages follows the policy above
- [x] the change follows our security guidelines
