### PR TITLE
feat(HMS-2225): Add limit,  offset and metadata

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - contextcheck # too restrictive
     - depguard # too verbose
     - tagalign # cleanenv is unreadable
+    - exhaustive
 linters-settings:
   govet:
     check-shadowing: true

--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -406,6 +406,26 @@
         }
       }
     },
+    "parameters": {
+      "Limit": {
+        "description": "The number of items to return",
+        "in": "query",
+        "name": "limit",
+        "schema": {
+          "default": 100,
+          "type": "integer"
+        }
+      },
+      "Offset": {
+        "description": "The number of items to skip before starting to collect the result set",
+        "in": "query",
+        "name": "offset",
+        "schema": {
+          "default": 0,
+          "type": "integer"
+        }
+      }
+    },
     "responses": {
       "BadRequest": {
         "content": {
@@ -1290,6 +1310,14 @@
       "get": {
         "description": "A pubkey represents an SSH public portion of a key pair with name and body. This operation returns list of all pubkeys for particular account.\n",
         "operationId": "getPubkeyList",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -1436,6 +1464,14 @@
       "get": {
         "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. This operation returns list of all reservations for particular account. To get a reservation with common fields, use /reservations/ID. To get a detailed reservation with all fields which are different per provider, use /reservations/aws/ID. Reservation can be in three states: pending, success, failed. This can be recognized by the success field (null for pending, true for success, false for failure). See the examples.\n",
         "operationId": "getReservationsList",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -1794,16 +1830,10 @@
         "operationId": "getSourceList",
         "parameters": [
           {
-            "in": "query",
-            "name": "provider",
-            "schema": {
-              "enum": [
-                "aws",
-                "azure",
-                "gcp"
-              ],
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
           }
         ],
         "responses": {

--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -229,7 +229,14 @@
               "steps": 3,
               "success": false
             }
-          ]
+          ],
+          "links": {
+            "next": "",
+            "previous": ""
+          },
+          "metadata": {
+            "total": 3
+          }
         }
       },
       "v1.GenericReservationResponsePayloadPendingExample": {
@@ -339,11 +346,18 @@
               "body": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEhnn80ZywmjeBFFOGm+cm+5HUwm62qTVnjKlOdYFLHN lzap",
               "fingerprint": "gL/y6MvNmJ8jDXtsL/oMmK8jUuIefN39BBuvYw/Rndk=",
               "fingerprint_legacy": "ee:f1:d4:62:99:ab:17:d9:3b:00:66:62:32:b2:55:9e",
-              "id": 1,
+              "id": 3,
               "name": "My key",
               "type": "ssh-ed25519"
             }
-          ]
+          ],
+          "links": {
+            "next": "",
+            "previous": "/api/provisioning/v1/pubkeys?limit=2\u0026offset=0"
+          },
+          "metadata": {
+            "total": 3
+          }
         }
       },
       "v1.PubkeyRequestExample": {
@@ -377,7 +391,14 @@
               "source_type_id": "",
               "uid": ""
             }
