### PR TITLE
Delete simple pointers

### DIFF
--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -116,7 +116,7 @@ Statuser process (`pbstatuser`) is a custom executable that runs in a single ins
 
 [Sources](https://github.com/RedHatInsights/sources-api-go) is an authentication inventory. Since it only requires Go, Redis and Postgres, we created a shell script that automatically checks out sources from git, compiles it, installs and creates postgres database, seeds data and starts the Sources application.
 
-Follow [instructions](../scripts/README.sources) to perform the setup. Note that configuration via `sources.local.conf` is **required** before the setup procedure. This has been written and tested for Fedora Linux, in other operating systems perform all the commands manually.
+Follow [instructions (section Sources service)](../scripts/README.md) to perform the setup. Note that configuration via `sources.local.conf` is **required** before the setup procedure. This has been written and tested for Fedora Linux, in other operating systems perform all the commands manually.
 
 Tip: On MacOS, you can install Sources on a remote Fedora Linux (or a small VM) and configure the application to connect there, instead of localhost.
 

--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -368,7 +368,7 @@ func (c *ec2Client) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchT
 	return res, nil
 }
 
-func (c *ec2Client) RunInstances(ctx context.Context, params *clients.AWSInstanceParams, amount int32, name *string, reservation *models.AWSReservation) ([]*string, *string, error) {
+func (c *ec2Client) RunInstances(ctx context.Context, params *clients.AWSInstanceParams, amount int32, name string, reservation *models.AWSReservation) ([]*string, *string, error) {
 	ctx, span := otel.Tracer(TraceName).Start(ctx, "RunInstances")
 	defer span.End()
 
@@ -408,10 +408,10 @@ func (c *ec2Client) RunInstances(ctx context.Context, params *clients.AWSInstanc
 		},
 	}
 
-	if name != nil {
+	if name != "" {
 		t := types.Tag{
 			Key:   ptr.To("Name"),
-			Value: name,
+			Value: &name,
 		}
 		input.TagSpecifications[0].Tags = append(input.TagSpecifications[0].Tags, t)
 	}

--- a/internal/clients/interface.go
+++ b/internal/clients/interface.go
@@ -90,7 +90,7 @@ type EC2 interface {
 	//
 	// All arguments are required except: launchTemplateID (empty string means no template in use).
 	//
-	RunInstances(ctx context.Context, details *AWSInstanceParams, amount int32, name *string, reservation *models.AWSReservation) ([]*string, *string, error)
+	RunInstances(ctx context.Context, details *AWSInstanceParams, amount int32, name string, reservation *models.AWSReservation) ([]*string, *string, error)
 
 	// GetAccountId returns AWS account number.
 	GetAccountId(ctx context.Context) (string, error)

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -159,7 +159,7 @@ func (mock *EC2ClientStub) CheckPermission(ctx context.Context, auth *clients.Au
 	return nil, nil
 }
 
-func (mock *EC2ClientStub) RunInstances(ctx context.Context, details *clients.AWSInstanceParams, amount int32, name *string, reservation *models.AWSReservation) ([]*string, *string, error) {
+func (mock *EC2ClientStub) RunInstances(ctx context.Context, details *clients.AWSInstanceParams, amount int32, name string, reservation *models.AWSReservation) ([]*string, *string, error) {
 	return nil, nil, nil
 }
 

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -54,7 +54,7 @@ type AWSDetail struct {
 	Region string `json:"region"`
 
 	// Optional instance name
-	Name *string `json:"name"`
+	Name string `json:"name"`
 
 	// Optional launch template id ("lt-987432987342") or empty string
 	LaunchTemplateID string `json:"launch_template_id"`

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -300,7 +300,7 @@ func NewAWSReservationResponse(reservation *models.AWSReservation, instances []*
 		Amount:           reservation.Detail.Amount,
 		InstanceType:     reservation.Detail.InstanceType,
 		ID:               reservation.ID,
-		Name:             StringNullToEmpty(reservation.Detail.Name),
+		Name:             reservation.Detail.Name,
 		PowerOff:         reservation.Detail.PowerOff,
 		Instances:        instancesResponse,
 		LaunchTemplateID: reservation.Detail.LaunchTemplateID,

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -84,7 +84,7 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	reservation.Steps = 3
 	reservation.StepTitles = []string{"Ensure public key", "Launch instance(s)", "Fetch instance(s) description"}
 	newName := config.Application.InstancePrefix + payload.Name
-	reservation.Detail.Name = &newName
+	reservation.Detail.Name = newName
 
 	// validate pubkey - must be always present because of data integrity (foreign keys)
 	logger.Debug().Msgf("Validating existence of pubkey %d for this account", reservation.PubkeyID)


### PR DESCRIPTION
Sometimes, we use pointers with no big reason. We'd dereference again and again. Sometimes it is not that needed. I split such cases into commits so that you can see which changes are related to one usage of such a variable.
I will no longer devote time to this, but these were easy changes, and there was no need to use pointers here, so I just wanted to delete these.
Before merging, I think I should merge the commits into one.