### PR TITLE
chore: remove dynamic fingerprint from error message

### DIFF
--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -207,7 +207,7 @@ func (c *ec2Client) GetPubkeyName(ctx context.Context, fingerprint string) (stri
 
 	if len(output.KeyPairs) == 0 {
 		span.SetStatus(codes.Error, fmt.Sprintf("no KeyPair with fingerprint (%s) found", fingerprint))
-		return "", fmt.Errorf("SSH key not found by its fingerprint (%s): %w", fingerprint, http.PubkeyNotFoundErr)
+		return "", fmt.Errorf("SSH key not found by its fingerprint: %w", http.PubkeyNotFoundErr)
 	}
 	return *output.KeyPairs[0].KeyName, nil
 }

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -140,7 +140,8 @@ func DoEnsurePubkeyOnAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) e
 			}
 			ec2Name = pubkey.Name
 		} else {
-			return fmt.Errorf("cannot fetch name of pubkey with fingerprint (%s): %w", fingerprint, err)
+			logger.Error().Err(err).Str("pubkey_fingerprint", fingerprint).Msg("Cannot fetch name of pubkey by its fingerprint")
+			return fmt.Errorf("cannot fetch name of pubkey by its fingerprint: %w", err)
 		}
 	} else {
 		logger.Debug().Msgf("Found pubkey by fingerprint (%s) with name '%s'", fingerprint, ec2Name)


### PR DESCRIPTION
I believe this is cleaner, as the dynamic fingerprint in the error message causes trouble and we do not really care about it.
I'm happy to down level the message even as I think we already log the job error as error.