### PR TITLE
ci(HMS-1947): Adjust memory request and limit in e2e test template

### DIFF
--- a/deploy/testing-integration.yaml
+++ b/deploy/testing-integration.yaml
@@ -80,21 +80,21 @@ objects:
           resources:
             limits:
               cpu: "1"
-              memory: 2Gi
+              memory: 1.5Gi
             requests:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 250m
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: provisioning-e2e-sel-${IMAGE_TAG}-${UID}
           image: ${IQE_SEL_IMAGE}
           resources:
             limits:
-              cpu: 300m
-              memory: 1Gi
+              cpu: 500m
+              memory: 1.5Gi
             requests:
-              cpu: 150m
-              memory: 512Mi
+              cpu: 100m
+              memory: 256Mi
           volumeMounts:
             - name: sel-shm
               mountPath: /dev/shm


### PR DESCRIPTION
This PR updates the e2e post-deploy test template:
- The selenium container needs a higher memory limit, but can request in smaller chunks.
- The CPU chunks for the iqe container can be smaller, and its memory limit reduced

----

Thanks for the contribution, make sure your commit message follows this subject style:

        type: brief summary up to 70 characters or
        type(scope): brief summary up to 70 characters

Type is required, scope is optional. Prefer lower-case and avoid dot at the end.

Find more info about types and scopes at:

https://github.com/RHEnVision/provisioning-backend#contributing

Take a moment to read our contributing and security guidelines:

https://github.com/RedHatInsights/secure-coding-checklist

**Checklist**

- [x] all commit messages follows the policy above
- [x] the change follows our security guidelines
