### PR TITLE
fix(HMS-2002): fix job queue duration registration

### DIFF
--- a/internal/metrics/registration.go
+++ b/internal/metrics/registration.go
@@ -15,7 +15,6 @@ func RegisterStatsMetrics() {
 	prometheus.MustRegister(
 		JobQueueSize,
 		JobQueueInFlight,
-		BackgroundJobDuration,
 		DbStatsDuration,
 		Reservations24hCount,
 		Reservations28dCount,
@@ -30,6 +29,7 @@ func RegisterApiMetrics() {
 
 func RegisterWorkerMetrics() {
 	prometheus.MustRegister(
+		BackgroundJobDuration,
 		ReservationCount,
 		CacheHits,
 	)


### PR DESCRIPTION
In the recent changes, I accidentally moved job duration from worker to stats process. The metric no longer exist in Prometheus on stage, this is because this needs to be registered for worker processes where jobs are actually processed not the stats process where no jobs are executed.

This fixes it, after the merge, the metric will re-appear on the dashboard.