### PR TITLE
fix(HMS-2181): statuser throttling configuration options

### DIFF
--- a/cmd/pbackend/statuser.go
+++ b/cmd/pbackend/statuser.go
@@ -122,6 +122,12 @@ func checkSourceAvailabilityAzure(ctx context.Context) {
 	defer processingWG.Done()
 
 	for s := range chAzure {
+		if random.Float32() > config.Azure.AvailabilityRate {
+			logger.Trace().Msgf("Skipping Azure source availability status %s", s.SourceApplicationID)
+			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeAzure.String(), "skipped", nil)
+			continue
+		}
+
 		logger.Trace().Msgf("Checking Azure source availability status %s", s.SourceApplicationID)
 		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeAzure.String(), func() error {
 			var err error
@@ -136,6 +142,8 @@ func checkSourceAvailabilityAzure(ctx context.Context) {
 
 			return fmt.Errorf("error during check: %w", err)
 		})
+
+		time.Sleep(config.Azure.AvailabilityDelay)
 	}
 }
 
@@ -144,6 +152,12 @@ func checkSourceAvailabilityAWS(ctx context.Context) {
 	defer processingWG.Done()
 
 	for s := range chAws {
+		if random.Float32() > config.AWS.AvailabilityRate {
+			logger.Trace().Msgf("Skipping AWS source availability status %s", s.SourceApplicationID)
+			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeAWS.String(), "skipped", nil)
+			continue
+		}
+
 		logger.Trace().Msgf("Checking AWS source availability status %s", s.SourceApplicationID)
 		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeAWS.String(), func() error {
 			var err error
@@ -172,6 +186,8 @@ func checkSourceAvailabilityAWS(ctx context.Context) {
 			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeAWS.String(), sr.Status.String(), err)
 			return fmt.Errorf("error during check: %w", err)
 		})
+
+		time.Sleep(config.AWS.AvailabilityDelay)
 	}
 }
 
