### PR TITLE
fix(HMS-2178): followup context bug fix

### DIFF
--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -211,7 +211,7 @@ func (b *kafkaBroker) Consume(ctx context.Context, topic string, since time.Time
 			if err != nil {
 				errLogger := newLogger.Logger()
 				errLogger.Warn().Err(err).Msgf("Could not extract identity from context to Kafka message")
-				newCtx = errLogger.WithContext(newCtx)
+				newCtx = errLogger.WithContext(ctx)
 			} else {
 				id := identity.Identity(newCtx)
 


### PR DESCRIPTION
We have missed this, in this codeflow, the `newCtx` would end up as a 'nil' value, which we should not use anymore. This ends up with panic.