### PR TITLE
fix(HMS-1453): list sources can be public

### DIFF
--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -61,10 +61,10 @@ func MountAPI(r *chi.Mux) {
 
 		// OpenAPI documented and supported routes
 		r.Route("/sources", func(r chi.Router) {
-			r.Use(middleware.EnforcePermissions("source", "read"))
-
 			r.Get("/", s.ListSources)
 			r.Route("/{ID}", func(r chi.Router) {
+				r.Use(middleware.EnforcePermissions("source", "read"))
+
 				r.Get("/status", s.SourcesStatus)
 
 				// TODO DEPRECATED: move this to outside of /sources (see below)


### PR DESCRIPTION
Protecting source list with RBAC is problematic for image builder which calls this endpoint. Since we do not share any data via this endpoint it is okay to have it public.