### PR TITLE
fix(HMS-2175): add AWS resource tag

### DIFF
--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strconv"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http"
@@ -367,7 +368,7 @@ func (c *ec2Client) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchT
 	return res, nil
 }
 
-func (c *ec2Client) RunInstances(ctx context.Context, params *clients.AWSInstanceParams, amount int32, name *string) ([]*string, *string, error) {
+func (c *ec2Client) RunInstances(ctx context.Context, params *clients.AWSInstanceParams, amount int32, name *string, reservation *models.AWSReservation) ([]*string, *string, error) {
 	ctx, span := otel.Tracer(TraceName).Start(ctx, "RunInstances")
 	defer span.End()
 
@@ -402,6 +403,10 @@ func (c *ec2Client) RunInstances(ctx context.Context, params *clients.AWSInstanc
 					{
 						Key:   ptr.To("Name"),
 						Value: name,
+					},
+					{
+						Key:   ptr.To("rhhc:rid"),
+						Value: ptr.To(config.EnvironmentPrefix("r", strconv.FormatInt(reservation.ID, 10))),
 					},
 				},
 			},

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -90,7 +90,7 @@ type EC2 interface {
 	//
 	// All arguments are required except: launchTemplateID (empty string means no template in use).
 	//
-	RunInstances(ctx context.Context, details *AWSInstanceParams, amount int32, name *string) ([]*string, *string, error)
+	RunInstances(ctx context.Context, details *AWSInstanceParams, amount int32, name *string, reservation *models.AWSReservation) ([]*string, *string, error)
 
 	// GetAccountId returns AWS account number.
 	GetAccountId(ctx context.Context) (string, error)

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -159,7 +159,7 @@ func (mock *EC2ClientStub) CheckPermission(ctx context.Context, auth *clients.Au
 	return nil, nil
 }
 
-func (mock *EC2ClientStub) RunInstances(ctx context.Context, details *clients.AWSInstanceParams, amount int32, name *string) ([]*string, *string, error) {
+func (mock *EC2ClientStub) RunInstances(ctx context.Context, details *clients.AWSInstanceParams, amount int32, name *string, reservation *models.AWSReservation) ([]*string, *string, error) {
 	return nil, nil, nil
 }
 

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -26,6 +26,24 @@ func Environment() string {
 	return "dev"
 }
 
+// EnvironmentPrefix wraps an identifier (e.g. id, unique id) in the following way.
+// For production environment, it returns "prefix-identifier". For any other environment,
+// it returns "prefix-identifier-env". Examples:
+//
+// * reservation-14572
+// * reservation-9531-stage
+// * reservation-13-ephemeral
+// * reservation-1-dev
+func EnvironmentPrefix(prefix, identifier string) string {
+	env := Environment()
+
+	if strings.HasPrefix(env, "prod") || env == "" {
+		return prefix + "-" + identifier
+	}
+
+	return prefix + "-" + identifier + "-" + env
+}
+
 // InEphemeralClowder returns true, when the app is running in ephemeral clowder environment.
 func InEphemeralClowder() bool {
 	return InClowder() && strings.Contains(*clowder.LoadedConfig.Metadata.EnvName, "ephemeral")

--- a/internal/config/helpers_test.go
+++ b/internal/config/helpers_test.go
@@ -1,0 +1,11 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironmentPrefix2(t *testing.T) {
+	require.Equal(t, "test-123-dev", EnvironmentPrefix("test", "123"))
+}

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -207,7 +207,7 @@ func DoLaunchInstanceAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) e
 	}
 
 	logger.Trace().Msg("Executing RunInstances")
-	instances, awsReservationId, err := ec2Client.RunInstances(ctx, req, args.Detail.Amount, args.Detail.Name)
+	instances, awsReservationId, err := ec2Client.RunInstances(ctx, req, args.Detail.Amount, args.Detail.Name, reservation)
 	if err != nil {
 		return fmt.Errorf("cannot run instances: %w", err)
 	}


### PR DESCRIPTION
We share a team account and sometimes it is not clear who created particular instance. This should make finding owners more easier. It adds AWS instance resource tag in the form of "pr-ID" where "pr" stands for production (or st for stage, ep for ephemeral, de for development) and ID is reservation ID.