### PR TITLE
fix(HMS-2178): followup context fix for statuser

### DIFF
--- a/internal/clients/http/ec2/iam_client.go
+++ b/internal/clients/http/ec2/iam_client.go
@@ -185,9 +185,6 @@ func listMissingPermissions(statements []string, expected Statement) []string {
 }
 
 func (c *ec2Client) listAttachedRolePolicies(ctx context.Context, roleName string) ([]*iamTypes.AttachedPolicy, error) {
-	logger := logger(ctx)
-
-	logger.Debug().Msgf("Listing attached role policies")
 	input := &iam.ListAttachedRolePoliciesInput{
 		RoleName: aws.String(roleName),
 	}
@@ -204,9 +201,6 @@ func (c *ec2Client) listAttachedRolePolicies(ctx context.Context, roleName strin
 }
 
 func (c *ec2Client) listInlineRolePolicies(ctx context.Context, roleName string) ([]string, error) {
-	logger := logger(ctx)
-
-	logger.Debug().Msgf("Listing attached role policies.")
 	rolePoliciesInput := &iam.ListRolePoliciesInput{
 		RoleName: aws.String(roleName),
 	}
@@ -232,8 +226,6 @@ func (c *ec2Client) listInlineRolePolicies(ctx context.Context, roleName string)
 }
 
 func (c *ec2Client) listPoliciesFromAttached(ctx context.Context, policies []*iamTypes.AttachedPolicy) ([]*iamTypes.Policy, error) {
-	logger := logger(ctx)
-	logger.Debug().Msgf("Fetching policies for attached policies")
 	result := make([]*iamTypes.Policy, len(policies))
 	for i := range policies {
 		input := &iam.GetPolicyInput{
@@ -282,10 +274,6 @@ func (c *ec2Client) checkInlinePolicies(ctx context.Context, missingPermissions 
 }
 
 func (c *ec2Client) CheckPermission(ctx context.Context, auth *clients.Authentication) ([]string, error) {
-	logger := logger(ctx)
-	logger.Debug().Msgf("Listing policies attached to the role")
-
-	logger.Debug().Msgf("Parsing ARN to get a friendly role name")
 	roleName, err := getRoleName(auth.Payload)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse ARN: %w", err)

--- a/internal/kafka/avail_status_msg.go
+++ b/internal/kafka/avail_status_msg.go
@@ -32,6 +32,7 @@ func genericMessage(ctx context.Context, m any, key string, topic string) (Gener
 		return GenericMessage{}, fmt.Errorf("unable to marshal message: %w", err)
 	}
 
+	// This will panic when identity was not present in the context (no error handling possible)
 	id := identity.Identity(ctx)
 
 	return GenericMessage{

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -263,6 +263,16 @@ func (b *kafkaBroker) Send(ctx context.Context, messages ...*GenericMessage) err
 			return DifferentTopicErr
 		}
 		kMessages[i] = m.KafkaMessage()
+		if logger.Trace().Enabled() {
+			dict := zerolog.Dict()
+			for _, h := range kMessages[i].Headers {
+				dict.Str(h.Key, string(h.Value))
+			}
+			logger.Trace().Str("topic", commonTopic).
+				Bytes("body", kMessages[i].Value).
+				Dict("headers", dict).
+				Msg("Kafka message")
+		}
 	}
 
 	err := w.WriteMessages(ctx, kMessages...)

--- a/internal/kafka/source_result.go
+++ b/internal/kafka/source_result.go
@@ -2,8 +2,6 @@ package kafka
 
 import (
 	"context"
-
-	"github.com/RHEnVision/provisioning-backend/internal/identity"
 )
 
 type StatusType string
@@ -14,18 +12,12 @@ const (
 )
 
 type SourceResult struct {
-	ResourceID string `json:"resource_id"`
-
-	// Resource type of the source
-	ResourceType string `json:"resource_type"`
-
-	Status StatusType `json:"status"`
-
-	Err error `json:"error"`
-
-	Identity identity.Principal `json:"-"`
-
-	MissingPermissions []string `json:"-"`
+	MessageContext     context.Context `json:"-"` // Carries logger and identity
+	ResourceID         string          `json:"resource_id"`
+	ResourceType       string          `json:"resource_type"`
+	Status             StatusType      `json:"status"`
+	Err                error           `json:"-"` // Sources do not support error field
+	MissingPermissions []string        `json:"-"` // Sources do not support reason field
 }
 
 func (sr SourceResult) GenericMessage(ctx context.Context) (GenericMessage, error) {

--- a/internal/logging/zerolog.go
+++ b/internal/logging/zerolog.go
@@ -58,7 +58,7 @@ func stdoutWriter(truncate bool) io.Writer {
 	writer := zerolog.ConsoleWriter{
 		Out:        os.Stdout,
 		NoColor:    config.InEphemeralClowder(),
-		TimeFormat: time.Kitchen,
+		TimeFormat: "15:04:05",
 	}
 	if truncate {
 		writer.FormatFieldValue = func(i interface{}) string {


### PR DESCRIPTION
So the previous fix we merged yesterday was not complete, I tested if it helped and unfortunately it did not so I kept digging. I have found a reason tho - when we receive kafka message, we extract identity, put it into a struct which is passed to worker and sending goroutines. We process everything and send it. There are problems.

We still see `Not found error from sources` and in order to find what is wrong, I need to see the whole logging transaction that can be correlated by msg_id or org_id. This is currently not possible:

![image](https://github.com/RHEnVision/provisioning-backend/assets/49752/4ca4cc96-06f1-48ce-8df9-7c1d31a2a1a3)

First, the goroutines which are processing have context previously named `ctx` and this context is used for logging. But this is the "global" context, the logger in that context does not have the msg_id, org_id and other required fields which are needed to correlate log records. It is supposed to only be used for context cancellation - e.g. when the service is shutting down and it should immediately break the loop and exit. Therefore I renamed this context to `cancelCtx` and it is not used, with two exceptions - when the timer expires and messages need to be sent (no message context available) and when the function needs to cancel (also there is no message so this is the only option).

The correct context we need to use is the message context, it has everything because the kafka consumer in the application prepares it and makes sure it is always a copy (see the previous PR https://github.com/RHEnVision/provisioning-backend/pull/606). We were discussing some time ago if it is good practice to pass context through channels and the opinion on Gopher slack was - it is possible, tho, we do not recommend to encapsulate only data that needs to be sent. This was true for identity, but now that we also want to pass logger around we have two data values: logger and identity. I think in this case it makes sense to pass copies of context around.

The 404 we see from sources is coming from the `clients.GetSourcesClient(ctx)` so something is wrong with that. We will see more info once logging is fixed, I believe that identity is incorrectly passed or something. This patch also adds trace logging of all sent kafka messages (headers, body) so we can investigate further the contents of messages on stage.