### PR TITLE
fix(HMS-2002): calculate db stats immediately

### DIFF
--- a/deploy/Provisioning-1674548289785.json
+++ b/deploy/Provisioning-1674548289785.json
@@ -107,7 +107,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "1 - (sum(provisioning_reservations_24h_count{result=\"pending\",provider=~\"$type\"}) / sum(provisioning_reservations_24h_count{provider=~\"$type\"}))",
+          "expr": "1 - (sum(provisioning_reservations_24h_count{result=\"pending\",provider=~\"$type\"} or on() vector(0)) / sum(provisioning_reservations_24h_count{provider=~\"$type\"}))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -178,7 +178,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(provisioning_reservations_24h_count{result=\"success\",provider=~\"$type\"}) / sum(provisioning_reservations_24h_count{provider=~\"$type\"})",
+          "expr": "sum(provisioning_reservations_24h_count{result=\"success\",provider=~\"$type\"} or on() vector(0)) / sum(provisioning_reservations_24h_count{provider=~\"$type\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -253,7 +253,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "1 - (sum(provisioning_reservations_28d_count{result=\"pending\",provider=~\"$type\"}) / sum(provisioning_reservations_28d_count{provider=~\"$type\"}))",
+          "expr": "1 - (sum(provisioning_reservations_28d_count{result=\"pending\",provider=~\"$type\"} or on() vector(0)) / sum(provisioning_reservations_28d_count{provider=~\"$type\"}))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -324,7 +324,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(provisioning_reservations_28d_count{result=\"success\",provider=~\"$type\"}) / sum(provisioning_reservations_28d_count{provider=~\"$type\"})",
+          "expr": "sum(provisioning_reservations_28d_count{result=\"success\",provider=~\"$type\"} or on() vector(0)) / sum(provisioning_reservations_28d_count{provider=~\"$type\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -419,7 +419,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(provisioning_reservations_24h_count{type=~\"$type\"}) OR on() vector(0)",
+          "expr": "sum(provisioning_reservations_24h_count{provider=~\"$type\"}) OR on() vector(0)",
           "legendFormat": "Pending",
           "range": true,
           "refId": "A"
@@ -514,7 +514,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(provisioning_reservations_24h_count{result=\"pending\", type=~\"$type\"}) OR on() vector(0)",
+          "expr": "sum(provisioning_reservations_24h_count{result=\"pending\", provider=~\"$type\"}) OR on() vector(0)",
           "legendFormat": "Pending",
           "range": true,
           "refId": "A"
@@ -525,7 +525,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(provisioning_reservations_24h_count{result=\"success\", type=~\"$type\"}) OR on() vector(0)",
+          "expr": "sum(provisioning_reservations_24h_count{result=\"success\", provider=~\"$type\"}) OR on() vector(0)",
           "hide": false,
           "legendFormat": "Success",
           "range": true,
@@ -538,7 +538,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(provisioning_reservations_24h_count{result=\"failure\", type=~\"$type\"}) OR on() vector(0)",
+          "expr": "sum(provisioning_reservations_24h_count{result=\"failure\", provider=~\"$type\"}) OR on() vector(0)",
           "hide": false,
           "legendFormat": "Failure",
           "range": true,
@@ -634,7 +634,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(provisioning_reservations_28d_count{result=\"pending\", type=~\"$type\"}) OR on() vector(0)",
+          "expr": "sum(provisioning_reservations_28d_count{result=\"pending\", provider=~\"$type\"}) OR on() vector(0)",
           "legendFormat": "Pending",
           "range": true,
           "refId": "A"
@@ -645,7 +645,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(provisioning_reservations_28d_count{result=\"success\", type=~\"$type\"}) OR on() vector(0)",
+          "expr": "sum(provisioning_reservations_28d_count{result=\"success\", provider=~\"$type\"}) OR on() vector(0)",
           "hide": false,
           "legendFormat": "Success",
           "range": true,
@@ -658,7 +658,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(provisioning_reservations_28d_count{result=\"failure\", type=~\"$type\"}) OR on() vector(0)",
+          "expr": "sum(provisioning_reservations_28d_count{result=\"failure\", provider=~\"$type\"}) OR on() vector(0)",
           "hide": false,
           "legendFormat": "Failure",
           "range": true,
@@ -2149,9 +2149,9 @@
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": "crcp01ue1-prometheus",
-          "value": "crcp01ue1-prometheus"
+          "selected": false,
+          "text": "crcs02ue1-prometheus",
+          "value": "crcs02ue1-prometheus"
         },
         "hide": 0,
         "includeAll": false,
@@ -2227,7 +2227,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],

--- a/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-provisioning.configmap.yaml
@@ -118,7 +118,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "1 - (sum(provisioning_reservations_24h_count{result=\"pending\",provider=~\"$type\"}) / sum(provisioning_reservations_24h_count{provider=~\"$type\"}))",
+                   "expr" : "1 - (sum(provisioning_reservations_24h_count{result=\"pending\",provider=~\"$type\"} or on() vector(0)) / sum(provisioning_reservations_24h_count{provider=~\"$type\"}))",
                    "legendFormat" : "__auto",
                    "range" : true,
                    "refId" : "A"
@@ -189,7 +189,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "sum(provisioning_reservations_24h_count{result=\"success\",provider=~\"$type\"}) / sum(provisioning_reservations_24h_count{provider=~\"$type\"})",
+                   "expr" : "sum(provisioning_reservations_24h_count{result=\"success\",provider=~\"$type\"} or on() vector(0)) / sum(provisioning_reservations_24h_count{provider=~\"$type\"})",
                    "legendFormat" : "__auto",
                    "range" : true,
                    "refId" : "A"
@@ -264,7 +264,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "1 - (sum(provisioning_reservations_28d_count{result=\"pending\",provider=~\"$type\"}) / sum(provisioning_reservations_28d_count{provider=~\"$type\"}))",
+                   "expr" : "1 - (sum(provisioning_reservations_28d_count{result=\"pending\",provider=~\"$type\"} or on() vector(0)) / sum(provisioning_reservations_28d_count{provider=~\"$type\"}))",
                    "legendFormat" : "__auto",
                    "range" : true,
                    "refId" : "A"
@@ -335,7 +335,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "sum(provisioning_reservations_28d_count{result=\"success\",provider=~\"$type\"}) / sum(provisioning_reservations_28d_count{provider=~\"$type\"})",
+                   "expr" : "sum(provisioning_reservations_28d_count{result=\"success\",provider=~\"$type\"} or on() vector(0)) / sum(provisioning_reservations_28d_count{provider=~\"$type\"})",
                    "legendFormat" : "__auto",
                    "range" : true,
                    "refId" : "A"
@@ -430,7 +430,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "sum(provisioning_reservations_24h_count{type=~\"$type\"}) OR on() vector(0)",
+                   "expr" : "sum(provisioning_reservations_24h_count{provider=~\"$type\"}) OR on() vector(0)",
                    "legendFormat" : "Pending",
                    "range" : true,
                    "refId" : "A"
@@ -525,7 +525,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "sum(provisioning_reservations_24h_count{result=\"pending\", type=~\"$type\"}) OR on() vector(0)",
+                   "expr" : "sum(provisioning_reservations_24h_count{result=\"pending\", provider=~\"$type\"}) OR on() vector(0)",
                    "legendFormat" : "Pending",
                    "range" : true,
                    "refId" : "A"
@@ -536,7 +536,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "sum(provisioning_reservations_24h_count{result=\"success\", type=~\"$type\"}) OR on() vector(0)",
+                   "expr" : "sum(provisioning_reservations_24h_count{result=\"success\", provider=~\"$type\"}) OR on() vector(0)",
                    "hide" : false,
                    "legendFormat" : "Success",
                    "range" : true,
@@ -549,7 +549,7 @@ data:
                    },
                    "editorMode" : "code",
                    "exemplar" : false,
-                   "expr" : "sum(provisioning_reservations_24h_count{result=\"failure\", type=~\"$type\"}) OR on() vector(0)",
+                   "expr" : "sum(provisioning_reservations_24h_count{result=\"failure\", provider=~\"$type\"}) OR on() vector(0)",
                    "hide" : false,
                    "legendFormat" : "Failure",
                    "range" : true,
@@ -645,7 +645,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "sum(provisioning_reservations_28d_count{result=\"pending\", type=~\"$type\"}) OR on() vector(0)",
+                   "expr" : "sum(provisioning_reservations_28d_count{result=\"pending\", provider=~\"$type\"}) OR on() vector(0)",
                    "legendFormat" : "Pending",
                    "range" : true,
                    "refId" : "A"
@@ -656,7 +656,7 @@ data:
                       "uid" : "${datasource}"
                    },
                    "editorMode" : "code",
-                   "expr" : "sum(provisioning_reservations_28d_count{result=\"success\", type=~\"$type\"}) OR on() vector(0)",
+                   "expr" : "sum(provisioning_reservations_28d_count{result=\"success\", provider=~\"$type\"}) OR on() vector(0)",
                    "hide" : false,
                    "legendFormat" : "Success",
                    "range" : true,
@@ -669,7 +669,7 @@ data:
                    },
                    "editorMode" : "code",
                    "exemplar" : false,
-                   "expr" : "sum(provisioning_reservations_28d_count{result=\"failure\", type=~\"$type\"}) OR on() vector(0)",
+                   "expr" : "sum(provisioning_reservations_28d_count{result=\"failure\", provider=~\"$type\"}) OR on() vector(0)",
                    "hide" : false,
                    "legendFormat" : "Failure",
                    "range" : true,
@@ -2160,9 +2160,9 @@ data:
           "list" : [
              {
                 "current" : {
-                   "selected" : true,
-                   "text" : "crcp01ue1-prometheus",
-                   "value" : "crcp01ue1-prometheus"
+                   "selected" : false,
+                   "text" : "crcs02ue1-prometheus",
+                   "value" : "crcs02ue1-prometheus"
                 },
                 "hide" : 0,
                 "includeAll" : false,
@@ -2238,7 +2238,7 @@ data:
              {
                 "allValue" : ".*",
                 "current" : {
-                   "selected" : false,
+                   "selected" : true,
                    "text" : [
                       "All"
                    ],


### PR DESCRIPTION
The Go built-in time Ticker does not trigger immediately and there does not seem to be an elegant way of doing that. We need the metric to immediately appear otherwise there are gaps up to 30 minutes in Prometheus after each restart of the application. This creates ugly gaphs:

![image](https://github.com/RHEnVision/provisioning-backend/assets/49752/62f8e411-7033-48f1-aeb6-1de628f16f05)

Part of this patch are changes of the dashboard to prevent "No data" behavior for cases when there are no pending reservations. In these cases, the panels should read "100%".

Finally there was a typo in label name which made the provider Grafana selector not work. This fixes it.