-          ]
+          ],
+          "links": {
+            "next": "",
+            "previous": "/api/provisioning/v1/sources?limit=2\u0026offset=0"
+          },
+          "metadata": {
+            "total": 4
+          }
         }
       },
       "v1.SourceUploadInfoAWSResponse": {
@@ -944,6 +965,25 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "links": {
+            "properties": {
+              "next": {
+                "type": "string"
+              },
+              "previous": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "metadata": {
+            "properties": {
+              "total": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         },
         "type": "object"
@@ -1044,6 +1084,25 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "links": {
+            "properties": {
+              "next": {
+                "type": "string"
+              },
+              "previous": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "metadata": {
+            "properties": {
+              "total": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         },
         "type": "object"
@@ -1069,6 +1128,25 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "links": {
+            "properties": {
+              "next": {
+                "type": "string"
+              },
+              "previous": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "metadata": {
+            "properties": {
+              "total": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         },
         "type": "object"
@@ -1829,6 +1907,18 @@
         "description": "Cloud credentials are kept in the sources application. This endpoint lists available sources for the particular account per individual type (AWS, Azure, ...). All the fields in the response are optional and can be omitted if Sources application also omits them.\n",
         "operationId": "getSourceList",
         "parameters": [
+          {
+            "in": "query",
+            "name": "provider",
+            "schema": {
+              "enum": [
+                "aws",
+                "azure",
+                "gcp"
+              ],
+              "type": "string"
+            }
+          },
           {
             "$ref": "#/components/parameters/Limit"
           },

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -471,6 +471,21 @@ components:
                     nullable: true
                 provider:
                     type: string
+    parameters:
+        Limit:
+            name: limit
+            in: query
+            description: The number of items to return
+            schema:
+                type: integer
+                default: 100
+        Offset:
+            name: offset
+            in: query
+            description: The number of items to skip before starting to collect the result set
+            schema:
+                type: integer
+                default: 0
     responses:
         BadRequest:
             description: The request's parameters are not valid
@@ -901,6 +916,9 @@ paths:
             description: |
                 A pubkey represents an SSH public portion of a key pair with name and body. This operation returns list of all pubkeys for particular account.
             operationId: getPubkeyList
+            parameters:
+                - $ref: '#/components/parameters/Limit'
+                - $ref: '#/components/parameters/Offset'
             responses:
                 "200":
                     description: Returned on success.
@@ -998,6 +1016,9 @@ paths:
             description: |
                 A reservation is a way to activate a job, keeps all data needed for a job to start. This operation returns list of all reservations for particular account. To get a reservation with common fields, use /reservations/ID. To get a detailed reservation with all fields which are different per provider, use /reservations/aws/ID. Reservation can be in three states: pending, success, failed. This can be recognized by the success field (null for pending, true for success, false for failure). See the examples.
             operationId: getReservationsList
+            parameters:
+                - $ref: '#/components/parameters/Limit'
+                - $ref: '#/components/parameters/Offset'
             responses:
                 "200":
                     description: Returned on success.
@@ -1229,14 +1250,8 @@ paths:
                 Cloud credentials are kept in the sources application. This endpoint lists available sources for the particular account per individual type (AWS, Azure, ...). All the fields in the response are optional and can be omitted if Sources application also omits them.
             operationId: getSourceList
             parameters:
-                - name: provider
-                  in: query
-                  schema:
-                    type: string
-                    enum:
-                        - aws
-                        - azure
-                        - gcp
+                - $ref: '#/components/parameters/Limit'
+                - $ref: '#/components/parameters/Offset'
             responses:
                 "200":
                     description: Returned on success.

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -307,6 +307,18 @@ components:
                             success:
                                 type: boolean
                                 nullable: true
+                links:
+                    type: object
+                    properties:
+                        next:
+                            type: string
+                        previous:
+                            type: string
+                metadata:
+                    type: object
+                    properties:
+                        total:
+                            type: integer
         v1.ListInstaceTypeResponse:
             type: object
             properties:
@@ -373,6 +385,18 @@ components:
                                 type: string
                             type:
                                 type: string
+                links:
+                    type: object
+                    properties:
+                        next:
+                            type: string
+                        previous:
+                            type: string
+                metadata:
+                    type: object
+                    properties:
+                        total:
+                            type: integer
         v1.ListSourceResponse:
             type: object
             properties:
@@ -389,6 +413,18 @@ components:
                                 type: string
                             uid:
                                 type: string
+                links:
+                    type: object
+                    properties:
+                        next:
+                            type: string
+                        previous:
+                            type: string
+                metadata:
+                    type: object
+                    properties:
+                        total:
+                            type: integer
         v1.NoopReservationResponse:
             type: object
             properties:
@@ -717,6 +753,11 @@ components:
                         - Fetch instance(s) description
                       steps: 3
                       success: false
+                links:
+                    next: ""
+                    previous: ""
+                metadata:
+                    total: 3
         v1.GenericReservationResponsePayloadPendingExample:
             value:
                 created_at: "2013-05-13T19:20:15Z"
@@ -794,9 +835,14 @@ components:
                     - body: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEhnn80ZywmjeBFFOGm+cm+5HUwm62qTVnjKlOdYFLHN lzap
                       fingerprint: gL/y6MvNmJ8jDXtsL/oMmK8jUuIefN39BBuvYw/Rndk=
                       fingerprint_legacy: ee:f1:d4:62:99:ab:17:d9:3b:00:66:62:32:b2:55:9e
-                      id: 1
+                      id: 3
                       name: My key
                       type: ssh-ed25519
+                links:
+                    next: ""
+                    previous: /api/provisioning/v1/pubkeys?limit=2&offset=0
+                metadata:
+                    total: 3
         v1.PubkeyRequestExample:
             value:
                 body: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEhnn80ZywmjeBFFOGm+cm+5HUwm62qTVnjKlOdYFLHN lzap
@@ -820,6 +866,11 @@ components:
                       name: My other AWS account
                       source_type_id: ""
                       uid: ""
+                links:
+                    next: ""
+                    previous: /api/provisioning/v1/sources?limit=2&offset=0
+                metadata:
+                    total: 4
         v1.SourceUploadInfoAWSResponse:
             value:
                 aws:
@@ -1250,6 +1301,14 @@ paths:
                 Cloud credentials are kept in the sources application. This endpoint lists available sources for the particular account per individual type (AWS, Azure, ...). All the fields in the response are optional and can be omitted if Sources application also omits them.
             operationId: getSourceList
             parameters:
+                - name: provider
+                  in: query
+                  schema:
+                    type: string
+                    enum:
+                        - aws
+                        - azure
+                        - gcp
                 - $ref: '#/components/parameters/Limit'
                 - $ref: '#/components/parameters/Offset'
             responses:

--- a/cmd/spec/example_pubkey.go
+++ b/cmd/spec/example_pubkey.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/RHEnVision/provisioning-backend/internal/payloads"
+import (
+	"github.com/RHEnVision/provisioning-backend/internal/page"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+)
 
 var PubkeyRequest = payloads.PubkeyRequest{
 	Name: "My key",
@@ -20,7 +23,7 @@ var PubkeyResponse = payloads.PubkeyResponse{
 var PubkeyListResponse = payloads.PubkeyListResponse{
 	Data: []*payloads.PubkeyResponse{
 		{
-			ID:                1,
+			ID:                3,
 			AccountID:         1,
 			Name:              "My key",
 			Body:              "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEhnn80ZywmjeBFFOGm+cm+5HUwm62qTVnjKlOdYFLHN lzap",
@@ -28,5 +31,12 @@ var PubkeyListResponse = payloads.PubkeyListResponse{
 			Fingerprint:       "gL/y6MvNmJ8jDXtsL/oMmK8jUuIefN39BBuvYw/Rndk=",
 			FingerprintLegacy: "ee:f1:d4:62:99:ab:17:d9:3b:00:66:62:32:b2:55:9e",
 		},
+	},
+	Metadata: page.Metadata{
+		Total: 3,
+	},
+	Links: page.Links{
+		Previous: "/api/provisioning/v1/pubkeys?limit=2&offset=0",
+		Next:     "",
 	},
 }

--- a/cmd/spec/example_reservation.go
+++ b/cmd/spec/example_reservation.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 )
@@ -62,6 +63,13 @@ var GenericReservationResponsePayloadListExample = payloads.GenericReservationLi
 		&GenericReservationResponsePayloadPendingExample,
 		&GenericReservationResponsePayloadSuccessExample,
 		&GenericReservationResponsePayloadFailureExample,
+	},
+	Metadata: page.Metadata{
+		Total: 3,
+	},
+	Links: page.Links{
+		Previous: "",
+		Next:     "",
 	},
 }
 

--- a/cmd/spec/example_source.go
+++ b/cmd/spec/example_source.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 )
 
@@ -14,6 +15,13 @@ var SourceListResponse = payloads.SourceListResponse{
 			ID:   "543621",
 			Name: "My other AWS account",
 		},
+	},
+	Metadata: page.Metadata{
+		Total: 4,
+	},
+	Links: page.Links{
+		Previous: "/api/provisioning/v1/sources?limit=2&offset=0",
+		Next:     "",
 	},
 }
 

--- a/cmd/spec/parameters.go
+++ b/cmd/spec/parameters.go
@@ -1,0 +1,28 @@
+package main
+
+type Parameter struct {
+	Name        string      `json:"name" yaml:"name"`
+	Description string      `json:"description" yaml:"description"`
+	Required    bool        `json:"required" yaml:"required"`
+	Default     interface{} `json:"default" yaml:"default"`
+	Type        string      `json:"type" yaml:"type"`
+	In          string      `json:"in" yaml:"in"`
+}
+
+var LimitQueryParam = Parameter{
+	Name:        "limit",
+	Description: "The number of items to return",
+	Default:     100,
+	Type:        "integer",
+	Required:    false,
+	In:          "query",
+}
+
+var OffsetQueryParam = Parameter{
+	Name:        "offset",
+	Description: "The number of items to skip before starting to collect the result set",
+	Default:     0,
+	Type:        "integer",
+	Required:    false,
+	In:          "query",
+}

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -107,6 +107,9 @@ paths:
       operationId: getPubkeyList
       tags:
         - Pubkey
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
       description: >
         A pubkey represents an SSH public portion of a key pair with name and body.
         This operation returns list of all pubkeys for particular account.
@@ -132,14 +135,8 @@ paths:
       tags:
         - Source
       parameters:
-      - name: provider
-        in: query
-        schema:
-          type: string
-          enum:
-            - aws
-            - azure
-            - gcp
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
       responses:
         '200':
           description: Returned on success.
@@ -341,6 +338,9 @@ paths:
       operationId: getReservationsList
       tags:
         - Reservation
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
       description: >
         A reservation is a way to activate a job, keeps all data needed for a job to start.
         This operation returns list of all reservations for particular account. To get a

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -135,6 +135,14 @@ paths:
       tags:
         - Source
       parameters:
+        - name: provider
+          in: query
+          schema:
+            type: string
+            enum:
+                - aws
+                - azure
+                - gcp
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
       responses:

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -82,7 +82,7 @@ func (c *sourcesClient) Ready(ctx context.Context) error {
 	return nil
 }
 
-func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, provider models.ProviderType) ([]*clients.Source, error) {
+func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, provider models.ProviderType) ([]*clients.Source, int, error) {
 	logger := logger(ctx)
 	params := &ListApplicationTypeSourcesParams{}
 	ctx, span := otel.Tracer(TraceName).Start(ctx, "ListProvisioningSourcesByProvider")
@@ -91,13 +91,13 @@ func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, p
 	appTypeId, err := c.GetProvisioningTypeId(ctx)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to get provisioning type id")
-		return nil, fmt.Errorf("failed to get provisioning app type: %w", err)
+		return nil, 0, fmt.Errorf("failed to get provisioning app type: %w", err)
 	}
 
 	sourcesProviderName := provider.SourcesProviderName()
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to get provider name according to sources service")
-		return nil, fmt.Errorf("failed to get provider name according to sources service: %w", err)
+		return nil, 0, fmt.Errorf("failed to get provider name according to sources service: %w", err)
 	}
 
 	offset := page.Offset(ctx).String()
@@ -107,15 +107,15 @@ func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, p
 		headers.AddEdgeRequestIdHeader, BuildQuery("filter[source_type][name]", sourcesProviderName, "offset", offset, "limit", limit))
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to fetch ApplicationTypes from sources")
-		return nil, fmt.Errorf("failed to get ApplicationTypes: %w", err)
+		return nil, 0, fmt.Errorf("failed to get ApplicationTypes: %w", err)
 	}
 
 	err = http.HandleHTTPResponses(ctx, resp.StatusCode())
 	if err != nil {
 		if errors.Is(err, clients.NotFoundErr) {
-			return nil, fmt.Errorf("list provisioning sources call: %w", http.SourceNotFoundErr)
+			return nil, 0, fmt.Errorf("list provisioning sources call: %w", http.SourceNotFoundErr)
 		}
-		return nil, fmt.Errorf("list provisioning sources call: %w", err)
+		return nil, 0, fmt.Errorf("list provisioning sources call: %w", err)
 	}
 
 	result := make([]*clients.Source, 0, len(*resp.JSON200.Data))
@@ -130,10 +130,15 @@ func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, p
 		result = append(result, &newSrc)
 	}
 
-	return result, nil
+	total := 0
+	if resp.JSON200.Meta != nil {
+		total = *resp.JSON200.Meta.Count
+	}
+
+	return result, total, nil
 }
 
-func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clients.Source, error) {
+func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clients.Source, int, error) {
 	logger := logger(ctx)
 	params := &ListApplicationTypeSourcesParams{}
 	ctx, span := otel.Tracer(TraceName).Start(ctx, "ListAllProvisioningSources")
@@ -142,7 +147,7 @@ func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clie
 	appTypeId, err := c.GetProvisioningTypeId(ctx)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to get provisioning type id")
-		return nil, fmt.Errorf("failed to get provisioning app type: %w", err)
+		return nil, 0, fmt.Errorf("failed to get provisioning app type: %w", err)
 	}
 
 	params.Offset = page.Offset(ctx).IntPtr()
@@ -151,15 +156,15 @@ func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clie
 	resp, err := c.client.ListApplicationTypeSourcesWithResponse(ctx, appTypeId, params, headers.AddSourcesIdentityHeader, headers.AddEdgeRequestIdHeader)
 	if err != nil {
 		logger.Warn().Err(err).Msg("Failed to fetch ApplicationTypes from sources")
-		return nil, fmt.Errorf("failed to get ApplicationTypes: %w", err)
+		return nil, 0, fmt.Errorf("failed to get ApplicationTypes: %w", err)
 	}
 
 	err = http.HandleHTTPResponses(ctx, resp.StatusCode())
 	if err != nil {
 		if errors.Is(err, clients.NotFoundErr) {
-			return nil, fmt.Errorf("list provisioning sources call: %w", http.SourceNotFoundErr)
+			return nil, 0, fmt.Errorf("list provisioning sources call: %w", http.SourceNotFoundErr)
 		}
-		return nil, fmt.Errorf("list provisioning sources call: %w", err)
+		return nil, 0, fmt.Errorf("list provisioning sources call: %w", err)
 	}
 
 	result := make([]*clients.Source, len(*resp.JSON200.Data))
@@ -172,7 +177,13 @@ func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clie
 		}
 		result[i] = &newSrc
 	}
