### PR TITLE
chore: improve source filtering message

### DIFF
--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -189,11 +189,12 @@ func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId string) 
 	// Sources API currently does not provide a good server-side filtering.
 	auth, err := filterSourceAuthentications(*resp.JSON200.Data)
 	if err != nil {
-		at := make([]string, 0)
+		at := zerolog.Arr()
 		for _, auth := range *resp.JSON200.Data {
-			at = append(at, string(*auth.Authtype))
+			at.Str(*auth.Authtype)
 		}
-		logger.Warn().Msgf("Sources did not return any Provisioning authentication for source(auth types): %s(%v)", sourceId, at)
+		// Likely a super-key that hasn't been processed by super-key-worker yet
+		logger.Warn().Str("source_id", sourceId).RawJSON("response", resp.Body).Array("filtered", at).Msg("Source does not have Provisioning authentication")
 		return nil, err
 	}
 


### PR DESCRIPTION
This improves error message, currently we see this:

```
7:25AM WRN Sources did not return any Provisioning authentication for source(auth types): 7([access_key_secret_key]) account_number=0369233 client=sources hostname=provisioning-backend-statuser-798cfbfb7-df24f org_id=3340851 source_id=7 trace_id=e979b318140c108c216628100f447d60 version=dc0d
```

after we enabled SA checks. This will reveal what actually source contains so we can take it from there.