### PR TITLE
fix: Redis nil pointers checking

### DIFF
--- a/internal/jobs/noop_job.go
+++ b/internal/jobs/noop_job.go
@@ -19,8 +19,13 @@ type NoopJobArgs struct {
 
 var NoOperationFailure = errors.New("job failed on request")
 
-// Unmarshall arguments and handle error
+// HandleNoop unmarshalls arguments and handle error
 func HandleNoop(ctx context.Context, job *worker.Job) {
+	if job == nil {
+		zerolog.Ctx(ctx).Error().Msg("No job to handle")
+		return
+	}
+
 	args, ok := job.Args.(NoopJobArgs)
 	if !ok {
 		err := fmt.Errorf("%w: job %s, reservation: %#v", ErrTypeAssertion, job.ID, job.Args)
@@ -42,7 +47,7 @@ func HandleNoop(ctx context.Context, job *worker.Job) {
 	finishJob(ctx, args.ReservationID, jobErr)
 }
 
-// Job logic, when error is returned the job status is updated accordingly
+// DoNoop is a job logic, when error is returned the job status is updated accordingly
 func DoNoop(ctx context.Context, args *NoopJobArgs) error {
 	logger := zerolog.Ctx(ctx)
 

--- a/internal/queue/stub/stub.go
+++ b/internal/queue/stub/stub.go
@@ -6,6 +6,7 @@ package stub
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/RHEnVision/provisioning-backend/internal/queue"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
@@ -13,7 +14,10 @@ import (
 
 type enqueueCtxKeyType string
 
-var ContextReadError = errors.New("failed to find or convert dao stored in testing context")
+var (
+	ContextReadError = errors.New("failed to find or convert dao stored in testing context")
+	JobNotFoundError = errors.New("no job found")
+)
 
 var enqueueCtxKey enqueueCtxKeyType = "enqueuer-stub"
 
@@ -58,6 +62,9 @@ func (h hollowEnqueuer) Enqueue(_ context.Context, _ *worker.Job) error {
 }
 
 func (s *stubEnqueuer) Enqueue(ctx context.Context, job *worker.Job) error {
+	if job == nil {
+		return fmt.Errorf("failed to enqueue: %w", JobNotFoundError)
+	}
 	s.enqueued = append(s.enqueued, job)
 	return nil
 }

--- a/pkg/worker/errors.go
+++ b/pkg/worker/errors.go
@@ -1,0 +1,7 @@
+package worker
+
+import (
+	"errors"
+)
+
+var JobNotFound = errors.New("job not found")

--- a/pkg/worker/job.go
+++ b/pkg/worker/job.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 
 	"github.com/RHEnVision/provisioning-backend/internal/identity"
-	"github.com/rs/zerolog"
-
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -73,6 +72,11 @@ type Stats struct {
 }
 
 func contextLogger(ctx context.Context, job *Job) context.Context {
+	if job == nil {
+		zerolog.Ctx(ctx).Error().Err(JobNotFound).Msg("No job, context not changed")
+		return ctx
+	}
+
 	accountId := job.AccountID
 	id := job.Identity
 	logger := zerolog.Ctx(ctx).With().

--- a/pkg/worker/memory.go
+++ b/pkg/worker/memory.go
@@ -27,6 +27,9 @@ func (w *MemoryWorker) RegisterHandler(jtype JobType, handler JobHandler, _ any)
 
 func (w *MemoryWorker) Enqueue(ctx context.Context, job *Job) error {
 	var err error
+	if job == nil {
+		return fmt.Errorf("unable to enqueue job: %w", JobNotFound)
+	}
 
 	if job.ID == uuid.Nil {
 		job.ID, err = uuid.NewRandom()
@@ -55,6 +58,11 @@ func (w *MemoryWorker) dequeueLoop(ctx context.Context) {
 }
 
 func (w *MemoryWorker) processJob(ctx context.Context, job *Job) {
+	if job == nil {
+		zerolog.Ctx(ctx).Error().Err(JobNotFound).Msg("No job to process")
+		return
+	}
+
 	if h, ok := w.handlers[job.Type]; ok {
 		ctx = contextLogger(ctx, job)
 		cCtx, cFunc := context.WithTimeout(ctx, config.Worker.Timeout)


### PR DESCRIPTION
This is just a small change. I might wait if I find some other missing nil pointer checking. But these are our own functions with pointer parameters, so I thought I should create a PR. We can also avoid pointers in general and make the functions accept `Job` instead of `*Job`