### PR TITLE
test(HMS-2344): Update test templates

### DIFF
--- a/deploy/testing-integration.yaml
+++ b/deploy/testing-integration.yaml
@@ -2,15 +2,20 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: provisioning-e2e
+  name: provisioning-${NAME_STUB}
 objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
-    name: provisioning-e2e-${IMAGE_TAG}-${UID}
+    name: provisioning-${NAME_STUB}-${UID}
     annotations:
       "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
       "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+    labels:
+      image-tag: ${IMAGE_TAG}
+      iqe-image-tag: ${IQE_IMAGE_TAG}
+      iqe-env: ${ENV_FOR_DYNACONF}
+      iqe-plugin: ${IQE_PLUGINS}
   spec:
     backoffLimit: 0
     template:
@@ -23,8 +28,8 @@ objects:
           emptyDir:
             medium: Memory
         containers:
-        - name: provisioning-e2e-iqe-${IMAGE_TAG}-${UID}
-          image: ${IQE_IMAGE}
+        - name: provisioning-${NAME_STUB}-${IMAGE_TAG}-${UID}
+          image: ${IQE_IMAGE}:${IQE_IMAGE_TAG}
           imagePullPolicy: Always
           args:
           - run
@@ -34,7 +39,7 @@ objects:
           - name: DYNACONF_MAIN__use_beta
             value: ${USE_BETA}
           - name: IQE_IBUTSU_SOURCE
-            value: provisioning-e2e-${IMAGE_TAG}-${UID}-${ENV_FOR_DYNACONF}
+            value: provisioning-saas-${IMAGE_TAG}-${UID}
           - name: IQE_BROWSERLOG
             value: ${IQE_BROWSERLOG}
           - name: IQE_NETLOG
@@ -90,7 +95,7 @@ objects:
               memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-        - name: provisioning-e2e-sel-${IMAGE_TAG}-${UID}
+        - name: iqe-sel-${IMAGE_TAG}-${UID}
           image: ${IQE_SEL_IMAGE}
           resources:
             limits:
@@ -112,7 +117,10 @@ parameters:
   from: "[a-z0-9]{6}"
 - name: IQE_IMAGE
   description: "container image path for the iqe plugin"
-  value: quay.io/cloudservices/iqe-tests:hms-integration
+  value: quay.io/cloudservices/iqe-tests
+- name: IQE_IMAGE_TAG
+  description: "container image tag for iqe plugin"
+  value: 'hms-integration'
 - name: ENV_FOR_DYNACONF
   value: stage_proxy
 - name: USE_BETA
@@ -137,3 +145,5 @@ parameters:
   value: "1"
 - name: IQE_NETLOG
   value: "1"
+- name: NAME_STUB
+  value: 'e2e-tests'

--- a/deploy/testing.yaml
+++ b/deploy/testing.yaml
@@ -16,7 +16,7 @@ objects:
     testing:
       iqe:
         debug: false
-        dynaconfEnvName: ${IQE_ENV}
+        dynaconfEnvName: ${ENV_FOR_DYNACONF}
         marker: ${IQE_MARKER}
 parameters:
 - name: IMAGE_TAG
@@ -27,6 +27,9 @@ parameters:
   generate: expression
   from: "[a-z0-9]{6}"
 - name: IQE_ENV
+  value: 'stage_post_deploy'
+# REPLACING IQE_ENV
+- name: ENV_FOR_DYNACONF
   value: 'stage_post_deploy'
 - name: IQE_MARKER
   value: 'stage'


### PR DESCRIPTION
Update the testing templates for some new parameters, related to moving test jobs to a different cluster


Related to moving the testing to a different cluster and changing the job type used in staging:
https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/77881

**Testing**
Deployed the template to ephemeral with a local bonfire config, everything was as expected with the resulting job. 


**Checklist**

- [*] all commit messages follows the policy above
- [*] the change follows our security guidelines
