### PR TITLE
feat(HMS-2248): Add token support for list template

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -230,11 +230,11 @@
               "success": false
             }
           ],
-          "links": {
-            "next": "",
-            "previous": ""
-          },
           "metadata": {
+            "links": {
+              "next": "",
+              "previous": ""
+            },
             "total": 3
           }
         }
@@ -331,7 +331,14 @@
               "id": "lt-9843797432897342",
               "name": "XXL large backend API"
             }
-          ]
+          ],
+          "metadata": {
+            "links": {
+              "next": "",
+              "previous": ""
+            },
+            "total": 0
+          }
         }
       },
       "v1.NoopReservationResponsePayloadExample": {
@@ -351,11 +358,11 @@
               "type": "ssh-ed25519"
             }
           ],
-          "links": {
-            "next": "",
-            "previous": "/api/provisioning/v1/pubkeys?limit=2\u0026offset=0"
-          },
           "metadata": {
+            "links": {
+              "next": "",
+              "previous": "/api/provisioning/v1/pubkeys?limit=2\u0026offset=0"
+            },
             "total": 3
           }
         }
@@ -394,11 +401,11 @@
               "uid": ""
             }
           ],
-          "links": {
-            "next": "",
-            "previous": "/api/provisioning/v1/sources?limit=2\u0026offset=0"
-          },
           "metadata": {
+            "links": {
+              "next": "",
+              "previous": "/api/provisioning/v1/sources?limit=2\u0026offset=0"
+            },
             "total": 4
           }
         }
@@ -446,6 +453,15 @@
         "schema": {
           "default": 0,
           "type": "integer"
+        }
+      },
+      "Token": {
+        "description": "The token used for requesting the next page of results; empty token for the first page",
+        "in": "query",
+        "name": "token",
+        "schema": {
+          "default": "",
+          "type": "string"
         }
       }
     },
@@ -968,19 +984,19 @@
             },
             "type": "array"
           },
