### PR TITLE
fix(HMS-2002): postpone db stats 10 minutes

### DIFF
--- a/config/api.env.example
+++ b/config/api.env.example
@@ -153,7 +153,7 @@
 #   STATS_JOBQUEUE_INTERVAL int64
 #     	how often to pull job queue statistics (default "1m")
 #   STATS_RESERVATIONS_INTERVAL int64
-#     	how often to pull reservation statistics (default "30m")
+#     	how often to pull reservation statistics (default "10m")
 #   TELEMETRY_ENABLED bool
 #     	open telemetry collecting (default "false")
 #   TELEMETRY_JAEGER_ENABLED bool

--- a/internal/background/db_stats.go
+++ b/internal/background/db_stats.go
@@ -46,7 +46,7 @@ func dbStatsObserveTick(ctx context.Context) {
 func dbStatsTick(ctx context.Context) error {
 	logger := zerolog.Ctx(ctx)
 	sdao := dao.GetStatDao(ctx)
-	stats, err := sdao.Get(ctx)
+	stats, err := sdao.Get(ctx, 10)
 	if err != nil {
 		return fmt.Errorf("stats error: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,7 @@ var config struct {
 	} `env-prefix:"APP_"`
 	Stats struct {
 		JobQueue             time.Duration `env:"JOBQUEUE_INTERVAL" env-default:"1m" env-description:"how often to pull job queue statistics"`
-		ReservationsInterval time.Duration `env:"RESERVATIONS_INTERVAL" env-default:"30m" env-description:"how often to pull reservation statistics"`
+		ReservationsInterval time.Duration `env:"RESERVATIONS_INTERVAL" env-default:"10m" env-description:"how often to pull reservation statistics"`
 	} `env-prefix:"STATS_"`
 	Database struct {
 		Host        string        `env:"HOST" env-default:"localhost" env-description:"main database hostname"`

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -115,5 +115,5 @@ var GetStatDao func(ctx context.Context) StatDao
 
 // StatDao represents an account (tenant)
 type StatDao interface {
-	Get(ctx context.Context) (*models.Statistics, error)
+	Get(ctx context.Context, delayMin int) (*models.Statistics, error)
 }

--- a/internal/dao/tests/stats_test.go
+++ b/internal/dao/tests/stats_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+// +build integration
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStats(t *testing.T) {
+	reservationDao, ctx := setupReservation(t)
+	defer reset()
+
+	t.Run("success", func(t *testing.T) {
+		res := newNoopReservation()
+		err := reservationDao.CreateNoop(ctx, res)
+		require.NoError(t, err)
+
+		statDao := dao.GetStatDao(ctx)
+		stats, err := statDao.Get(ctx, 0)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), stats.Usage24h[0].Count)
+	})
+}


### PR DESCRIPTION
Reservations metrics are calculated ever 30 minutes and windows are 24hours and 28 days back.

This patch delays that by 10 minutes because from time to time when Azure reservation is in progress, thus in "pending" state, it is collected by Prometheus. Possibly an alert could be triggered when multiple customers would be waiting for reservation to complete. Since reservations takes from few seconds (AWS) to 9 minutes (Azure) on average, delaying the numbers for 10 minutes solves this problem completely.

The patch shorten the delay between database query from 30 to 10 minutes, since queries are about 20ms in total I think we can afford running them more often.