### PR TITLE
docs: Add missing changelog dependency to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,8 @@ For **feat** and **fix** types a Jira issue link is required.
 Please use the scope like `feat(HMS-XXX): subject`
 or put the issue reference in commit body as `Fixes: HMS-XXX` or `Refs: HMS-XXX`
 
-Use `make check-commits` to check commit message locally.
+To check commit message locally please install
+https://github.com/RHEnVision/changelog and then run `make check-commits`.
 
 ## Basic guidelines for code contributions
 


### PR DESCRIPTION
In order to run `make check-commits` you need to install the changelog tool first.

Thanks for the contribution, make sure your commit message follows this subject style:

        type: brief summary up to 70 characters or
        type(scope): brief summary up to 70 characters

Type is required, scope is optional. Prefer lower-case and avoid dot at the end.

Find more info about types and scopes at:

https://github.com/RHEnVision/provisioning-backend#contributing

Take a moment to read our contributing and security guidelines:

https://github.com/RedHatInsights/secure-coding-checklist

**Checklist**

- [ ] all commit messages follows the policy above
- [ ] the change follows our security guidelines