-	return result, nil
+
+	total := 0
+	if resp.JSON200.Meta != nil {
+		total = *resp.JSON200.Meta.Count
+	}
+
+	return result, total, nil
 }
 
 func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId string) (*clients.Authentication, error) {

--- a/internal/clients/http/sources/sources_client_test.go
+++ b/internal/clients/http/sources/sources_client_test.go
@@ -112,9 +112,9 @@ func TestSourcesClient_ListAllProvisioningSources(t *testing.T) {
 	client, err := sources.NewSourcesClientWithUrl(ctx, ts.URL)
 	require.NoError(t, err, "failed to initialize sources client with test server")
 
-	sources, clientErr := client.ListAllProvisioningSources(ctx)
+	sources, total, clientErr := client.ListAllProvisioningSources(ctx)
 	assert.NoError(t, clientErr, "Could not list all provisioning sources")
-	assert.Equal(t, 2, len(sources))
+	assert.Equal(t, 2, total)
 	assert.Equal(t, "1", sources[0].SourceTypeID)
 	assert.Equal(t, "2", sources[1].SourceTypeID)
 }

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -13,10 +13,10 @@ var GetSourcesClient func(ctx context.Context) (Sources, error)
 // Sources interface provides access to the Sources backend service API
 type Sources interface {
 	// ListProvisioningSourcesByProvider returns sources filtered by provider that have provisioning credentials assigned
-	ListProvisioningSourcesByProvider(ctx context.Context, provider models.ProviderType) ([]*Source, error)
+	ListProvisioningSourcesByProvider(ctx context.Context, provider models.ProviderType) ([]*Source, int, error)
 
 	// ListAllProvisioningSources returns all sources that have provisioning credentials assigned
-	ListAllProvisioningSources(ctx context.Context) ([]*Source, error)
+	ListAllProvisioningSources(ctx context.Context) ([]*Source, int, error)
 
 	// GetArn returns authentication associated with provisioning app for given sourceId
 	GetAuthentication(ctx context.Context, sourceId string) (*Authentication, error)

--- a/internal/clients/stubs/sources_stub.go
+++ b/internal/clients/stubs/sources_stub.go
@@ -98,7 +98,7 @@ func (mock *SourcesClientStub) GetProvisioningTypeId(ctx context.Context) (strin
 	return "11", nil
 }
 
-func (mock *SourcesClientStub) ListAllProvisioningSources(ctx context.Context) ([]*clients.Source, error) {
+func (mock *SourcesClientStub) ListAllProvisioningSources(ctx context.Context) ([]*clients.Source, int, error) {
 	TestSourceData := []*clients.Source{
 		{
 			ID:           "1",
@@ -113,10 +113,10 @@ func (mock *SourcesClientStub) ListAllProvisioningSources(ctx context.Context) (
 			Uid:          "31b5338b-685d-4056-ba39-d00b4d7f19cc",
 		},
 	}
-	return TestSourceData, nil
+	return TestSourceData, 2, nil
 }
 
-func (mock *SourcesClientStub) ListProvisioningSourcesByProvider(ctx context.Context, provider models.ProviderType) ([]*clients.Source, error) {
+func (mock *SourcesClientStub) ListProvisioningSourcesByProvider(ctx context.Context, provider models.ProviderType) ([]*clients.Source, int, error) {
 	TestSourceData := []*clients.Source{
 		{
 			ID:           "1",
@@ -131,7 +131,7 @@ func (mock *SourcesClientStub) ListProvisioningSourcesByProvider(ctx context.Con
 			Uid:          "31b5338b-685d-4056-ba39-d00b4d7f19cc",
 		},
 	}
-	return TestSourceData, nil
+	return TestSourceData, 2, nil
 }
 
 // APIClient

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -38,6 +38,7 @@ type PubkeyDao interface {
 	Update(ctx context.Context, pk *models.Pubkey) error
 	GetById(ctx context.Context, id int64) (*models.Pubkey, error)
 	List(ctx context.Context, limit, offset int64) ([]*models.Pubkey, error)
+	Count(ctx context.Context) (int, error)
 	Delete(ctx context.Context, id int64) error
 
 	UnscopedCreateResource(ctx context.Context, pkr *models.PubkeyResource) error
@@ -78,6 +79,9 @@ type ReservationDao interface {
 
 	// GetGCPById returns reservation for a particular account.
 	GetGCPById(ctx context.Context, id int64) (*models.GCPReservation, error)
+
+	// Count returns total reservations for a particular account.
+	Count(ctx context.Context) (int, error)
 
 	// List returns reservation for a particular account.
 	List(ctx context.Context, limit, offset int64) ([]*models.Reservation, error)

--- a/internal/dao/pgx/pubkey_pgx.go
+++ b/internal/dao/pgx/pubkey_pgx.go
@@ -110,6 +110,19 @@ func (x *pubkeyDao) List(ctx context.Context, limit, offset int64) ([]*models.Pu
 	return result, nil
 }
 
+func (x *pubkeyDao) Count(ctx context.Context) (int, error) {
+	query := `SELECT COUNT(*) FROM pubkeys WHERE account_id = $1`
+	accountId := identity.AccountId(ctx)
+
+	var result int
+	err := db.Pool.QueryRow(ctx, query, accountId).Scan(&result)
+	if err != nil {
+		return 0, fmt.Errorf("pgx error: %w", err)
+	}
+
+	return result, nil
+}
+
 func (x *pubkeyDao) Delete(ctx context.Context, id int64) error {
 	query := `DELETE FROM pubkeys WHERE account_id = $1 AND id = $2`
 	accountId := identity.AccountId(ctx)

--- a/internal/dao/pgx/reservation_pgx.go
+++ b/internal/dao/pgx/reservation_pgx.go
@@ -235,6 +235,19 @@ func (x *reservationDao) GetGCPById(ctx context.Context, id int64) (*models.GCPR
 	return result, nil
 }
 
+func (x *reservationDao) Count(ctx context.Context) (int, error) {
+	query := `SELECT COUNT(*) FROM reservations WHERE account_id = $1`
+	accountId := identity.AccountId(ctx)
+
+	var result int
+	err := db.Pool.QueryRow(ctx, query, accountId).Scan(&result)
+	if err != nil {
+		return 0, fmt.Errorf("pgx error: %w", err)
+	}
+
+	return result, nil
+}
+
 func (x *reservationDao) List(ctx context.Context, limit, offset int64) ([]*models.Reservation, error) {
 	query := `SELECT * FROM reservations WHERE account_id = $1 ORDER BY id LIMIT $2 OFFSET $3`
 

--- a/internal/dao/stubs/pubkey_dao.go
+++ b/internal/dao/stubs/pubkey_dao.go
@@ -82,6 +82,10 @@ func (stub *pubkeyDaoStub) List(ctx context.Context, limit, offset int64) ([]*mo
 	return filtered, nil
 }
 
+func (stub *pubkeyDaoStub) Count(ctx context.Context) (int, error) {
+	return len(stub.store), nil
+}
+
 func (stub *pubkeyDaoStub) Delete(ctx context.Context, id int64) error {
 	for idx, p := range stub.store {
 		if p.AccountID == ctxAccountId(ctx) && p.ID == id {

--- a/internal/dao/stubs/reservation_dao.go
+++ b/internal/dao/stubs/reservation_dao.go
@@ -103,6 +103,10 @@ func (stub *reservationDaoStub) GetGCPById(ctx context.Context, id int64) (*mode
 	return nil, dao.ErrNoRows
 }
 
+func (stub *reservationDaoStub) Count(ctx context.Context) (int, error) {
+	return len(stub.storeAWS) + len(stub.storeAzure) + len(stub.storeGCP), nil
+}
+
 func (stub *reservationDaoStub) List(ctx context.Context, limit, offset int64) ([]*models.Reservation, error) {
 	return nil, nil
 }

--- a/internal/middleware/pagination_middleware.go
+++ b/internal/middleware/pagination_middleware.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/RHEnVision/provisioning-backend/internal/page"
+)
+
+// Pagination middleware is used to extract the offset and the limit
+func Pagination(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		offset := r.URL.Query().Get("offset")
+		limit := r.URL.Query().Get("limit")
+
+		newCtx := page.WithOffset(r.Context(), offset)
+		newCtx = page.WithLimit(newCtx, limit)
+		next.ServeHTTP(w, r.WithContext(newCtx))
+	})
+}

--- a/internal/middleware/pagination_middleware_test.go
+++ b/internal/middleware/pagination_middleware_test.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RHEnVision/provisioning-backend/internal/page"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaginationMiddleware(t *testing.T) {
+	t.Run("with limit and offset", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), "GET", "/api/data?offset=10&limit=20", nil)
+		require.NoError(t, err, "failed to create request")
+		rr := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			limit := page.Limit(r.Context()).Int()
+			offset := page.Offset(r.Context()).Int()
+			assert.Equal(t, 10, offset)
+			assert.Equal(t, 20, limit)
+		})
+
+		paginationHandler := Pagination(handler)
+		paginationHandler.ServeHTTP(rr, req)
+	})
+	t.Run("without limit and offset", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), "GET", "/api/data?offset=&limit=", nil)
+		require.NoError(t, err, "failed to create request")
+		rr := httptest.NewRecorder()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			limit := page.Limit(r.Context()).Int()
+			offset := page.Offset(r.Context()).Int()
+			assert.Equal(t, 0, offset)
+			assert.Equal(t, 100, limit)
+		})
+
+		paginationHandler := Pagination(handler)
+		paginationHandler.ServeHTTP(rr, req)
+	})
+}

