### PR TITLE
chore: new sentry replacements

### DIFF
--- a/internal/logging/sentry_replacer.go
+++ b/internal/logging/sentry_replacer.go
@@ -20,6 +20,10 @@ var filters = []string{
 	`([0-9a-fA-F]{2}[:-]){15}[0-9a-fA-F]{2}`,
 	// Example: 192.168.1.100:32453,
 	`\d+\.\d+\.\d+\.\d+:\d+`,
+	// Example: The resource 'projects/xxx' was not found
+	`'projects/[^']*'`,
+	// Example: 2023-06-24T19:34:34.2581206+00:00
+	`\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d+\+\d\d:\d\d`,
 }
 
 var replacement = []byte{'?'}

--- a/internal/logging/sentry_replacer_test.go
+++ b/internal/logging/sentry_replacer_test.go
@@ -90,3 +90,17 @@ func TestAWSResourceID(t *testing.T) {
 	_, _ = repl.Write([]byte("instance ID 'i-0fe8a8adc1403f5b1' does not exist\n\n\n"))
 	require.Equal(t, "instance ID '?' does not exist\n\n\n", buf.String())
 }
+
+func TestGoogleProject(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("The resource 'projects/xxx' was not found\n"))
+	require.Equal(t, "The resource ? was not found\n", buf.String())
+}
+
+func TestAzureTime(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	repl := NewSentryReplacer(buf)
+	_, _ = repl.Write([]byte("'start time': '2023-06-24T19:34:34.2581206+00:00'\n"))
+	require.Equal(t, "'start time': '?'\n", buf.String())
+}


### PR DESCRIPTION
We see bunch of Azure and GCP errors in GlitchTip, each error is unique because project id and operation start time. This makes sure all errors are grouped together.