### PR TITLE
fix(HMS-2328): fix context in failed launch notifications

### DIFF
--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -80,7 +80,10 @@ func (x *client) FailedLaunch(ctx context.Context, reservationId int64, jobError
 	}
 
 	notificationEvent := []kafka.NotificationEvent{{Payload: marshalError}}
-	notificationMsg, err := kafka.NotificationMessage{Context: reservation, EventType: kafka.NotificationFailureEventType, Events: notificationEvent}.GenericMessage(ctx)
+	notificationMsg, err := kafka.NotificationMessage{
+		Context:   kafka.NotificationContext{Provider: reservation.Provider.String(), LaunchID: reservationId},
+		EventType: kafka.NotificationFailureEventType, Events: notificationEvent,
+	}.GenericMessage(ctx)
 	if err != nil {
 		logger.Error().Err(err).Msg("Unable to create notification failure message")
 		return


### PR DESCRIPTION
The provider's name and the launch id are not transferred correctly, which impacts the instant email template, as you can see in the following screenshot:

![Screen Shot 2023-08-10 at 18 57 59](https://github.com/RHEnVision/provisioning-backend/assets/11807069/a0d957f8-c84f-44e6-b170-8fcd4dc98110)