--- a/internal/page/page.go
+++ b/internal/page/page.go
@@ -1,0 +1,76 @@
+package page
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
+	"github.com/rs/zerolog"
+)
+
+type (
+	ctxKeyType  int
+	limitOffset int
+)
+
+const (
+	offsetCtxKey ctxKeyType = iota
+	limitCtxKey
+)
+
+const (
+	defaultValueLimit  = 100
+	defaultValueOffset = 0
+)
+
+// WithOffset returns context copy with offset value.
+func WithOffset(ctx context.Context, offsetStr string) context.Context {
+	logger := zerolog.Ctx(ctx)
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		logger.Err(err).Msg("Offset is missing or invalid, setting offset value to 0")
+		offset = defaultValueOffset
+	}
+	return context.WithValue(ctx, offsetCtxKey, offset)
+}
+
+// WithLimit returns context copy with limit value.
+func WithLimit(ctx context.Context, limitStr string) context.Context {
+	logger := zerolog.Ctx(ctx)
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit < 0 {
+		logger.Err(err).Msg("Limit is missing or invalid, setting limit value to 100")
+		limit = defaultValueLimit
+	}
+	return context.WithValue(ctx, limitCtxKey, limit)
+}
+
+func Limit(ctx context.Context) limitOffset {
+	if lim, ok := ctx.Value(limitCtxKey).(int); ok {
+		return limitOffset(lim)
+	}
+	return limitOffset(defaultValueLimit)
+}
+
+func Offset(ctx context.Context) limitOffset {
+	if off, ok := ctx.Value(offsetCtxKey).(int); ok {
+		return limitOffset(off)
+	}
+	return limitOffset(defaultValueOffset)
+}
+
+func (o limitOffset) IntPtr() *int {
+	return ptr.To(int(o))
+}
+
+func (o limitOffset) Int() int {
+	return int(o)
+}
+
+func (o limitOffset) Int64() int64 {
+	return int64(o)
+}
+
+func (o limitOffset) String() string {
+	return strconv.Itoa(int(o))
+}

