### PR TITLE
chore: use sum for provisioning db duration rate

### DIFF
--- a/deploy/Provisioning-1674548289785.json
+++ b/deploy/Provisioning-1674548289785.json
@@ -725,7 +725,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(provisioning_db_stats_duration_sum[35m])\n/\nrate(provisioning_db_stats_duration_count[35m])",
+          "expr": "sum(rate(provisioning_db_stats_duration_sum[35m]))\n/\nsum(rate(provisioning_db_stats_duration_count[35m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -2149,9 +2149,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "crcs02ue1-prometheus",
-          "value": "crcs02ue1-prometheus"
+          "selected": true,
+          "text": "crcp01ue1-prometheus",
+          "value": "crcp01ue1-prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -2302,6 +2302,6 @@
   "timezone": "",
   "title": "Provisioning",
   "uid": "211",
-  "version": 2,
+  "version": 7,
   "weekStart": ""
 }

--- a/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
@@ -736,7 +736,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "rate(provisioning_db_stats_duration_sum[35m])\n/\nrate(provisioning_db_stats_duration_count[35m])",
+                   "expr" : "sum(rate(provisioning_db_stats_duration_sum[35m]))\n/\nsum(rate(provisioning_db_stats_duration_count[35m]))",
                    "legendFormat" : "__auto",
                    "range" : true,
                    "refId" : "A"
@@ -2160,9 +2160,9 @@ data:
           "list" : [
              {
                 "current" : {
-                   "selected" : false,
-                   "text" : "crcs02ue1-prometheus",
-                   "value" : "crcs02ue1-prometheus"
+                   "selected" : true,
+                   "text" : "crcp01ue1-prometheus",
+                   "value" : "crcp01ue1-prometheus"
                 },
                 "hide" : 0,
                 "includeAll" : false,
@@ -2313,6 +2313,6 @@ data:
        "timezone" : "",
        "title" : "Provisioning",
        "uid" : "211",
-       "version" : 2,
+       "version" : 7,
        "weekStart" : ""
     }


### PR DESCRIPTION
SSIA

Small typo, fixes the problem after containers are restarted - the pane shows multiple values instead of one.

![image](https://github.com/RHEnVision/provisioning-backend/assets/49752/3933bf6f-84fc-46fb-b595-20d797c88c2f)
