### PR TITLE
ci(HMS-1947): Add browser log params to e2e test template

### DIFF
--- a/deploy/testing-integration.yaml
+++ b/deploy/testing-integration.yaml
@@ -35,6 +35,10 @@ objects:
             value: ${USE_BETA}
           - name: IQE_IBUTSU_SOURCE
             value: provisioning-e2e-${IMAGE_TAG}-${UID}-${ENV_FOR_DYNACONF}
+          - name: IQE_BROWSERLOG
+            value: ${IQE_BROWSERLOG}
+          - name: IQE_NETLOG
+            value: ${IQE_NETLOG}
           - name: IQE_PLUGINS
             value: ${IQE_PLUGINS}
           - name: IQE_MARKER_EXPRESSION
@@ -129,3 +133,7 @@ parameters:
   value: ''
 - name: IQE_SEL_IMAGE
   value: 'quay.io/redhatqe/selenium-standalone:ff_91.9.1esr_chrome_103.0.5060.114'
+- name: IQE_BROWSERLOG
+  value: "1"
+- name: IQE_NETLOG
+  value: "1"


### PR DESCRIPTION
This PR adds `IQE_BROWSERLOG=1` and `IQE_NETLOG=1` params / env vars to the e2e test template, so that any UI test failures will automatically capture and send browser logs to our test reporting portal.

---

Thanks for the contribution, make sure your commit message follows this subject style:

        type: brief summary up to 70 characters or
        type(scope): brief summary up to 70 characters

Type is required, scope is optional. Prefer lower-case and avoid dot at the end.

Find more info about types and scopes at:

https://github.com/RHEnVision/provisioning-backend#contributing

Take a moment to read our contributing and security guidelines:

https://github.com/RedHatInsights/secure-coding-checklist

**Checklist**

- [ ] all commit messages follows the policy above
- [ ] the change follows our security guidelines