--- a/internal/payloads/pubkey_payload.go
+++ b/internal/payloads/pubkey_payload.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 
 	"github.com/go-chi/render"
 )
@@ -25,7 +26,9 @@ type PubkeyResponse struct {
 	FingerprintLegacy string `json:"fingerprint_legacy,omitempty" yaml:"fingerprint_legacy,omitempty"`
 }
 type PubkeyListResponse struct {
-	Data []*PubkeyResponse `json:"data" yaml:"data"`
+	Data     []*PubkeyResponse `json:"data" yaml:"data"`
+	Metadata page.Metadata     `json:"metadata" yaml:"metadata"`
+	Links    page.Links        `json:"links" yaml:"links"`
 }
 
 func (p *PubkeyRequest) Bind(_ *http.Request) error {
@@ -59,10 +62,10 @@ func NewPubkeyResponse(pubkey *models.Pubkey) *PubkeyResponse {
 	}
 }
 
-func NewPubkeyListResponse(pubkeys []*models.Pubkey) render.Renderer {
+func NewPubkeyListResponse(pubkeys []*models.Pubkey, info *page.Info) render.Renderer {
 	list := make([]*PubkeyResponse, len(pubkeys))
 	for i, pubkey := range pubkeys {
 		list[i] = NewPubkeyResponse(pubkey)
 	}
-	return &PubkeyListResponse{Data: list}
+	return &PubkeyListResponse{Data: list, Metadata: info.Metadata, Links: info.Links}
 }

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 	"github.com/go-chi/render"
 )
 
