### PR TITLE
fix(HMS-2295): add numeric rid to GCP

### DIFF
--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -166,7 +166,7 @@ func (c *ec2Client) ImportPubkey(ctx context.Context, key *models.Pubkey, tag st
 			ResourceType: types.ResourceTypeKeyPair,
 			Tags: []types.Tag{
 				{
-					Key:   ptr.To("rhhc:id"),
+					Key:   ptr.To("rh-kid"),
 					Value: ptr.To(tag),
 				},
 			},
@@ -401,7 +401,7 @@ func (c *ec2Client) RunInstances(ctx context.Context, params *clients.AWSInstanc
 			ResourceType: types.ResourceTypeInstance,
 			Tags: []types.Tag{
 				{
-					Key:   ptr.To("rhhc:rid"),
+					Key:   ptr.To("rh-rid"),
 					Value: ptr.To(config.EnvironmentPrefix("r", strconv.FormatInt(reservation.ID, 10))),
 				},
 			},

--- a/internal/clients/http/gcp/gcp_client.go
+++ b/internal/clients/http/gcp/gcp_client.go
@@ -186,7 +186,8 @@ func (c *gcpClient) InsertInstances(ctx context.Context, params *clients.GCPInst
 			MinCount:    &amount,
 			InstanceProperties: &computepb.InstanceProperties{
 				Labels: map[string]string{
-					"rhhcc-rid": params.UUID,
+					"rh-rid":  config.EnvironmentPrefix("r", strconv.FormatInt(params.ReservationID, 10)),
+					"rh-uuid": params.UUID,
 				},
 				Disks: []*computepb.AttachedDisk{
 					{
@@ -251,7 +252,7 @@ func (c *gcpClient) ListInstancesIDsByLabel(ctx context.Context, uuid string) ([
 
 	logger := logger(ctx)
 	ids := make([]*string, 0)
-	filter := fmt.Sprintf("labels.rhhcc-rid=%v", uuid)
+	filter := fmt.Sprintf("labels.rh-uuid=%v", uuid)
 	lstReq := &computepb.AggregatedListInstancesRequest{
 		Project: c.auth.Payload,
 		Filter:  &filter,

--- a/internal/clients/instance_params.go
+++ b/internal/clients/instance_params.go
@@ -15,6 +15,9 @@ type GCPInstanceParams struct {
 	// InstanceType to launch
 	MachineType string
 
+	// ReservationID contains reservation ID that is stored in GCP label
+	ReservationID int64
+
 	// UUID for instance that was created in a reservation
 	UUID string
 

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -71,7 +71,7 @@ func (mock *EC2ClientStub) ImportPubkey(ctx context.Context, key *models.Pubkey,
 		KeyPairId:      &ec2KeyID,
 		PublicKey:      &key.Body,
 		Tags: []types.Tag{{
-			Key:   ptr.To("rhhc:id"),
+			Key:   ptr.To("rh-kid"),
 			Value: &tag,
 		}},
 	}

--- a/internal/jobs/launch_instance_gcp.go
+++ b/internal/jobs/launch_instance_gcp.go
@@ -112,6 +112,7 @@ func DoLaunchInstanceGCP(ctx context.Context, args *LaunchInstanceGCPTaskArgs) e
 		Zone:             args.Zone,
 		KeyBody:          pk.Body,
 		StartupScript:    string(userData),
+		ReservationID:    args.ReservationID,
 		UUID:             args.Detail.UUID,
 		LaunchTemplateID: args.LaunchTemplateID,
 	}


### PR DESCRIPTION
We currently do not store reservation id, the number, which is useful for figuring out owner of the instance.

While on it, I also noticed that we use fairly long "rhhhc" prefix, I propose to shorten it just to "rh".

Additionally, I noticed that AWS keys allows colons while GCP does not. Therefore I propose to use "rh-" (with dash characters) for both AWS and GCP.

The "rid" key is already used for unique identifier we generate during GCP launch, so I renamed it to "rh-uuid". It serves for identifying instances, "rh-rid" is now used for reservation numeric id. It could be used to the the same as well, but I do not want to change code too much.

Finally, keypair id was renamed to "rh-kid" to avoid too generic "id".