### PR TITLE
chore: fix typo and replace more identifiers

### DIFF
--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -206,7 +206,7 @@ func (c *ec2Client) GetPubkeyName(ctx context.Context, fingerprint string) (stri
 	}
 
 	if len(output.KeyPairs) == 0 {
-		span.SetStatus(codes.Error, fmt.Sprintf("no KeyPair with fingerpring (%s) found", fingerprint))
+		span.SetStatus(codes.Error, fmt.Sprintf("no KeyPair with fingerprint (%s) found", fingerprint))
 		return "", fmt.Errorf("SSH key not found by its fingerprint (%s): %w", fingerprint, http.PubkeyNotFoundErr)
 	}
 	return *output.KeyPairs[0].KeyName, nil

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -140,7 +140,7 @@ func DoEnsurePubkeyOnAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) e
 			}
 			ec2Name = pubkey.Name
 		} else {
-			return fmt.Errorf("cannot fetch name of pubkey with fingerpring (%s): %w", fingerprint, err)
+			return fmt.Errorf("cannot fetch name of pubkey with fingerprint (%s): %w", fingerprint, err)
 		}
 	} else {
 		logger.Debug().Msgf("Found pubkey by fingerprint (%s) with name '%s'", fingerprint, ec2Name)

--- a/internal/logging/sentry_replacer.go
+++ b/internal/logging/sentry_replacer.go
@@ -14,6 +14,11 @@ var filters = []string{
 	`[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}`,
 	// Example (AWS SDK): arn:aws:iam::4328974392798432:role/my-role-123
 	`arn:aws:[[:word:]]+::\d+:[[:word:]\*-]+/[[:word:]\*-]+`,
+	// Example (AWS SDK): i-1234567890abcdef0
+	`[a-z]-[0-9a-f]{17}`,
+	// Example: 57:d4:13:ff:c0:74:51:50:41:ec:e1:cd:f1:88:b0:61
+	`([0-9a-fA-F]{2}[:-]){15}[0-9a-fA-F]{2}`,
+	// Example: 192.168.1.100:32453,
 	`\d+\.\d+\.\d+\.\d+:\d+`,
 }
 

--- a/internal/logging/sentry_replacer_test.go
+++ b/internal/logging/sentry_replacer_test.go
@@ -76,3 +76,17 @@ func TestIPv4(t *testing.T) {
 	_, _ = repl.Write([]byte("read tcp 10.128.24.14:42094->10.0.217.126:6379: i/o timeout\n"))
 	require.Equal(t, "read tcp ?->?: i/o timeout\n", buf.String())
 }
+
+func TestFingerprint(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("pubkey with fingerprint (57:d4:13:ff:c0:74:51:50:41:ec:e1:cd:f1:88:b0:61)\n"))
+	require.Equal(t, "pubkey with fingerprint (?)\n", buf.String())
+}
+
+func TestAWSResourceID(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("instance ID 'i-0fe8a8adc1403f5b1' does not exist\n\n\n"))
+	require.Equal(t, "instance ID '?' does not exist\n\n\n", buf.String())
+}


### PR DESCRIPTION
Just a typo and two new Sentry replacers.