### PR TITLE
fix(HMS-2327): fix empty resource perm check

### DIFF
--- a/internal/services/permissions.go
+++ b/internal/services/permissions.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http/rbac"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
@@ -11,10 +12,22 @@ import (
 
 var ErrMissingExtraPermission = errors.New("missing permission")
 
+// removeEmptyStrings returns a copy of a slice without empty strings
+func removeEmptyStrings(s []string) []string {
+	r := make([]string, 0, len(s))
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
+}
+
 // CheckPermissionAndRender can be used to perform an extra permission check that is more detailed than the one
 // performed by the middleware. Do not use this function as the only permission check, permissions should always
 // be enforced via middleware as a bare minimum.
-func CheckPermissionAndRender(w http.ResponseWriter, r *http.Request, resource, permission string) error {
+func CheckPermissionAndRender(w http.ResponseWriter, r *http.Request, permission string, resources ...string) error {
+	resource := strings.Join(removeEmptyStrings(resources), ".")
 	if !rbac.Acl(r.Context()).IsAllowed(resource, permission) {
 		permErr := fmt.Errorf("%w: %s on %s", ErrMissingExtraPermission, permission, resource)
 		renderError(w, r, payloads.NewMissingPermissionError(r.Context(), resource, permission, permErr))

--- a/internal/services/permissions_test.go
+++ b/internal/services/permissions_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/clients/http/rbac"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckPermissionAndRenderJoin(t *testing.T) {
+	ctx := context.Background()
+	ctx = rbac.WithAcl(ctx, clients.AccessList{
+		clients.NewAccess("provisioning:r1.r2:perm"),
+	})
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(ctx, "GET", "/", nil)
+	require.NoError(t, err, "failed to create request")
+
+	err = CheckPermissionAndRender(w, req, "perm", "r1", "r2")
+	require.NoError(t, err)
+}
+
+func TestCheckPermissionAndRenderEmpty(t *testing.T) {
+	ctx := context.Background()
+	ctx = rbac.WithAcl(ctx, clients.AccessList{
+		clients.NewAccess("provisioning:r1:perm"),
+	})
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(ctx, "GET", "/", nil)
+	require.NoError(t, err, "failed to create request")
+
+	err = CheckPermissionAndRender(w, req, "perm", "r1", "")
+	require.NoError(t, err)
+}
+
+func TestCheckPermissionAndRenderOne(t *testing.T) {
+	ctx := context.Background()
+	ctx = rbac.WithAcl(ctx, clients.AccessList{
+		clients.NewAccess("provisioning:r1:perm"),
+	})
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(ctx, "GET", "/", nil)
+	require.NoError(t, err, "failed to create request")
+
+	err = CheckPermissionAndRender(w, req, "perm", "r1")
+	require.NoError(t, err)
+}

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -32,7 +32,7 @@ func CreateReservation(w http.ResponseWriter, r *http.Request) {
 	pType := models.ProviderTypeFromString(chi.URLParam(r, "TYPE"))
 
 	// Check permission for individual provider type
-	if CheckPermissionAndRender(w, r, fmt.Sprintf("reservation.%s", pType), "write") != nil {
+	if CheckPermissionAndRender(w, r, "write", "reservation", pType.String()) != nil {
 		return
 	}
 
@@ -81,8 +81,7 @@ func GetReservationDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check permission for individual provider type
-	if CheckPermissionAndRender(w, r, fmt.Sprintf("reservation.%s", providerType), "read") != nil {
+	if CheckPermissionAndRender(w, r, "read", "reservation", providerType.String()) != nil {
 		return
 	}
 


### PR DESCRIPTION
The app perform `reservation:read` check via middleware and then additional `reservation.provider:read` check in the service function. However, it is possible to read a generic reservation where the provider is set to empty string. In this case, check is performed on an incorrect resource `reservation.` (note the trailing dot) which does not match anything and the request ends up with access denied:

![image](https://github.com/RHEnVision/provisioning-backend/assets/49752/facf0025-37b6-4c9c-80d0-dfe100645941)

This refactoring fixes that, the function now takes the verb first and then arbitrary amount of resources, removes empty strings and joins them with `.` characters so this is avoided for the future.