### PR TITLE
fix(HMS-2325): return 429 on rate error

### DIFF
--- a/internal/dao/dao_errors.go
+++ b/internal/dao/dao_errors.go
@@ -33,4 +33,7 @@ var (
 
 	// ErrStubContextAlreadySet is returned when stub object was already added to the context
 	ErrStubContextAlreadySet = errors.New("context object already set")
+
+	// ErrReservationRateExceeded is returned when SQL constraint does not allow to insert more reservations
+	ErrReservationRateExceeded = errors.New("rate limit exceeded")
 )

--- a/internal/dao/pgx/reservation_pgx.go
+++ b/internal/dao/pgx/reservation_pgx.go
@@ -3,6 +3,7 @@ package pgx
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
@@ -137,8 +138,12 @@ func (x *reservationDao) createGenericReservation(ctx context.Context, reservati
 		reservation.StepTitles,
 		reservation.Status).Scan(&reservation.ID, &reservation.CreatedAt)
 	if err != nil {
+		if strings.Contains(err.Error(), "too many pending reservations") {
+			return fmt.Errorf("%w: %s", dao.ErrReservationRateExceeded, err.Error())
+		}
 		return fmt.Errorf("failed to create reservation record: %w", err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
We currently return 500 which is not a good choice.

After the change:

```
HTTP/1.1 429 Too Many Requests
Content-Type: application/json
X-Rh-Version: 8c45 (2023-08-11T07:52:29Z)
X-Trace-Id: 5dfd8b3b28be1258d580497b648001e5
Date: Fri, 11 Aug 2023 14:46:34 GMT
Content-Length: 248

{
  "msg": "too many pending reservations for this account, wait and try again",
  "trace_id": "5dfd8b3b28be1258d580497b648001e5",
  "error": "failed to create reservation record: rate limit exceeded: xxx",
  "version": "8c45",
  "build_time": "2023-08-11T07:52:29Z"
}
```