### PR TITLE
chore: retry GCP get instance details

### DIFF
--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -255,9 +255,9 @@ func FetchInstancesDescriptionAWS(ctx context.Context, args *LaunchInstanceAWSTa
 	}
 
 	err = waitAndRetry(ctx, func() error {
-		instancesDescriptionList, err := ec2Client.DescribeInstanceDetails(ctx, instancesIDList)
-		if err != nil {
-			return fmt.Errorf("cannot get list instances description: %w", err)
+		instancesDescriptionList, errRetry := ec2Client.DescribeInstanceDetails(ctx, instancesIDList)
+		if errRetry != nil {
+			return fmt.Errorf("cannot get list instances description: %w", errRetry)
 		}
 
 		if len(instancesDescriptionList) == 0 {
@@ -265,8 +265,8 @@ func FetchInstancesDescriptionAWS(ctx context.Context, args *LaunchInstanceAWSTa
 		}
 
 		for _, instance := range instancesDescriptionList {
-			err := rDao.UpdateReservationInstance(ctx, args.ReservationID, instance)
-			if err != nil {
+			errRetry := rDao.UpdateReservationInstance(ctx, args.ReservationID, instance)
+			if errRetry != nil {
 				return fmt.Errorf("cannot update instance description: %w", err)
 			}
 		}


### PR DESCRIPTION
I accidentally pushed into `main` from my IDE. I do believe the code is correct, there is a linter issue tho.

Instead of revert, let’s do a proper review and only in case we find it is not correct I can revert.

https://github.com/RHEnVision/provisioning-backend/commit/079d149c99c71f54a6dd32fea82cf6adf30c5f8b

This PR will fix all comments.