-          "links": {
-            "properties": {
-              "next": {
-                "type": "string"
-              },
-              "previous": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
           "metadata": {
             "properties": {
+              "links": {
+                "properties": {
+                  "next": {
+                    "type": "string"
+                  },
+                  "previous": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
               "total": {
                 "type": "integer"
               }
@@ -1054,6 +1070,25 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "metadata": {
+            "properties": {
+              "links": {
+                "properties": {
+                  "next": {
+                    "type": "string"
+                  },
+                  "previous": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "total": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         },
         "type": "object"
@@ -1087,19 +1122,19 @@
             },
             "type": "array"
           },
-          "links": {
-            "properties": {
-              "next": {
-                "type": "string"
-              },
-              "previous": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
           "metadata": {
             "properties": {
+              "links": {
+                "properties": {
+                  "next": {
+                    "type": "string"
+                  },
+                  "previous": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
               "total": {
                 "type": "integer"
               }
@@ -1134,19 +1169,19 @@
             },
             "type": "array"
           },
-          "links": {
-            "properties": {
-              "next": {
-                "type": "string"
-              },
-              "previous": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
           "metadata": {
             "properties": {
+              "links": {
+                "properties": {
+                  "next": {
+                    "type": "string"
+                  },
+                  "previous": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
               "total": {
                 "type": "integer"
               }
@@ -2052,7 +2087,7 @@
     },
     "/sources/{ID}/launch_templates": {
       "get": {
-        "description": "Return a list of launch templates.\nA launch template is a configuration set with a name that is available through hyperscaler API. When creating reservations, launch template can be provided in order to set additional configuration for instances.\nCurrently only AWS Launch Templates are supported.\n",
+        "description": "Return a list of launch templates.\nA launch template is a configuration set with a name that is available through hyperscaler API. When creating reservations, launch template can be provided in order to set additional configuration for instances. In GCP, when using templates, propagated user attributes are not overridden or updated. Only new attributes are added to the instance.\nCurrently AWS and GCP Launch Templates are supported.\n",
         "operationId": "getLaunchTemplatesList",
         "parameters": [
           {
@@ -2073,6 +2108,12 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/Token"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
           }
         ],
         "responses": {

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -307,16 +307,16 @@ components:
                             success:
                                 type: boolean
                                 nullable: true
-                links:
-                    type: object
-                    properties:
-                        next:
-                            type: string
-                        previous:
-                            type: string
                 metadata:
                     type: object
                     properties:
+                        links:
+                            type: object
+                            properties:
+                                next:
+                                    type: string
+                                previous:
+                                    type: string
                         total:
                             type: integer
         v1.ListInstaceTypeResponse:
@@ -364,6 +364,18 @@ components:
                                 type: string
                             name:
                                 type: string
+                metadata:
+                    type: object
+                    properties:
+                        links:
+                            type: object
+                            properties:
+                                next:
+                                    type: string
+                                previous:
+                                    type: string
+                        total:
+                            type: integer
         v1.ListPubkeyResponse:
             type: object
             properties:
@@ -385,16 +397,16 @@ components:
                                 type: string
                             type:
                                 type: string
-                links:
-                    type: object
-                    properties:
-                        next:
-                            type: string
-                        previous:
-                            type: string
                 metadata:
                     type: object
                     properties:
+                        links:
+                            type: object
+                            properties:
+                                next:
+                                    type: string
+                                previous:
+                                    type: string
                         total:
                             type: integer
         v1.ListSourceResponse:
@@ -415,16 +427,16 @@ components:
                                 type: string
                             uid:
                                 type: string
-                links:
-                    type: object
-                    properties:
-                        next:
-                            type: string
-                        previous:
-                            type: string
                 metadata:
                     type: object
                     properties:
+                        links:
+                            type: object
+                            properties:
+                                next:
+                                    type: string
+                                previous:
+                                    type: string
                         total:
                             type: integer
         v1.NoopReservationResponse:
@@ -528,6 +540,13 @@ components:
             schema:
                 type: integer
                 default: 0
+        Token:
+            name: token
+            in: query
+            description: The token used for requesting the next page of results; empty token for the first page
+            schema:
+                type: string
+                default: ""
     responses:
         BadRequest:
             description: The request's parameters are not valid
@@ -759,10 +778,10 @@ components:
                         - Fetch instance(s) description
                       steps: 3
                       success: false
-                links:
-                    next: ""
-                    previous: ""
                 metadata:
+                    links:
+                        next: ""
+                        previous: ""
                     total: 3
         v1.GenericReservationResponsePayloadPendingExample:
             value:
@@ -832,6 +851,11 @@ components:
                 data:
                     - id: lt-9843797432897342
                       name: XXL large backend API
+                metadata:
+                    links:
+                        next: ""
+                        previous: ""
+                    total: 0
         v1.NoopReservationResponsePayloadExample:
             value:
                 reservation_id: 1310
@@ -844,10 +868,10 @@ components:
                       id: 3
                       name: My key
                       type: ssh-ed25519
-                links:
-                    next: ""
-                    previous: /api/provisioning/v1/pubkeys?limit=2&offset=0
                 metadata:
+                    links:
+                        next: ""
+                        previous: /api/provisioning/v1/pubkeys?limit=2&offset=0
                     total: 3
         v1.PubkeyRequestExample:
             value:
@@ -874,10 +898,10 @@ components:
                       source_type_id: ""
                       status: available
                       uid: ""
-                links:
-                    next: ""
-                    previous: /api/provisioning/v1/sources?limit=2&offset=0
                 metadata:
+                    links:
+                        next: ""
+                        previous: /api/provisioning/v1/sources?limit=2&offset=0
                     total: 4
         v1.SourceUploadInfoAWSResponse:
             value:
@@ -1395,8 +1419,8 @@ paths:
                 - Source
             description: |
                 Return a list of launch templates.
-                A launch template is a configuration set with a name that is available through hyperscaler API. When creating reservations, launch template can be provided in order to set additional configuration for instances.
-                Currently only AWS Launch Templates are supported.
+                A launch template is a configuration set with a name that is available through hyperscaler API. When creating reservations, launch template can be provided in order to set additional configuration for instances. In GCP, when using templates, propagated user attributes are not overridden or updated. Only new attributes are added to the instance.
+                Currently AWS and GCP Launch Templates are supported.
             operationId: getLaunchTemplatesList
             parameters:
                 - name: ID
@@ -1412,6 +1436,8 @@ paths:
                   required: true
                   schema:
                     type: string
+                - $ref: '#/components/parameters/Token'
+                - $ref: '#/components/parameters/Limit'
             responses:
                 "200":
                     description: Return on success.

--- a/cmd/spec/example_pubkey.go
+++ b/cmd/spec/example_pubkey.go
@@ -34,9 +34,9 @@ var PubkeyListResponse = payloads.PubkeyListResponse{
 	},
 	Metadata: page.Metadata{
 		Total: 3,
-	},
-	Links: page.Links{
-		Previous: "/api/provisioning/v1/pubkeys?limit=2&offset=0",
-		Next:     "",
+		Links: page.Links{
+			Previous: "/api/provisioning/v1/pubkeys?limit=2&offset=0",
+			Next:     "",
+		},
 	},
 }

--- a/cmd/spec/example_reservation.go
+++ b/cmd/spec/example_reservation.go
@@ -66,10 +66,10 @@ var GenericReservationResponsePayloadListExample = payloads.GenericReservationLi
 	},
 	Metadata: page.Metadata{
 		Total: 3,
-	},
-	Links: page.Links{
-		Previous: "",
-		Next:     "",
+		Links: page.Links{
+			Previous: "",
+			Next:     "",
+		},
 	},
 }
 

--- a/cmd/spec/example_source.go
+++ b/cmd/spec/example_source.go
@@ -20,10 +20,10 @@ var SourceListResponse = payloads.SourceListResponse{
 	},
 	Metadata: page.Metadata{
 		Total: 4,
-	},
-	Links: page.Links{
-		Previous: "/api/provisioning/v1/sources?limit=2&offset=0",
-		Next:     "",
+		Links: page.Links{
+			Previous: "/api/provisioning/v1/sources?limit=2&offset=0",
+			Next:     "",
+		},
 	},
 }
 

--- a/cmd/spec/example_templates.go
+++ b/cmd/spec/example_templates.go
@@ -1,12 +1,20 @@
 package main
 
-import "github.com/RHEnVision/provisioning-backend/internal/payloads"
+import (
+	"github.com/RHEnVision/provisioning-backend/internal/page"
+	"github.com/RHEnVision/provisioning-backend/internal/payloads"
+)
 
 var LaunchTemplateListResponse = payloads.LaunchTemplateListResponse{
 	Data: []*payloads.LaunchTemplateResponse{
 		{
 			ID:   "lt-9843797432897342",
 			Name: "XXL large backend API",
+		},
+	},
+	Metadata: page.Metadata{
+		Links: page.Links{
+			Next: "",
 		},
 	},
 }

--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -70,6 +70,7 @@ func addExamples(gen *APISchemaGen) {
 func addParameters(gen *APISchemaGen) {
 	gen.addQueryParameter("Limit", LimitQueryParam)
 	gen.addQueryParameter("Offset", OffsetQueryParam)
+	gen.addQueryParameter("Token", TokenQueryParam)
 }
 
 // addErrorSchemas all generic errors, that can be returned.

--- a/cmd/spec/parameters.go
+++ b/cmd/spec/parameters.go
@@ -26,3 +26,12 @@ var OffsetQueryParam = Parameter{
 	Required:    false,
 	In:          "query",
 }
+
+var TokenQueryParam = Parameter{
+	Name:        "token",
+	Description: "The token used for requesting the next page of results; empty token for the first page",
+	Default:     "",
+	Type:        "string",
+	Required:    false,
+	In:          "query",
+}

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -261,8 +261,10 @@ paths:
         A launch template is a configuration set with a name that is available through hyperscaler
         API. When creating reservations, launch template can be provided in order to set additional
         configuration for instances.
-
-        Currently only AWS Launch Templates are supported.
+        In GCP, when using templates, propagated user attributes are not overridden or updated.
+        Only new attributes are added to the instance.
+        
+        Currently AWS and GCP Launch Templates are supported.
       operationId: getLaunchTemplatesList
       tags:
         - Source
@@ -280,6 +282,8 @@ paths:
             type: string
           required: true
           description: Hyperscaler region
+        - $ref: '#/components/parameters/Token'
+        - $ref: '#/components/parameters/Limit'
       responses:
         '200':
           description: Return on success.

--- a/internal/clients/http/gcp/gcp_client.go
+++ b/internal/clients/http/gcp/gcp_client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/logging"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 
 	compute "cloud.google.com/go/compute/apiv1"
@@ -100,44 +101,42 @@ func (c *gcpClient) NewInstanceTemplatesClient(ctx context.Context) (*compute.In
 	return client, nil
 }
 
-func (c *gcpClient) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchTemplate, error) {
+func (c *gcpClient) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchTemplate, string, error) {
 	ctx, span := otel.Tracer(TraceName).Start(ctx, "ListLaunchTemplates")
 	defer span.End()
-
+	var token string
 	logger := logger(ctx)
 	logger.Trace().Msgf("Listing launch templates")
 
 	templatesClient, err := c.NewInstanceTemplatesClient(ctx)
 	if err != nil {
 		logger.Error().Err(err).Msg("Could not get instances client")
-		return nil, fmt.Errorf("unable to get instances client: %w", err)
+		return nil, "", fmt.Errorf("unable to get instances client: %w", err)
 	}
 	defer templatesClient.Close()
 
-	req := &computepb.AggregatedListInstanceTemplatesRequest{
-		Project: c.auth.Payload,
+	limit := page.Limit(ctx).Int()
+	req := &computepb.ListInstanceTemplatesRequest{
+		Project:    c.auth.Payload,
+		MaxResults: ptr.To(uint32(limit)),
+		PageToken:  ptr.To(page.Token(ctx)),
 	}
 
-	var templatesList []*clients.LaunchTemplate
-	templates := templatesClient.AggregatedList(ctx, req)
-	for {
-		pair, err := templates.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		} else if err != nil {
-			logger.Error().Err(err).Msg("An error occurred during listing launch templates")
-			span.SetStatus(codes.Error, err.Error())
-			return nil, fmt.Errorf("cannot list launch templates: %w", err)
-		} else {
-			instancesTemplates := pair.Value.InstanceTemplates
-			for _, template := range instancesTemplates {
-				id := strconv.FormatUint(*template.Id, 10)
-				templatesList = append(templatesList, &clients.LaunchTemplate{ID: id, Name: template.GetName()})
-			}
-		}
+	var lst []*computepb.InstanceTemplate
+	it := templatesClient.List(ctx, req)
+	pager := iterator.NewPager(it, it.PageInfo().MaxSize, token)
+	nextToken, err := pager.NextPage(&lst)
+	if err != nil {
+		return nil, "", fmt.Errorf("unable to get next page: %w", err)
 	}
 
-	return templatesList, nil
+	templatesList := make([]*clients.LaunchTemplate, 0, len(lst))
+	for _, template := range lst {
+		id := strconv.FormatUint(*template.Id, 10)
+		templatesList = append(templatesList, &clients.LaunchTemplate{ID: id, Name: template.GetName()})
+	}
+
+	return templatesList, nextToken, nil
 }
 
 func (c *gcpClient) InsertInstances(ctx context.Context, params *clients.GCPInstanceParams, amount int64) ([]*string, *string, error) {

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -83,8 +83,8 @@ type EC2 interface {
 	// ListInstanceTypesWithPaginator lists all instance types.
 	ListInstanceTypes(ctx context.Context) ([]*InstanceType, error)
 
-	// ListLaunchTemplates lists all launch templates.
-	ListLaunchTemplates(ctx context.Context) ([]*LaunchTemplate, error)
+	// ListLaunchTemplates lists all launch templates and returns the next page token.
+	ListLaunchTemplates(ctx context.Context) ([]*LaunchTemplate, string, error)
 
 	// RunInstances launches one or more instances.
 	//
@@ -156,5 +156,6 @@ type GCP interface {
 
 	GetInstanceDescriptionByID(ctx context.Context, id, zone string) (*InstanceDescription, error)
 
-	ListLaunchTemplates(ctx context.Context) ([]*LaunchTemplate, error)
+	// ListLaunchTemplates lists all launch templates and returns the next page token.
+	ListLaunchTemplates(ctx context.Context) ([]*LaunchTemplate, string, error)
 }

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -142,7 +142,7 @@ func (mock *EC2ClientStub) ListInstanceTypes(ctx context.Context) ([]*clients.In
 	}, nil
 }
 
-func (mock *EC2ClientStub) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchTemplate, error) {
+func (mock *EC2ClientStub) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchTemplate, string, error) {
 	return []*clients.LaunchTemplate{
 		{
 			ID:   "lt-8732678436272377",
@@ -152,7 +152,7 @@ func (mock *EC2ClientStub) ListLaunchTemplates(ctx context.Context) ([]*clients.
 			ID:   "lt-8732678438462378",
 			Name: "XXLarge AMD64 database",
 		},
-	}, nil
+	}, "", nil
 }
 
 func (mock *EC2ClientStub) CheckPermission(ctx context.Context, auth *clients.Authentication) ([]string, error) {

--- a/internal/clients/stubs/gcp_stub.go
+++ b/internal/clients/stubs/gcp_stub.go
@@ -91,8 +91,8 @@ func (mock *GCPClientStub) GetInstanceDescriptionByID(ctx context.Context, id, z
 	return nil, MissingInstanceIDErr
 }
 
-func (mock *GCPClientStub) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchTemplate, error) {
-	return nil, nil
+func (mock *GCPClientStub) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchTemplate, string, error) {
+	return nil, "", nil
 }
 
 func (mock *GCPClientStub) InsertInstances(ctx context.Context, params *clients.GCPInstanceParams, amount int64) ([]*string, *string, error) {

--- a/internal/middleware/pagination_middleware.go
+++ b/internal/middleware/pagination_middleware.go
@@ -11,9 +11,12 @@ func Pagination(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		offset := r.URL.Query().Get("offset")
 		limit := r.URL.Query().Get("limit")
+		token := r.URL.Query().Get("token")
 
 		newCtx := page.WithOffset(r.Context(), offset)
 		newCtx = page.WithLimit(newCtx, limit)
+		newCtx = page.WithToken(newCtx, token)
+
 		next.ServeHTTP(w, r.WithContext(newCtx))
 	})
 }

--- a/internal/page/page.go
+++ b/internal/page/page.go
@@ -21,6 +21,7 @@ type (
 const (
 	offsetCtxKey ctxKeyType = iota
 	limitCtxKey
+	tokenCtxKey
 )
 
 const (
@@ -33,12 +34,8 @@ type Links struct {
 	Next     string `json:"next"`
 }
 type Metadata struct {
-	Total int `json:"total"`
-}
-
-type Info struct {
-	Metadata Metadata `json:"metadata"`
-	Links    Links    `json:"links"`
+	Total int   `json:"total,omitempty"`
+	Links Links `json:"links,omitempty"`
 }
 
 // WithOffset returns context copy with offset value.
@@ -63,6 +60,15 @@ func WithLimit(ctx context.Context, limitStr string) context.Context {
 	return context.WithValue(ctx, limitCtxKey, limit)
 }
 
+// WithToken returns context copy with token value.
+func WithToken(ctx context.Context, token string) context.Context {
+	logger := zerolog.Ctx(ctx)
+	if token == "" {
+		logger.Info().Msg("token is empty, listing first page")
+	}
+	return context.WithValue(ctx, tokenCtxKey, token)
+}
+
 func Limit(ctx context.Context) limitOffset {
 	if lim, ok := ctx.Value(limitCtxKey).(int); ok {
 		return limitOffset(lim)
@@ -77,6 +83,13 @@ func Offset(ctx context.Context) limitOffset {
 	return limitOffset(defaultValueOffset)
 }
 
+func Token(ctx context.Context) string {
+	if token, ok := ctx.Value(tokenCtxKey).(string); ok {
+		return token
+	}
+	return ""
+}
+
 func (o limitOffset) IntPtr() *int {
 	return ptr.To(int(o))
 }
@@ -89,11 +102,15 @@ func (o limitOffset) Int64() int64 {
 	return int64(o)
 }
 
+func (o limitOffset) Int32() int32 {
+	return int32(o)
+}
+
 func (o limitOffset) String() string {
 	return strconv.Itoa(int(o))
 }
 
-func APIInfoResponse(ctx context.Context, r *http.Request, total int) *Info {
+func NewOffsetMetadata(ctx context.Context, r *http.Request, total int) *Metadata {
 	limit := Limit(ctx).Int()
 	offset := Offset(ctx).Int()
 	var prev, next string
@@ -120,13 +137,31 @@ func APIInfoResponse(ctx context.Context, r *http.Request, total int) *Info {
 		next = fmt.Sprintf("%v?%v", r.URL.Path, q.Encode())
 	}
 
-	return &Info{
-		Metadata: Metadata{
-			Total: total,
-		},
+	return &Metadata{
+		Total: total,
 		Links: Links{
 			Next:     next,
 			Previous: prev,
+		},
+	}
+}
+
+func NewTokenMetadata(ctx context.Context, r *http.Request, nextToken string) *Metadata {
+	limit := Limit(ctx).Int()
+	var next string
+
+	if nextToken == "" {
+		next = ""
+	} else {
+		q := url.Values{}
+		q.Add("limit", strconv.Itoa(limit))
+		q.Add("token", nextToken)
+		next = fmt.Sprintf("%v?%v", r.URL.Path, q.Encode())
+	}
+
+	return &Metadata{
+		Links: Links{
+			Next: next,
 		},
 	}
 }

--- a/internal/payloads/launch_template_payload.go
+++ b/internal/payloads/launch_template_payload.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 	"github.com/go-chi/render"
 )
 
@@ -14,28 +15,21 @@ type LaunchTemplateResponse struct {
 }
 
 type LaunchTemplateListResponse struct {
-	Data []*LaunchTemplateResponse `json:"data" yaml:"data"`
-}
-
-func (s *LaunchTemplateResponse) Bind(_ *http.Request) error {
-	return nil
-}
-
-func (s *LaunchTemplateResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
-	return nil
+	Data     []*LaunchTemplateResponse `json:"data" yaml:"data"`
+	Metadata page.Metadata             `json:"metadata" yaml:"metadata"`
 }
 
 func (s *LaunchTemplateListResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
 	return nil
 }
 
-func NewListLaunchTemplateResponse(sl []*clients.LaunchTemplate) render.Renderer {
+func NewListLaunchTemplateResponse(sl []*clients.LaunchTemplate, meta *page.Metadata) render.Renderer {
 	list := make([]*LaunchTemplateResponse, len(sl))
-	for i, instanceType := range sl {
+	for i, tmpl := range sl {
 		list[i] = &LaunchTemplateResponse{
-			ID:   instanceType.ID,
-			Name: instanceType.Name,
+			ID:   tmpl.ID,
+			Name: tmpl.Name,
 		}
 	}
-	return &LaunchTemplateListResponse{Data: list}
+	return &LaunchTemplateListResponse{Data: list, Metadata: *meta}
 }

--- a/internal/payloads/pubkey_payload.go
+++ b/internal/payloads/pubkey_payload.go
@@ -28,7 +28,6 @@ type PubkeyResponse struct {
 type PubkeyListResponse struct {
 	Data     []*PubkeyResponse `json:"data" yaml:"data"`
 	Metadata page.Metadata     `json:"metadata" yaml:"metadata"`
-	Links    page.Links        `json:"links" yaml:"links"`
 }
 
 func (p *PubkeyRequest) Bind(_ *http.Request) error {
@@ -62,10 +61,10 @@ func NewPubkeyResponse(pubkey *models.Pubkey) *PubkeyResponse {
 	}
 }
 
-func NewPubkeyListResponse(pubkeys []*models.Pubkey, info *page.Info) render.Renderer {
+func NewPubkeyListResponse(pubkeys []*models.Pubkey, meta *page.Metadata) render.Renderer {
 	list := make([]*PubkeyResponse, len(pubkeys))
 	for i, pubkey := range pubkeys {
 		list[i] = NewPubkeyResponse(pubkey)
 	}
-	return &PubkeyListResponse{Data: list, Metadata: info.Metadata, Links: info.Links}
+	return &PubkeyListResponse{Data: list, Metadata: *meta}
 }

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -243,7 +243,6 @@ type GCPReservationRequest struct {
 type GenericReservationListResponse struct {
 	Data     []*GenericReservationResponse `json:"data" yaml:"data"`
 	Metadata page.Metadata                 `json:"metadata" yaml:"metadata"`
-	Links    page.Links                    `json:"links" yaml:"links"`
 }
 
 func (p *GenericReservationResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
@@ -364,12 +363,12 @@ func NewNoopReservationResponse(reservation *models.NoopReservation) render.Rend
 	}
 }
 
-func NewReservationListResponse(reservations []*models.Reservation, info *page.Info) render.Renderer {
+func NewReservationListResponse(reservations []*models.Reservation, meta *page.Metadata) render.Renderer {
 	list := make([]*GenericReservationResponse, len(reservations))
 	for i, reservation := range reservations {
 		list[i] = reservationResponseMapper(reservation)
 	}
-	return &GenericReservationListResponse{Data: list, Metadata: info.Metadata, Links: info.Links}
+	return &GenericReservationListResponse{Data: list, Metadata: *meta}
 }
 
 func reservationResponseMapper(reservation *models.Reservation) *GenericReservationResponse {

--- a/internal/payloads/sources_payload.go
+++ b/internal/payloads/sources_payload.go
@@ -20,7 +20,6 @@ type SourceResponse struct {
 type SourceListResponse struct {
 	Data     []*SourceResponse `json:"data" yaml:"data"`
 	Metadata page.Metadata     `json:"metadata" yaml:"metadata"`
-	Links    page.Links        `json:"links" yaml:"links"`
 }
 
 func (s *SourceResponse) Render(_ http.ResponseWriter, _ *http.Request) error {
@@ -31,7 +30,7 @@ func (s *SourceListResponse) Render(_ http.ResponseWriter, _ *http.Request) erro
 	return nil
 }
 
-func NewListSourcesResponse(sourceList []*clients.Source, info *page.Info) render.Renderer {
+func NewListSourcesResponse(sourceList []*clients.Source, meta *page.Metadata) render.Renderer {
 	list := make([]*SourceResponse, len(sourceList))
 	for i, source := range sourceList {
 		list[i] = &SourceResponse{
@@ -42,7 +41,7 @@ func NewListSourcesResponse(sourceList []*clients.Source, info *page.Info) rende
 			Status:       source.Status,
 		}
 	}
-	return &SourceListResponse{Data: list, Metadata: info.Metadata, Links: info.Links}
+	return &SourceListResponse{Data: list, Metadata: *meta}
 }
 
 type SourceUploadInfoResponse struct {

--- a/internal/routes/all_routes.go
+++ b/internal/routes/all_routes.go
@@ -75,7 +75,7 @@ func MountAPI(r *chi.Mux) {
 				// TODO DEPRECATED: replaced with upload_info
 				r.Get("/account_identity", s.GetAWSAccountIdentity)
 
-				r.Get("/launch_templates", s.ListLaunchTemplates)
+				r.With(middleware.Pagination).Get("/launch_templates", s.ListLaunchTemplates)
 				r.Get("/upload_info", s.GetSourceUploadInfo)
 				r.Route("/validate_permissions", func(r chi.Router) {
 					r.Get("/", s.ValidatePermissions)

--- a/internal/services/launch_templates_service.go
+++ b/internal/services/launch_templates_service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
+	"github.com/RHEnVision/provisioning-backend/internal/page"
 	"github.com/RHEnVision/provisioning-backend/internal/payloads"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -63,13 +64,15 @@ func ListLaunchTemplateAWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	templates, err := ec2Client.ListLaunchTemplates(r.Context())
+	templates, nextToken, err := ec2Client.ListLaunchTemplates(r.Context())
 	if err != nil {
 		renderError(w, r, payloads.NewAWSError(r.Context(), "unable to list AWS EC2 launch templates", err))
 		return
 	}
 
-	if err := render.Render(w, r, payloads.NewListLaunchTemplateResponse(templates)); err != nil {
+	meta := page.NewTokenMetadata(r.Context(), r, nextToken)
+
+	if err := render.Render(w, r, payloads.NewListLaunchTemplateResponse(templates, meta)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render launch templates list", err))
 		return
 	}
@@ -95,13 +98,15 @@ func ListLaunchTemplateGCP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	templates, err := gcpClient.ListLaunchTemplates(r.Context())
+	templates, nextToken, err := gcpClient.ListLaunchTemplates(r.Context())
 	if err != nil {
 		renderError(w, r, payloads.NewGCPError(r.Context(), "unable to list GCP launch templates", err))
 		return
 	}
 
-	if err := render.Render(w, r, payloads.NewListLaunchTemplateResponse(templates)); err != nil {
+	meta := page.NewTokenMetadata(r.Context(), r, nextToken)
+
+	if err := render.Render(w, r, payloads.NewListLaunchTemplateResponse(templates, meta)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render launch templates list", err))
 		return
 	}

--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -65,9 +65,9 @@ func ListPubkeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info := page.APIInfoResponse(r.Context(), r, totalPubkeys)
+	meta := page.NewOffsetMetadata(r.Context(), r, totalPubkeys)
 
-	if err := render.Render(w, r, payloads.NewPubkeyListResponse(pubkeys, info)); err != nil {
+	if err := render.Render(w, r, payloads.NewPubkeyListResponse(pubkeys, meta)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render pubkeys list", err))
 		return
 	}

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -75,9 +75,9 @@ func ListReservations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info := page.NewOffsetMetadata(r.Context(), r, totalRes)
+	meta := page.NewOffsetMetadata(r.Context(), r, totalRes)
 
-	if err := render.Render(w, r, payloads.NewReservationListResponse(reservations, info)); err != nil {
+	if err := render.Render(w, r, payloads.NewReservationListResponse(reservations, meta)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render reservations list", err))
 		return
 	}

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -75,7 +75,7 @@ func ListReservations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info := page.APIInfoResponse(r.Context(), r, totalRes)
+	info := page.NewOffsetMetadata(r.Context(), r, totalRes)
 
 	if err := render.Render(w, r, payloads.NewReservationListResponse(reservations, info)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render reservations list", err))

--- a/internal/services/sources_service.go
+++ b/internal/services/sources_service.go
@@ -48,7 +48,7 @@ func ListAllProvisioningSources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info := page.APIInfoResponse(r.Context(), r, total)
+	info := page.NewOffsetMetadata(r.Context(), r, total)
 
 	if err := render.Render(w, r, payloads.NewListSourcesResponse(sourcesList, info)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render sources list", err))
@@ -71,7 +71,7 @@ func ListProvisioningSourcesByProvider(w http.ResponseWriter, r *http.Request, a
 		return
 	}
 
-	info := page.APIInfoResponse(r.Context(), r, total)
+	info := page.NewOffsetMetadata(r.Context(), r, total)
 
 	if err := render.Render(w, r, payloads.NewListSourcesResponse(sourcesList, info)); err != nil {
 		renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render sources list", err))

--- a/scripts/rest_examples/launchtemlates-gcp-list.http
+++ b/scripts/rest_examples/launchtemlates-gcp-list.http
@@ -1,4 +1,0 @@
-
-GET http://{{hostname}}:{{port}}/{{prefix}}/sources/3/launch_templates HTTP/1.1
-Content-Type: application/json
-X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/launchtemplates-aws-list.http
+++ b/scripts/rest_examples/launchtemplates-aws-list.http
@@ -1,4 +1,4 @@
 // @no-log
-GET http://{{hostname}}:{{port}}/{{prefix}}/sources/1/launch_templates?region=us-east-1 HTTP/1.1
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources/1/launch_templates?region=us-east-1&limit=&token= HTTP/1.1
 Content-Type: application/json
 X-Rh-Identity: {{identity}}

--- a/scripts/rest_examples/launchtemplates-gcp-list.http
+++ b/scripts/rest_examples/launchtemplates-gcp-list.http
@@ -1,0 +1,4 @@
+
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources/3/launch_templates?limit=&token= HTTP/1.1
+Content-Type: application/json
+X-Rh-Identity: {{identity}}


### PR DESCRIPTION
Depends on https://github.com/RHEnVision/provisioning-backend/pull/625
This PR introduces pagination support for AWS and GCP by returning the received token when fetching the corresponding page. To validate the retrieval of AWS pages, the token needs to be escaped since it is in base64 format.

However, tests are currently missing, andI plan on adding those once will get some feedback. Additionally, tests are failing due to the initial commit missing limit and offset. I plan to stub them and proceed with adding the tests once this implementation is agreed upon.

Please let me know if you have any feedback or suggestions regarding this approach before proceeding with the test implementation.
For easy review just take a look at the changes made by the second commit, once the dependent PR will be merged i'll rebase.