### PR TITLE
fix(HMS-2258): Check errors after defer

### DIFF
--- a/internal/clients/http/image_builder/image_client.go
+++ b/internal/clients/http/image_builder/image_client.go
@@ -50,7 +50,11 @@ func (c *ibClient) Ready(ctx context.Context) error {
 		logger.Error().Err(err).Msg("Readiness request failed for image builder")
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if tempErr := resp.Body.Close(); tempErr != nil {
+			logger.Error().Err(tempErr).Msg("Readiness request for image builder: response body close error")
+		}
+	}()
 
 	err = http.HandleHTTPResponses(ctx, resp.StatusCode)
 	if err != nil {

--- a/internal/clients/http/rbac/rbac_client.go
+++ b/internal/clients/http/rbac/rbac_client.go
@@ -57,7 +57,11 @@ func (c *rbac) Ready(ctx context.Context) error {
 		logger.Error().Err(err).Msgf("Readiness request failed for RBAC: %s", err.Error())
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if tempErr := resp.Body.Close(); tempErr != nil {
+			logger.Error().Err(tempErr).Msg("Readiness request for RBAC: response body close error")
+		}
+	}()
 
 	err = http.HandleHTTPResponses(ctx, resp.StatusCode)
 	if err != nil {

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -72,7 +72,11 @@ func (c *sourcesClient) Ready(ctx context.Context) error {
 		logger.Error().Err(err).Msg("Readiness request failed for sources")
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if tempErr := resp.Body.Close(); tempErr != nil {
+			logger.Error().Err(tempErr).Msg("Readiness request for sources: response body close error")
+		}
+	}()
 
 	err = http.HandleHTTPResponses(ctx, resp.StatusCode)
 	if err != nil {
@@ -232,7 +236,11 @@ func (c *sourcesClient) loadAppId(ctx context.Context) (string, error) {
 		logger.Warn().Err(err).Msg("Failed to fetch ApplicationTypes from sources")
 		return "", fmt.Errorf("failed to fetch ApplicationTypes: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if tempErr := resp.Body.Close(); tempErr != nil {
+			logger.Error().Err(tempErr).Msg("ApplicationTypes fetching from sources: response body close error")
+		}
+	}()
 
 	err = http.HandleHTTPResponses(ctx, resp.StatusCode)
 	if err != nil {

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -196,7 +196,12 @@ func Seed(ctx context.Context, seedScript string) error {
 	if err != nil {
 		return fmt.Errorf("unable to open seed script %s: %w", seedScript, err)
 	}
-	defer file.Close()
+	defer func() {
+		if tempErr := file.Close(); tempErr != nil {
+			logger.Error().Err(tempErr).Msgf("Error when closing the seed script %s", seedScript)
+		}
+	}()
+
 	buffer, err := io.ReadAll(file)
 	if err != nil {
 		return fmt.Errorf("unable to read seed script %s: %w", seedScript, err)


### PR DESCRIPTION
This is the first part of the error handling fix, and also the next thing I have noticed. Sometimes, when we use defer, we do not check for errors returned from such functions. I do not think this is correct. If we have a reason we don't do that, let me know. Otherwise, I will look around the codebase to check this in more places.