### PR TITLE
chore: lower reservation limit to 2

### DIFF
--- a/internal/dao/tests/reservation_test.go
+++ b/internal/dao/tests/reservation_test.go
@@ -359,7 +359,7 @@ func TestReservationRate(t *testing.T) {
 	rdao, ctx := setupReservation(t)
 	t.Run("allows slow reservations", func(t *testing.T) {
 		defer reset()
-		for i := 1; i <= 5; i++ {
+		for i := 1; i <= 2; i++ {
 			println(i)
 			res := newNoopReservation()
 			err := rdao.CreateNoop(ctx, res)
@@ -374,7 +374,7 @@ func TestReservationRate(t *testing.T) {
 	rdao2, ctx2 := setupReservationOrg2(t)
 	t.Run("throttles too fast reservations", func(t *testing.T) {
 		defer reset()
-		for i := 1; i <= 5; i++ {
+		for i := 1; i <= 2; i++ {
 			res := newNoopReservation()
 			err := rdao.CreateNoop(ctx, res)
 			require.NoError(t, err)

--- a/internal/migrations/sql/021_lower_limit.sql
+++ b/internal/migrations/sql/021_lower_limit.sql
@@ -1,0 +1,26 @@
+-- Actual reservation limit per account and provider type (returns constant number)
+CREATE OR REPLACE FUNCTION reservations_rate_limit() RETURNS INTEGER AS
+$reservations_rate_limit$
+BEGIN
+  RETURN 2;
+END;
+$reservations_rate_limit$ LANGUAGE plpgsql;
+
+-- Rate limiting function (throws exception when exceeded)
+CREATE OR REPLACE FUNCTION reservations_rate() RETURNS TRIGGER AS
+$reservations_rate$
+DECLARE
+  maximum INTEGER := reservations_rate_limit();
+  last_rec RECORD;
+BEGIN
+  FOR last_rec IN SELECT COUNT(*) FROM reservations WHERE account_id = NEW.account_id AND provider = NEW.provider AND success IS NULL AND created_at >= now() - INTERVAL '1 second'
+    LOOP
+      IF last_rec.count >= maximum THEN
+        -- When changing the exception string, also change the ErrReservationRateExceeded handling Go code
+        RAISE EXCEPTION 'too many pending reservations for this provider (maximum % per second)', maximum;
+      END IF;
+    END LOOP;
+
+  RETURN NEW;
+END;
+$reservations_rate$ LANGUAGE plpgsql;


### PR DESCRIPTION
This lowers down the limit to 2 which was tested as the only one that works.

Also changes the trigger function not to include the amount of pending reservations in the error message to avoid confusing GlitchTip.

Do not merge until performance team is done with testing.