### PR TITLE
feat: Allow request params to have description

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -1168,9 +1168,11 @@
       "v1.PubkeyRequest": {
         "properties": {
           "body": {
+            "description": "User facing name of the newly created pubkey",
             "type": "string"
           },
           "name": {
+            "description": "Public portion of a SSH key pair",
             "type": "string"
           }
         },

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -438,8 +438,10 @@ components:
             properties:
                 body:
                     type: string
+                    description: User facing name of the newly created pubkey
                 name:
                     type: string
+                    description: Public portion of a SSH key pair
         v1.PubkeyResponse:
             type: object
             properties:

--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -108,18 +108,21 @@ func NewSchemaGenerator() *APISchemaGen {
 	return s
 }
 
-// Schema customizer allowing tagging with nullable to work
-var enableNullableOpt = openapi3gen.SchemaCustomizer(
+// Schema customizer allowing tagging with description and nullable to work
+var enableNullableAndDescriptionOpts = openapi3gen.SchemaCustomizer(
 	func(_name string, _t reflect.Type, tag reflect.StructTag, schema *openapi3.Schema) error {
 		if tag.Get("nullable") == "true" {
 			schema.Nullable = true
+		}
+		if desc, ok := tag.Lookup("description"); ok && desc != "-" {
+			schema.Description = desc
 		}
 		return nil
 	},
 )
 
 func (s *APISchemaGen) addSchema(name string, model interface{}) {
-	schema, err := openapi3gen.NewSchemaRefForValue(model, s.Components.Schemas, enableNullableOpt)
+	schema, err := openapi3gen.NewSchemaRefForValue(model, s.Components.Schemas, enableNullableAndDescriptionOpts)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/payloads/pubkey_payload.go
+++ b/internal/payloads/pubkey_payload.go
@@ -11,8 +11,8 @@ import (
 
 // See models.Pubkey
 type PubkeyRequest struct {
-	Name string `json:"name" yaml:"name"`
-	Body string `json:"body" yaml:"body"`
+	Name string `json:"name" yaml:"name" description:"Public portion of a SSH key pair"`
+	Body string `json:"body" yaml:"body" description:"User facing name of the newly created pubkey"`
 }
 
 // See models.Pubkey


### PR DESCRIPTION
The [OpenAPI library](https://github.com/getkin/kin-openapi) we use to generate spec, does not support descriptions for request parameters.

This enables it and adds first two descriptions.
Our Tech writers are working on helping documenting our API, so this should enable them to do so.
