### PR TITLE
ci(HMS-1947): Update names and add parameter in e2e test template

### DIFF
--- a/deploy/testing-integration.yaml
+++ b/deploy/testing-integration.yaml
@@ -2,12 +2,12 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: provisioning-stage-e2e
+  name: provisioning-e2e
 objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
-    name: provisioning-stage-e2e-${IMAGE_TAG}-${UID}
+    name: provisioning-e2e-${IMAGE_TAG}-${UID}
     annotations:
       "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
       "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
@@ -23,7 +23,7 @@ objects:
           emptyDir:
             medium: Memory
         containers:
-        - name: provisioning-stage-e2e-iqe-${IMAGE_TAG}-${UID}
+        - name: provisioning-e2e-iqe-${IMAGE_TAG}-${UID}
           image: ${IQE_IMAGE}
           imagePullPolicy: Always
           args:
@@ -33,6 +33,8 @@ objects:
             value: ${ENV_FOR_DYNACONF}
           - name: DYNACONF_MAIN__use_beta
             value: ${USE_BETA}
+          - name: IQE_IBUTSU_SOURCE
+            value: provisioning-e2e-${IMAGE_TAG}-${UID}-${ENV_FOR_DYNACONF}
           - name: IQE_PLUGINS
             value: ${IQE_PLUGINS}
           - name: IQE_MARKER_EXPRESSION
@@ -84,7 +86,7 @@ objects:
               memory: 1Gi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-        - name: provisioning-stage-e2e-selenium-${UID}
+        - name: provisioning-e2e-sel-${IMAGE_TAG}-${UID}
           image: ${IQE_SEL_IMAGE}
           resources:
             limits:


### PR DESCRIPTION
This PR makes the following changes to the post-deploy e2e test template:
- Update resource names to not be specific to the stage environment
- Create an identifier string to pass to the test container's IQE_IBUTSU_SOURCE env value. This is used when reporting test results.

---

Thanks for the contribution, make sure your commit message follows this subject style:

        type: brief summary up to 70 characters or
        type(scope): brief summary up to 70 characters

Type is required, scope is optional. Prefer lower-case and avoid dot at the end.

Find more info about types and scopes at:

https://github.com/RHEnVision/provisioning-backend#contributing

Take a moment to read our contributing and security guidelines:

https://github.com/RedHatInsights/secure-coding-checklist

**Checklist**

- [ ] all commit messages follows the policy above
- [ ] the change follows our security guidelines