@@ -240,7 +241,9 @@ type GCPReservationRequest struct {
 }
 
 type GenericReservationListResponse struct {
-	Data []*GenericReservationResponse `json:"data" yaml:"data"`
+	Data     []*GenericReservationResponse `json:"data" yaml:"data"`
+	Metadata page.Metadata                 `json:"metadata" yaml:"metadata"`
+	Links    page.Links                    `json:"links" yaml:"links"`
 }
 
 func (p *GenericReservationResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
@@ -361,12 +364,12 @@ func NewNoopReservationResponse(reservation *models.NoopReservation) render.Rend
 	}
 }
 
-func NewReservationListResponse(reservations []*models.Reservation) render.Renderer {
+func NewReservationListResponse(reservations []*models.Reservation, info *page.Info) render.Renderer {
 	list := make([]*GenericReservationResponse, len(reservations))
 	for i, reservation := range reservations {
 		list[i] = reservationResponseMapper(reservation)
 	}
-	return &GenericReservationListResponse{Data: list}
+	return &GenericReservationListResponse{Data: list, Metadata: info.Metadata, Links: info.Links}
 }
 
 func reservationResponseMapper(reservation *models.Reservation) *GenericReservationResponse {

--- a/internal/payloads/sources_payload.go
+++ b/internal/payloads/sources_payload.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 	"github.com/go-chi/render"
 )
 
@@ -16,7 +17,9 @@ type SourceResponse struct {
 }
 
 type SourceListResponse struct {
-	Data []*SourceResponse `json:"data" yaml:"data"`
+	Data     []*SourceResponse `json:"data" yaml:"data"`
+	Metadata page.Metadata     `json:"metadata" yaml:"metadata"`
+	Links    page.Links        `json:"links" yaml:"links"`
 }
 
 func (s *SourceResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
@@ -27,7 +30,7 @@ func (s *SourceListResponse) Render(_ http.ResponseWriter, _ *http.Request) erro
 	return nil
 }
 
-func NewListSourcesResponse(sourceList []*clients.Source) render.Renderer {
+func NewListSourcesResponse(sourceList []*clients.Source, info *page.Info) render.Renderer {
 	list := make([]*SourceResponse, len(sourceList))
 	for i, source := range sourceList {
 		list[i] = &SourceResponse{
@@ -37,7 +40,7 @@ func NewListSourcesResponse(sourceList []*clients.Source) render.Renderer {
 			Uid:          source.Uid,
 		}
 	}
-	return &SourceListResponse{Data: list}
+	return &SourceListResponse{Data: list, Metadata: info.Metadata, Links: info.Links}
 }
 
 type SourceUploadInfoResponse struct {

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -65,6 +65,7 @@ func MountAPI(r *chi.Mux) {
 			// r.Use(middleware.EnforcePermissions("source", "read"))
 
 			r.Get("/", s.ListSources)
+			r.With(middleware.Pagination).Get("/", s.ListSources)
 			r.Route("/{ID}", func(r chi.Router) {
 				r.Get("/status", s.SourcesStatus)
 
@@ -84,7 +85,8 @@ func MountAPI(r *chi.Mux) {
 
 		r.Route("/pubkeys", func(r chi.Router) {
 			r.With(middleware.EnforcePermissions("pubkey", "write")).Post("/", s.CreatePubkey)
-			r.With(middleware.EnforcePermissions("pubkey", "read")).Get("/", s.ListPubkeys)
+			r.With(middleware.EnforcePermissions("pubkey", "read")).With(middleware.Pagination).Get("/", s.ListPubkeys)
+			r.Post("/", s.CreatePubkey)
 			r.Route("/{ID}", func(r chi.Router) {
 				r.With(middleware.EnforcePermissions("pubkey", "read")).Get("/", s.GetPubkey)
 				r.With(middleware.EnforcePermissions("pubkey", "write")).Delete("/", s.DeletePubkey)
@@ -92,7 +94,7 @@ func MountAPI(r *chi.Mux) {
 		})
 
 		r.Route("/reservations", func(r chi.Router) {
-			r.With(middleware.EnforcePermissions("reservation", "read")).Get("/", s.ListReservations)
+			r.With(middleware.EnforcePermissions("reservation", "read")).With(middleware.Pagination).Get("/", s.ListReservations)
 			// Different types do have different payloads, therefore TYPE must be part of
 			// URL and not a URL (filter) parameter.
 			r.Route("/{TYPE}", func(r chi.Router) {

--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/db"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/render"
 	"github.com/rs/zerolog"
@@ -49,7 +50,10 @@ func CreatePubkey(w http.ResponseWriter, r *http.Request) {
 func ListPubkeys(w http.ResponseWriter, r *http.Request) {
 	pubkeyDao := dao.GetPubkeyDao(r.Context())
 
-	pubkeys, err := pubkeyDao.List(r.Context(), 100, 0)
+	offset := page.Offset(r.Context()).Int64()
+	limit := page.Limit(r.Context()).Int64()
+
+	pubkeys, err := pubkeyDao.List(r.Context(), limit, offset)
 	if err != nil {
 		renderError(w, r, payloads.NewDAOError(r.Context(), "list pubkeys", err))
 		return

--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -59,7 +59,15 @@ func ListPubkeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := render.Render(w, r, payloads.NewPubkeyListResponse(pubkeys)); err != nil {
+	totalPubkeys, err := pubkeyDao.Count(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewDAOError(r.Context(), "count pubkeys", err))
+		return
+	}
+
+	info := page.APIInfoResponse(r.Context(), r, totalPubkeys)
+
+	if err := render.Render(w, r, payloads.NewPubkeyListResponse(pubkeys, info)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render pubkeys list", err))
 		return
 	}

--- a/internal/services/pubkey_service_test.go
+++ b/internal/services/pubkey_service_test.go
@@ -24,6 +24,7 @@ func TestListPubkeysHandler(t *testing.T) {
 	ctx := stubs.WithAccountDaoOne(context.Background())
 	ctx = identity.WithTenant(t, ctx)
 	ctx = stubs.WithPubkeyDao(ctx)
+
 	err := stubs.AddPubkey(ctx, &models.Pubkey{
 		Name: factories.SeqNameWithPrefix("pubkey"),
 		Body: factories.GenerateRSAPubKey(t),
@@ -35,7 +36,7 @@ func TestListPubkeysHandler(t *testing.T) {
 	})
 	require.NoError(t, err, "failed to add stubbed key")
 
-	req, err := http.NewRequestWithContext(ctx, "GET", "/api/provisioning/pubkeys", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", "/api/provisioning/pubkeys?limit=&offset=", nil)
 	require.NoError(t, err, "failed to create request")
 
 	rr := httptest.NewRecorder()

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -69,7 +69,15 @@ func ListReservations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := render.Render(w, r, payloads.NewReservationListResponse(reservations)); err != nil {
+	totalRes, err := rDao.Count(r.Context())
+	if err != nil {
+		renderError(w, r, payloads.NewDAOError(r.Context(), "count reservations", err))
+		return
+	}
+
+	info := page.APIInfoResponse(r.Context(), r, totalRes)
+
+	if err := render.Render(w, r, payloads.NewReservationListResponse(reservations, info)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render reservations list", err))
 		return
 	}

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -59,7 +60,10 @@ func CreateReservation(w http.ResponseWriter, r *http.Request) {
 func ListReservations(w http.ResponseWriter, r *http.Request) {
 	rDao := dao.GetReservationDao(r.Context())
 
-	reservations, err := rDao.List(r.Context(), 100, 0)
+	offset := page.Offset(r.Context()).Int64()
+	limit := page.Limit(r.Context()).Int64()
+
+	reservations, err := rDao.List(r.Context(), limit, offset)
 	if err != nil {
 		renderError(w, r, payloads.NewDAOError(r.Context(), "list reservations", err))
 		return

--- a/scripts/rest_examples/list-aws-sources.http
+++ b/scripts/rest_examples/list-aws-sources.http
@@ -1,4 +1,4 @@
 // @no-log
-GET http://{{hostname}}:{{port}}/{{prefix}}/sources?provider=aws HTTP/1.1
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources?provider=aws&limit=&offset= HTTP/1.1
 Content-Type: application/json
 X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/pubkeys-list.http
+++ b/scripts/rest_examples/pubkeys-list.http
@@ -1,5 +1,5 @@
 // @no-log
-GET http://{{hostname}}:{{port}}/{{prefix}}/pubkeys/ HTTP/1.1
+GET http://{{hostname}}:{{port}}/{{prefix}}/pubkeys?limit=&offset= HTTP/1.1
 Content-Type: application/json
 X-Rh-Identity: {{identity}}
 

--- a/scripts/rest_examples/reservation-list.http
+++ b/scripts/rest_examples/reservation-list.http
@@ -1,4 +1,4 @@
 // @no-log
-GET http://{{hostname}}:{{port}}/{{prefix}}/reservations/ HTTP/1.1
+GET http://{{hostname}}:{{port}}/{{prefix}}/reservations?limit=&offset= HTTP/1.1
 Content-Type: application/json
 X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/sources-list.http
+++ b/scripts/rest_examples/sources-list.http
@@ -1,4 +1,4 @@
 // @no-log
-GET http://{{hostname}}:{{port}}/{{prefix}}/sources HTTP/1.1
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources?limit=&offset= HTTP/1.1
 Content-Type: application/json
 X-Rh-Identity: {{identity}}


### PR DESCRIPTION
This PR introduces support for pagination with limit and offset parameters to the `List Pubkeys` and` List Sources `endpoints. The pagination functionality has been implemented as a custom middleware, which can be added to specific endpoints as needed. The offset and limit values are added to the context and retrieved in the corresponding handler functions.

To achieve pagination, the PR utilizes Postgres' built-in LIMIT and OFFSET functionality, as well as the offset and limit parameters available in the sources client.

Currently, some tests are missing, which I  intends to add. Before proceeding with adding the tests, I would appreciate your feedback on the proposed approach.