### PR TITLE
fix(HMS-2233): fix reservation id tag for AWS

### DIFF
--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -395,22 +395,25 @@ func (c *ec2Client) RunInstances(ctx context.Context, params *clients.AWSInstanc
 		KeyName:        &params.KeyName,
 		UserData:       &encodedUserData,
 	}
-	if name != nil {
-		input.TagSpecifications = []types.TagSpecification{
-			{
-				ResourceType: types.ResourceTypeInstance,
-				Tags: []types.Tag{
-					{
-						Key:   ptr.To("Name"),
-						Value: name,
-					},
-					{
-						Key:   ptr.To("rhhc:rid"),
-						Value: ptr.To(config.EnvironmentPrefix("r", strconv.FormatInt(reservation.ID, 10))),
-					},
+
+	input.TagSpecifications = []types.TagSpecification{
+		{
+			ResourceType: types.ResourceTypeInstance,
+			Tags: []types.Tag{
+				{
+					Key:   ptr.To("rhhc:rid"),
+					Value: ptr.To(config.EnvironmentPrefix("r", strconv.FormatInt(reservation.ID, 10))),
 				},
 			},
+		},
+	}
+
+	if name != nil {
+		t := types.Tag{
+			Key:   ptr.To("Name"),
+			Value: name,
 		}
+		input.TagSpecifications[0].Tags = append(input.TagSpecifications[0].Tags, t)
 	}
 
 	resp, err := c.ec2.RunInstances(ctx, input)

--- a/internal/middleware/enforce_identity.go
+++ b/internal/middleware/enforce_identity.go
@@ -55,6 +55,7 @@ func EnforceIdentity(next http.Handler) http.Handler {
 
 		topLevelOrgIDFallback(&jsonData)
 
+		logger.Debug().RawJSON("user", []byte(idRaw)).Msg("Enforcing identity")
 		err = checkHeader(r.Context(), &jsonData, w)
 		if err != nil {
 			return


### PR DESCRIPTION
Only worked when Name was provided. Name is not supported from the UI, so this is why it does not work on stage/prod. Also adding user to logging which will be useful for identification of owner of the instance.