### PR TITLE
fix(HMS-1453): platform RBAC support enabled

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -524,7 +524,7 @@ parameters:
     value: "debug"
   - description: RBAC checking enabled
     name: APP_RBAC_ENABLED
-    value: "false"
+    value: "true"
   - description: RBAC checking enabled
     name: REST_ENDPOINTS_RBAC_URL
     value: "http://rbac-service:8000/api/rbac/v1"


### PR DESCRIPTION
This PR enables RBAC, it will fail tests.

The following roles are required in order to perform tasks:

https://github.com/RedHatInsights/rbac-config/blob/master/configs/stage/roles/provisioning.json

These are the possible permissions:

https://github.com/RedHatInsights/rbac-config/blob/master/configs/stage/permissions/provisioning.json

Note these roles and permissions are not in production yet, I will link prod PR in a moment.