### PR TITLE
fix(HMS-2143): pending state stat

### DIFF
--- a/internal/dao/pgx/stat_pgx.go
+++ b/internal/dao/pgx/stat_pgx.go
@@ -32,7 +32,15 @@ func (x *statDao) getUsage(ctx context.Context, interval string) ([]*models.Usag
 	select provider, 'failure' as result, count(provider) as count
 	from reservations
 	where created_at >= now() - cast($1 as interval)
-	  and (success is null or success = false)
+	  and success = false
+	group by provider
+
+	union all
+
+	select provider, 'pending' as result, count(provider) as count
+	from reservations
+	where created_at >= now() - cast($1 as interval)
+	  and success is null
 	group by provider`
 
 	var result []*models.UsageStat


### PR DESCRIPTION
I am struggling with our major SLO: reservation success rate. As you can see on our production cluster, success rate is currently below 70%. While I see about half of these failures being done by GCP which is in development, another half of the failures are AWS.

Our SLO alert currently fires "randomly" because we use prometheus counter which resets every now and than. I created a new metric that is calculated by stats process on the background (is gauge metric) and that will work, but it will cause the SLO to have a very long recovery rate because our traffic is pretty low.

Therefore I propose to change our major SLO from "success rate" to "processing rate" similarly what we do with sources availability checks. We cannot do anything if a customer fires 10 unsuccessful launches because they revoke a permission. An alert will only alert us, but we cannot do anything about it. On the other hand, reservations being not processed is an important metric and alert is appropriate - workers are perhaps down, kafka is down, jobs are getting killed (OOM) or something like that.

This patch will allow us to monitor pending state, higher pending reservations will mean something is going on and jobs are either exiting (OOM) or workers are not processing the data. It can also mean that workers cannot keep up with the incoming reservations.

Once this is merged, I will do a dashboard update + alert.