### PR TITLE
chore: Fix aws configuration doc

### DIFF
--- a/docs/configure-amazon-role.md
+++ b/docs/configure-amazon-role.md
@@ -137,7 +137,7 @@ Create a new policy for the Tenant account:
                 "ec2:ImportKeyPair",
                 "ec2:RunInstances",
                 "ec2:StartInstances",
-                "ec2:ListRolePolicies",
+                "iam:ListRolePolicies"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
There was misleading information in our docs. We could merge this with some other fixes, but let's not forget this.
