### PR TITLE
fix(HMS-2462): Include details explaining the unavailability of a source

### DIFF
--- a/internal/kafka/source_result.go
+++ b/internal/kafka/source_result.go
@@ -16,6 +16,7 @@ type SourceResult struct {
 	ResourceID         string          `json:"resource_id"`
 	ResourceType       string          `json:"resource_type"`
 	Status             StatusType      `json:"status"`
+	UserError          string          `json:"error"`
 	Err                error           `json:"-"` // Sources do not support error field
 	MissingPermissions []string        `json:"-"` // Sources do not support reason field
 }


### PR DESCRIPTION
This PR adds another field, a user friendly error msg to show on sources UI. 
* It is possible to test this only on Stage (we need the statuser listener configured locally as well). 