### PR TITLE
chore: add compile daemon targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ tags
 TAGS
 
 # binaries
-/pbackend
+/pbackend*
 /pbapi
 /pbmigrate
 /pbworker

--- a/mk/0_initial.mk
+++ b/mk/0_initial.mk
@@ -17,6 +17,7 @@ GOLINT?=$(GOBIN)/golangci-lint
 GOFUMPT?=$(GOBIN)/gofumpt
 GOIMPORTS?=$(GOBIN)/goimports
 OAPICODEGEN?=$(GOBIN)/oapi-codegen
+CDAEMON?=$(GOBIN)/CompileDaemon
 TERN?=$(GOBIN)/tern
 
 .PHONY: check-go

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -20,12 +20,32 @@ run-api: check-go ## Run backend API using `go run`
 	$(GO) run ./cmd/pbackend api
 
 .PHONY: run-worker
-run-worker: check-go ## Run backend API using `go run`
+run-worker: check-go ## Run worker using `go run`
 	$(GO) run ./cmd/pbackend worker
 
 .PHONY: run-statuser
-run-statuser: check-go ## Run backend API using `go run`
+run-statuser: check-go ## Run statuser using `go run`
 	$(GO) run ./cmd/pbackend statuser
+
+.PHONY: run-stats
+run-stats: check-go ## Run stats using `go run`
+	$(GO) run ./cmd/pbackend stats
+
+.PHONY: cd-api
+cd-api: check-go ## Run backend API using compile daemon
+	$(CDAEMON) -build='go build -buildvcs=false -o ./pbackend-cd-api ./cmd/pbackend' -command='./pbackend-cd-api api'
+
+.PHONY: cd-worker
+cd-worker: check-go ## Run worker using compile daemon
+	$(CDAEMON) -build='go build -buildvcs=false -o ./pbackend-cd-worker ./cmd/pbackend' -command='./pbackend-cd-worker worker'
+
+.PHONY: cd-statuser
+cd-statuser: check-go ## Run statuser using compile daemon
+	$(CDAEMON) -build='go build -buildvcs=false -o ./pbackend-cd-statuser ./cmd/pbackend' -command='./pbackend-cd-statuser statuser'
+
+.PHONY: cd-stats
+cd-stats: check-go ## Run stats using compile daemon
+	$(CDAEMON) -build='go build -buildvcs=false -o ./pbackend-cd-stats ./cmd/pbackend' -command='./pbackend-cd-stats stats'
 
 CMD?=version
 .PHONY: run

--- a/mk/tools.mk
+++ b/mk/tools.mk
@@ -14,6 +14,7 @@ install-tools: ## Install required Go commands into ./bin
 	GOBIN=$(GOBIN) $(GO) install github.com/jackc/tern/v2@v2.1.1
 	GOBIN=$(GOBIN) $(GO) install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.13.4
 	GOBIN=$(GOBIN) $(GO) install mvdan.cc/gofumpt@v0.5.0
+	GOBIN=$(GOBIN) $(GO) install github.com/githubnemo/CompileDaemon@latest
 
 .PHONY: update-tools
 update-tools: ## Update required Go commands


### PR DESCRIPTION
So I looked into the compile daemon problem:

I figured out that ability to run multiple "actions" within our pbackend application is more significant refactoring that I thought. Adding just go command to main functions will not work because every single "action" (api, worker, statuser) initializes logging, db, redis and other resources differently. I don’t think such a refactoring is worth the effort.

Then I looked into creating a Makefile target that would run individual "actions", this did not work because different compile daemon processes were overwriting pbackend binary which was causing issues.

The solution is this PR where every binary is different so compile daemon works even if you try to run multiple instances of it. This creates more binaries but the Go cache is shared so compilation is at least much faster.

In the compose, it should be possible to run these from a shell wrapper:

```bash
#!/bin/bash
make cd-stats &
make cd-statuser &
make cd-worker &
make cd-api
```

Something like that: single container, multiple processes, automatic recompilation. I am not going to work on compose part tho, take it from here if you are interested or close this PR.