### PR TITLE
feat(HMS-729): Reservations cleanup

### DIFF
--- a/config/api.env.example
+++ b/config/api.env.example
@@ -132,6 +132,12 @@
 #     	prometheus metrics path (default "/metrics")
 #   PROMETHEUS_PORT int
 #     	prometheus HTTP port (default "9000")
+#   RESERVATION_CLEANUP_ENABLED bool
+#     	reservation cleanup enabled (default "false")
+#   RESERVATION_CLEANUP_INTERVAL int64
+#     	how often to cleanup the reservation (default "1h")
+#   RESERVATION_LIFETIME int64
+#     	how old reservation should be deleted, default equal to 365 days (default "8760h")
 #   REST_ENDPOINTS_IMAGE_BUILDER_PASSWORD string
 #     	image builder credentials (dev only) (default "")
 #   REST_ENDPOINTS_IMAGE_BUILDER_PROXY_URL string

--- a/internal/background/cleanup.go
+++ b/internal/background/cleanup.go
@@ -1,0 +1,41 @@
+package background
+
+import (
+	"context"
+	"time"
+
+	"github.com/RHEnVision/provisioning-backend/internal/dao"
+	"github.com/rs/zerolog"
+)
+
+func dbCleanup(ctx context.Context, sleep time.Duration) {
+	logger := zerolog.Ctx(ctx)
+	logger.Debug().Msgf("Started reservation cleanup %s", sleep.String())
+	defer func() {
+		logger.Debug().Msgf("Database reservation cleanup routine exited")
+	}()
+
+	ticker := time.NewTicker(sleep)
+
+	cleanupReservations(ctx)
+
+	for {
+		select {
+		case <-ticker.C:
+			cleanupReservations(ctx)
+
+		case <-ctx.Done():
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func cleanupReservations(ctx context.Context) {
+	logger := zerolog.Ctx(ctx)
+	sdao := dao.GetReservationDao(ctx)
+	err := sdao.Cleanup(ctx)
+	if err != nil {
+		logger.Error().Err(err).Msg("Error while performing reservation cleanup")
+	}
+}

--- a/internal/background/initialize.go
+++ b/internal/background/initialize.go
@@ -41,4 +41,9 @@ func InitializeStats(ctx context.Context) {
 
 	// start database statistics
 	go dbStatsLoop(ctx, config.Stats.ReservationsInterval)
+
+	// cleanup old reservations
+	if config.Reservation.CleanupEnabled {
+		go dbCleanup(ctx, config.Reservation.CleanupInterval)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,11 @@ var config struct {
 		JobQueue             time.Duration `env:"JOBQUEUE_INTERVAL" env-default:"1m" env-description:"how often to pull job queue statistics"`
 		ReservationsInterval time.Duration `env:"RESERVATIONS_INTERVAL" env-default:"10m" env-description:"how often to pull reservation statistics"`
 	} `env-prefix:"STATS_"`
+	Reservation struct {
+		CleanupEnabled  bool          `env:"CLEANUP_ENABLED" env-default:"false" env-description:"reservation cleanup enabled"`
+		Lifetime        time.Duration `env:"LIFETIME" env-default:"8760h" env-description:"how old reservation should be deleted, default equal to 365 days"`
+		CleanupInterval time.Duration `env:"CLEANUP_INTERVAL" env-default:"1h" env-description:"how often to cleanup the reservation"`
+	} `env-prefix:"RESERVATION_"`
 	Database struct {
 		Host        string        `env:"HOST" env-default:"localhost" env-description:"main database hostname"`
 		Port        uint16        `env:"PORT" env-default:"5432" env-description:"main database port"`
@@ -167,6 +172,7 @@ var config struct {
 var (
 	Application   = &config.App
 	Stats         = &config.Stats
+	Reservation   = &config.Reservation
 	Database      = &config.Database
 	Prometheus    = &config.Prometheus
 	Logging       = &config.Logging

--- a/internal/dao/dao_interfaces.go
+++ b/internal/dao/dao_interfaces.go
@@ -109,6 +109,9 @@ type ReservationDao interface {
 
 	// Delete deletes a reservation. Only used in tests and background cleanup job. UNSCOPED.
 	Delete(ctx context.Context, id int64) error
+
+	// Cleanup old reservations
+	Cleanup(ctx context.Context) error
 }
 
 var GetStatDao func(ctx context.Context) StatDao

--- a/internal/dao/stubs/reservation_dao.go
+++ b/internal/dao/stubs/reservation_dao.go
@@ -144,6 +144,10 @@ func (stub *reservationDaoStub) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
+func (stub *reservationDaoStub) Cleanup(ctx context.Context) error {
+	return nil
+}
+
 func (stub *reservationDaoStub) UpdateReservationInstance(ctx context.Context, reservationID int64, instance *clients.InstanceDescription) error {
 	for _, instRes := range stub.instances[reservationID] {
 		if instRes.InstanceID == instance.ID {


### PR DESCRIPTION
Be careful with testing this. This will, by default, delete your reservations older than one year every one hour.

Configurable database cleanup. The default is deleting reservations older than one year every hour. I think we could maybe **improve** this by making sure users could **switch the reservation cleanup off**.
It is a bit unfortunate that the cleanenv does not offer days/years units, so we'd have to use hours even in case of a long reservation lifetime. Another thing is, that the leap year is not being taken care of. :( 