### PR TITLE
docs: Improve API documentation - Pubkey

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -431,7 +431,7 @@
     },
     "parameters": {
       "Limit": {
-        "description": "The number of items to return",
+        "description": "The number of items to return.",
         "in": "query",
         "name": "limit",
         "schema": {
@@ -440,7 +440,7 @@
         }
       },
       "Offset": {
-        "description": "The number of items to skip before starting to collect the result set",
+        "description": "The number of items to skip before starting to collect the result set.",
         "in": "query",
         "name": "offset",
         "schema": {
@@ -1168,11 +1168,11 @@
       "v1.PubkeyRequest": {
         "properties": {
           "body": {
-            "description": "User facing name of the newly created pubkey",
+            "description": "Add a public part of a SSH key pair.",
             "type": "string"
           },
           "name": {
-            "description": "Public portion of a SSH key pair",
+            "description": "Enter the name of the newly created pubkey.",
             "type": "string"
           }
         },
@@ -1396,7 +1396,7 @@
     },
     "/pubkeys": {
       "get": {
-        "description": "A pubkey represents an SSH public portion of a key pair with name and body. This operation returns list of all pubkeys for particular account.\n",
+        "description": "Returns a list of all public keys available in a particular account.\n",
         "operationId": "getPubkeyList",
         "parameters": [
           {
@@ -1420,7 +1420,7 @@
                 }
               }
             },
-            "description": "Returned on success."
+            "description": "OK. Returned on success."
           },
           "500": {
             "$ref": "#/components/responses/InternalError"
@@ -1431,7 +1431,7 @@
         ]
       },
       "post": {
-        "description": "A pubkey represents an SSH public portion of a key pair with name and body. When pubkey is created, it is stored in the Provisioning database. Pubkeys are uploaded to clouds when an instance is launched. Some fields (e.g. type or fingerprint) are read only.\n",
+        "description": "Creates a new public key and stores it in the provisioning database. Public keys are uploaded to clouds at the time of launching an instance. Some fields such as type or fingerprint are read-only.\n",
         "operationId": "createPubkey",
         "requestBody": {
           "content": {
@@ -1463,7 +1463,7 @@
                 }
               }
             },
-            "description": "Returned on success."
+            "description": "OK. Returned on success."
           },
           "500": {
             "$ref": "#/components/responses/InternalError"
@@ -1476,11 +1476,11 @@
     },
     "/pubkeys/{ID}": {
       "delete": {
-        "description": "A pubkey represents an SSH public portion of a key pair with name and body. If a pubkey was uploaded to one or more clouds, the deletion request will attempt to delete those SSH keys from all clouds. This means in order to delete a pubkey the account must have valid credentials to all cloud accounts the pubkey was uploaded to, otherwise the delete operation will fail and the pubkey will not be deleted from Provisioning database. This operation returns no body.\n",
+        "description": "Deletes SSH keys that were uploaded with the specified public key from all the clouds. If a public key (pubkey) has been uploaded to one or more cloud providers, the deletion request attempts to remove those SSH keys from all associated clouds. Therefore, to delete a public key, the account must possess valid credentials for all cloud accounts to which the pubkey was uploaded. Otherwise, the delete operation fails, and the public key is not removed from the Provisioning database. This operation does not return a response body.\n",
         "operationId": "removePubkeyById",
         "parameters": [
           {
-            "description": "Database ID of resource.",
+            "description": "Enter the database ID of resource.",
             "in": "path",
             "name": "ID",
             "required": true,
@@ -1506,7 +1506,7 @@
         ]
       },
       "get": {
-        "description": "A pubkey represents an SSH public portion of a key pair with name and body. Pubkeys must have unique name and body (SSH public key fingerprint) per each account. Pubkey type is detected during create operation as well as fingerprints. Currently two types are supported: RSA and ssh-ed25519. Also, two fingerprint types are calculated: standard SHA fingerprint and legacy MD5 fingerprint available under fingerprint_legacy field. Fingerprints are used to check uniqueness of key.\n",
+        "description": "Gets details of the specified public key.",
         "operationId": "getPubkeyById",
         "parameters": [
           {
@@ -1534,7 +1534,7 @@
                 }
               }
             },
-            "description": "Returned on success"
+            "description": "OK. Returned on success"
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
@@ -2167,7 +2167,7 @@
   ],
   "tags": [
     {
-      "description": "Public SSH keys operations",
+      "description": "A pubkey represents the SSH public portion of a key pair with a name and body. Public key types and fingerprints are detected during their creation process. Two types are supported: RSA and ssh-ed25519. Fingerprints are calculated in two ways: using the standard SHA method and the legacy MD5 method, which is available under the fingerprint_legacy field. Each public key has a unique name and body and helps in verifying the uniqueness of the keys. Using this API, you can perform the following operations.\n",
       "name": "Pubkey"
     }
   ]

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -438,10 +438,10 @@ components:
             properties:
                 body:
                     type: string
-                    description: User facing name of the newly created pubkey
+                    description: Add a public part of a SSH key pair.
                 name:
                     type: string
-                    description: Public portion of a SSH key pair
+                    description: Enter the name of the newly created pubkey.
         v1.PubkeyResponse:
             type: object
             properties:
@@ -517,14 +517,14 @@ components:
         Limit:
             name: limit
             in: query
-            description: The number of items to return
+            description: The number of items to return.
             schema:
                 type: integer
                 default: 100
         Offset:
             name: offset
             in: query
-            description: The number of items to skip before starting to collect the result set
+            description: The number of items to skip before starting to collect the result set.
             schema:
                 type: integer
                 default: 0
@@ -973,14 +973,14 @@ paths:
             tags:
                 - Pubkey
             description: |
-                A pubkey represents an SSH public portion of a key pair with name and body. This operation returns list of all pubkeys for particular account.
+                Returns a list of all public keys available in a particular account.
             operationId: getPubkeyList
             parameters:
                 - $ref: '#/components/parameters/Limit'
                 - $ref: '#/components/parameters/Offset'
             responses:
                 "200":
-                    description: Returned on success.
+                    description: OK. Returned on success.
                     content:
                         application/json:
                             schema:
@@ -994,7 +994,7 @@ paths:
             tags:
                 - Pubkey
             description: |
-                A pubkey represents an SSH public portion of a key pair with name and body. When pubkey is created, it is stored in the Provisioning database. Pubkeys are uploaded to clouds when an instance is launched. Some fields (e.g. type or fingerprint) are read only.
+                Creates a new public key and stores it in the provisioning database. Public keys are uploaded to clouds at the time of launching an instance. Some fields such as type or fingerprint are read-only.
             operationId: createPubkey
             requestBody:
                 description: request body
@@ -1008,7 +1008,7 @@ paths:
                                 $ref: '#/components/examples/v1.PubkeyRequestExample'
             responses:
                 "200":
-                    description: Returned on success.
+                    description: OK. Returned on success.
                     content:
                         application/json:
                             schema:
@@ -1023,12 +1023,12 @@ paths:
             tags:
                 - Pubkey
             description: |
-                A pubkey represents an SSH public portion of a key pair with name and body. If a pubkey was uploaded to one or more clouds, the deletion request will attempt to delete those SSH keys from all clouds. This means in order to delete a pubkey the account must have valid credentials to all cloud accounts the pubkey was uploaded to, otherwise the delete operation will fail and the pubkey will not be deleted from Provisioning database. This operation returns no body.
+                Deletes SSH keys that were uploaded with the specified public key from all the clouds. If a public key (pubkey) has been uploaded to one or more cloud providers, the deletion request attempts to remove those SSH keys from all associated clouds. Therefore, to delete a public key, the account must possess valid credentials for all cloud accounts to which the pubkey was uploaded. Otherwise, the delete operation fails, and the public key is not removed from the Provisioning database. This operation does not return a response body.
             operationId: removePubkeyById
             parameters:
                 - name: ID
                   in: path
-                  description: Database ID of resource.
+                  description: Enter the database ID of resource.
                   required: true
                   schema:
                     type: integer
@@ -1043,8 +1043,7 @@ paths:
         get:
             tags:
                 - Pubkey
-            description: |
-                A pubkey represents an SSH public portion of a key pair with name and body. Pubkeys must have unique name and body (SSH public key fingerprint) per each account. Pubkey type is detected during create operation as well as fingerprints. Currently two types are supported: RSA and ssh-ed25519. Also, two fingerprint types are calculated: standard SHA fingerprint and legacy MD5 fingerprint available under fingerprint_legacy field. Fingerprints are used to check uniqueness of key.
+            description: Gets details of the specified public key.
             operationId: getPubkeyById
             parameters:
                 - name: ID
@@ -1056,7 +1055,7 @@ paths:
                     format: int64
             responses:
                 "200":
-                    description: Returned on success
+                    description: OK. Returned on success
                     content:
                         application/json:
                             schema:
@@ -1469,4 +1468,5 @@ servers:
             default: "8000"
 tags:
     - name: Pubkey
-      description: Public SSH keys operations
+      description: |
+        A pubkey represents the SSH public portion of a key pair with a name and body. Public key types and fingerprints are detected during their creation process. Two types are supported: RSA and ssh-ed25519. Fingerprints are calculated in two ways: using the standard SHA method and the legacy MD5 method, which is available under the fingerprint_legacy field. Each public key has a unique name and body and helps in verifying the uniqueness of the keys. Using this API, you can perform the following operations.

--- a/cmd/spec/parameters.go
+++ b/cmd/spec/parameters.go
@@ -11,7 +11,7 @@ type Parameter struct {
 
 var LimitQueryParam = Parameter{
 	Name:        "limit",
-	Description: "The number of items to return",
+	Description: "The number of items to return.",
 	Default:     100,
 	Type:        "integer",
 	Required:    false,
@@ -20,7 +20,7 @@ var LimitQueryParam = Parameter{
 
 var OffsetQueryParam = Parameter{
 	Name:        "offset",
-	Description: "The number of items to skip before starting to collect the result set",
+	Description: "The number of items to skip before starting to collect the result set.",
 	Default:     0,
 	Type:        "integer",
 	Required:    false,

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -8,20 +8,20 @@ info:
   version: 1.0.0
 tags:
   - name: Pubkey
-    description: Public SSH keys operations
+    description: >
+      A pubkey represents the SSH public portion of a key pair with a name and body.
+      Public key types and fingerprints are detected during their creation process.
+      Two types are supported: RSA and ssh-ed25519.
+      Fingerprints are calculated in two ways: using the standard SHA method and the legacy MD5 method, which is available under the fingerprint_legacy field.
+      Each public key has a unique name and body and helps in verifying the uniqueness of the keys.
+      Using this API, you can perform the following operations.
 paths:
   /pubkeys/{ID}:
     get:
       operationId: getPubkeyById
       tags:
         - Pubkey
-      description: >
-        A pubkey represents an SSH public portion of a key pair with name and body.
-        Pubkeys must have unique name and body (SSH public key fingerprint) per each account.
-        Pubkey type is detected during create operation as well as fingerprints.
-        Currently two types are supported: RSA and ssh-ed25519. Also, two fingerprint
-        types are calculated: standard SHA fingerprint and legacy MD5 fingerprint available
-        under fingerprint_legacy field. Fingerprints are used to check uniqueness of key.
+      description: Gets details of the specified public key.
       parameters:
         - name: ID
           in: path
@@ -32,7 +32,7 @@ paths:
             format: int64
       responses:
         "200":
-          description: 'Returned on success'
+          description: 'OK. Returned on success'
           content:
             application/json:
               schema:
@@ -49,18 +49,19 @@ paths:
       tags:
         - Pubkey
       description: >
-        A pubkey represents an SSH public portion of a key pair with name and body.
-        If a pubkey was uploaded to one or more clouds, the deletion request will
-        attempt to delete those SSH keys from all clouds. This means in order to delete
-        a pubkey the account must have valid credentials to all cloud accounts the pubkey
-        was uploaded to, otherwise the delete operation will fail and the pubkey will
-        not be deleted from Provisioning database.
-        This operation returns no body.
+        Deletes SSH keys that were uploaded with the specified public key from all the clouds.
+        If a public key (pubkey) has been uploaded to one or more cloud providers,
+        the deletion request attempts to remove those SSH keys from all associated clouds.
+        Therefore, to delete a public key, the account must possess valid credentials
+        for all cloud accounts to which the pubkey was uploaded.
+        Otherwise, the delete operation fails,
+        and the public key is not removed from the Provisioning database.
+        This operation does not return a response body.
       parameters:
         - name: ID
           in: path
           required: true
-          description: 'Database ID of resource.'
+          description: 'Enter the database ID of resource.'
           schema:
             type: integer
             format: int64
@@ -77,10 +78,9 @@ paths:
       tags:
         - Pubkey
       description: >
-        A pubkey represents an SSH public portion of a key pair with name and body.
-        When pubkey is created, it is stored in the Provisioning database. Pubkeys are
-        uploaded to clouds when an instance is launched. Some fields (e.g. type or
-        fingerprint) are read only.
+        Creates a new public key and stores it in the provisioning database.
+        Public keys are uploaded to clouds at the time of launching an instance.
+        Some fields such as type or fingerprint are read-only.
       requestBody:
         content:
           application/json:
@@ -93,7 +93,7 @@ paths:
         required: true
       responses:
         '200':
-          description: 'Returned on success.'
+          description: 'OK. Returned on success.'
           content:
             application/json:
               schema:
@@ -111,11 +111,10 @@ paths:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
       description: >
-        A pubkey represents an SSH public portion of a key pair with name and body.
-        This operation returns list of all pubkeys for particular account.
+        Returns a list of all public keys available in a particular account.
       responses:
         '200':
-          description: 'Returned on success.'
+          description: 'OK. Returned on success.'
           content:
             application/json:
               schema:

--- a/internal/payloads/pubkey_payload.go
+++ b/internal/payloads/pubkey_payload.go
@@ -11,8 +11,8 @@ import (
 
 // See models.Pubkey
 type PubkeyRequest struct {
-	Name string `json:"name" yaml:"name" description:"Public portion of a SSH key pair"`
-	Body string `json:"body" yaml:"body" description:"User facing name of the newly created pubkey"`
+	Name string `json:"name" yaml:"name" description:"Enter the name of the newly created pubkey."`
+	Body string `json:"body" yaml:"body" description:"Add a public part of a SSH key pair."`
 }
 
 // See models.Pubkey


### PR DESCRIPTION
* Considering only 1 endpoint (Pubkey) and 4 operation IDs under it (getPubkeyList,createPubkey,removePubkeyById,getPubkeyById)
* Removed duplicate information.
* Added detailed information of an endpoint at the top.
* Re-organised information to make the best use of space.

Feel free to suggest if there are any more modifications required.

Thanks for the contribution, make sure your commit message follows this subject style:

        type: brief summary up to 70 characters or
        type(scope): brief summary up to 70 characters

Type is required, scope is optional. Prefer lower-case and avoid dot at the end.

Find more info about types and scopes at:

https://github.com/RHEnVision/provisioning-backend#contributing

Take a moment to read our contributing and security guidelines:

https://github.com/RedHatInsights/secure-coding-checklist

**Checklist**

- [x] all commit messages follows the policy above
- [x] the change follows our security guidelines