@@ -180,6 +196,12 @@ func checkSourceAvailabilityGCP(ctx context.Context) {
 	defer processingWG.Done()
 
 	for s := range chGcp {
+		if random.Float32() > config.GCP.AvailabilityRate {
+			logger.Trace().Msgf("Skipping GCP source availability status %s", s.SourceApplicationID)
+			metrics.IncTotalSentAvailabilityCheckReqs(models.ProviderTypeGCP.String(), "skipped", nil)
+			continue
+		}
+
 		logger.Trace().Msgf("Checking GCP source availability status %s", s.SourceApplicationID)
 		metrics.ObserveAvailabilityCheckReqsDuration(models.ProviderTypeGCP.String(), func() error {
 			var err error
@@ -209,6 +231,8 @@ func checkSourceAvailabilityGCP(ctx context.Context) {
 
 			return fmt.Errorf("error during check: %w", err)
 		})
+
+		time.Sleep(config.GCP.AvailabilityDelay)
 	}
 }
 

--- a/config/api.env.example
+++ b/config/api.env.example
@@ -66,6 +66,10 @@
 #     	AWS region when not provided (default "us-east-1")
 #   AWS_LOGGING bool
 #     	AWS service account logging (verbose) (default "false")
+#   AWS_AVAILABILITY_DELAY int64
+#     	arbitrary delay between sources availability checks (time interval syntax) (default "1s")
+#   AWS_AVAILABILITY_RATE float32
+#     	probability rate for availability checks (0.0 = all skipped, 1.0 = nothing skipped) (default "1.0")
 #   AZURE_TENANT_ID string
 #     	Azure service account tenant id (default "")
 #   AZURE_CLIENT_ID string
@@ -80,12 +84,20 @@
 #     	Azure region when not provided (default "eastus")
 #   AZURE_SUBSCRIPTION_ID string
 #     	Azure service account subscription id (default "")
+#   AZURE_AVAILABILITY_DELAY int64
+#     	arbitrary delay between sources availability checks (time interval syntax) (default "1s")
+#   AZURE_AVAILABILITY_RATE float32
+#     	probability rate for availability checks (0.0 = all skipped, 1.0 = nothing skipped) (default "1.0")
 #   GCP_PROJECT_ID string
 #     	GCP service account project id (default "")
 #   GCP_JSON string
 #     	GCP service account credentials (base64 encoded) (default "e30K")
 #   GCP_DEFAULT_ZONE string
 #     	GCP region when not provided (default "us-east4")
+#   GCP_AVAILABILITY_DELAY int64
+#     	arbitrary delay between sources availability checks (time interval syntax) (default "1s")
+#   GCP_AVAILABILITY_RATE float32
+#     	probability rate for availability checks (0.0 = all skipped, 1.0 = nothing skipped) (default "1.0")
 #   PROMETHEUS_PORT int
 #     	prometheus HTTP port (default "9000")
 #   PROMETHEUS_PATH string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,11 +80,13 @@ var config struct {
 		Stream  string `env:"STREAM" env-default:"" env-description:"cloudwatch logging stream"`
 	} `env-prefix:"CLOUDWATCH_"`
 	AWS struct {
-		Key           string `env:"KEY" env-default:"" env-description:"AWS service account key"`
-		Secret        string `env:"SECRET" env-default:"" env-description:"AWS service account secret"`
-		Session       string `env:"SESSION" env-default:"" env-description:"AWS service account session"`
-		DefaultRegion string `env:"DEFAULT_REGION" env-default:"us-east-1" env-description:"AWS region when not provided"`
-		Logging       bool   `env:"LOGGING" env-default:"false" env-description:"AWS service account logging (verbose)"`
+		Key               string        `env:"KEY" env-default:"" env-description:"AWS service account key"`
+		Secret            string        `env:"SECRET" env-default:"" env-description:"AWS service account secret"`
+		Session           string        `env:"SESSION" env-default:"" env-description:"AWS service account session"`
+		DefaultRegion     string        `env:"DEFAULT_REGION" env-default:"us-east-1" env-description:"AWS region when not provided"`
+		Logging           bool          `env:"LOGGING" env-default:"false" env-description:"AWS service account logging (verbose)"`
+		AvailabilityDelay time.Duration `env:"AVAILABILITY_DELAY" env-default:"1s" env-description:"arbitrary delay between sources availability checks (time interval syntax)"`
+		AvailabilityRate  float32       `env:"AVAILABILITY_RATE" env-default:"1.0" env-description:"probability rate for availability checks (0.0 = all skipped, 1.0 = nothing skipped)"`
 	} `env-prefix:"AWS_"`
 	Azure struct {
 		TenantID            string `env:"TENANT_ID" env-default:"" env-description:"Azure service account tenant id"`
@@ -94,12 +96,16 @@ var config struct {
 		ClientPrincipalName string `env:"CLIENT_PRINCIPAL_NAME" env-default:"RH HCC" env-description:"Azure display name for the offering principal"`
 		DefaultRegion       string `env:"DEFAULT_REGION" env-default:"eastus" env-description:"Azure region when not provided"`
 		// SubscriptionID is not used in prod environments - used to fetch instance types
-		SubscriptionID string `env:"SUBSCRIPTION_ID" env-default:"" env-description:"Azure service account subscription id"`
+		SubscriptionID    string        `env:"SUBSCRIPTION_ID" env-default:"" env-description:"Azure service account subscription id"`
+		AvailabilityDelay time.Duration `env:"AVAILABILITY_DELAY" env-default:"1s" env-description:"arbitrary delay between sources availability checks (time interval syntax)"`
+		AvailabilityRate  float32       `env:"AVAILABILITY_RATE" env-default:"1.0" env-description:"probability rate for availability checks (0.0 = all skipped, 1.0 = nothing skipped)"`
 	} `env-prefix:"AZURE_"`
 	GCP struct {
-		ProjectID   string `env:"PROJECT_ID" env-default:"" env-description:"GCP service account project id"`
-		JSON        string `env:"JSON" env-default:"e30K" env-description:"GCP service account credentials (base64 encoded)"`
-		DefaultZone string `env:"DEFAULT_ZONE" env-default:"us-east4" env-description:"GCP region when not provided"`
+		ProjectID         string        `env:"PROJECT_ID" env-default:"" env-description:"GCP service account project id"`
+		JSON              string        `env:"JSON" env-default:"e30K" env-description:"GCP service account credentials (base64 encoded)"`
+		DefaultZone       string        `env:"DEFAULT_ZONE" env-default:"us-east4" env-description:"GCP region when not provided"`
+		AvailabilityDelay time.Duration `env:"AVAILABILITY_DELAY" env-default:"1s" env-description:"arbitrary delay between sources availability checks (time interval syntax)"`
+		AvailabilityRate  float32       `env:"AVAILABILITY_RATE" env-default:"1.0" env-description:"probability rate for availability checks (0.0 = all skipped, 1.0 = nothing skipped)"`
 	} `env-prefix:"GCP_"`
 	Prometheus struct {
 		Port int    `env:"PORT" env-default:"9000" env-description:"prometheus HTTP port"`

--- a/internal/random/random.go
+++ b/internal/random/random.go
@@ -35,3 +35,8 @@ func TraceID() trace.TraceID {
 	_, _ = mrand.Read(tid[:])
 	return tid
 }
+
+// Float32 returns mathematical random float number in the (0.0, 1.0> interval.
+func Float32() float32 {
+	return mrand.Float32()
+}


### PR DESCRIPTION
We are tracking a ticket to implement caching of source availability checks when necessary (AWS API limits). However, the numbers from both stage and production shows that we do hundreds of checks per hour, so it would be preliminary to work on this.

https://issues.redhat.com/browse/HMS-1244

However, it makes sense to prepare app configuration values just in case we hit some API limits and we will need to slow down rate of availability checks. One configuration value (delay) can be used to arbitrarily slow down pace of checks per hyperscaler. Another config value (rate) can be used for random skipping of checks in case we need to buy time in order to do proper caching implementation.

We have about 150 checks in total on stage, production is currently similar. Therefore I suggest to start with the default value of 1 second which has plenty of room for growth. If we start getting Kafka lag (we have a SLO for that), we can easily either shorten the delay or enable dice rolling (e.g. every 2/3 check will be skipped on average = rate 0.33).