### PR TITLE
chore: remove logging of bad input values

### DIFF
--- a/internal/page/page.go
+++ b/internal/page/page.go
@@ -40,10 +40,8 @@ type Metadata struct {
 
 // WithOffset returns context copy with offset value.
 func WithOffset(ctx context.Context, offsetStr string) context.Context {
-	logger := zerolog.Ctx(ctx)
 	offset, err := strconv.Atoi(offsetStr)
 	if err != nil || offset < 0 {
-		logger.Err(err).Msg("Offset is missing or invalid, setting offset value to 0")
 		offset = defaultValueOffset
 	}
 	return context.WithValue(ctx, offsetCtxKey, offset)
@@ -51,10 +49,8 @@ func WithOffset(ctx context.Context, offsetStr string) context.Context {
 
 // WithLimit returns context copy with limit value.
 func WithLimit(ctx context.Context, limitStr string) context.Context {
-	logger := zerolog.Ctx(ctx)
 	limit, err := strconv.Atoi(limitStr)
 	if err != nil || limit < 0 {
-		logger.Err(err).Msg("Limit is missing or invalid, setting limit value to 100")
 		limit = defaultValueLimit
 	}
 	return context.WithValue(ctx, limitCtxKey, limit)


### PR DESCRIPTION
Our security team runs regular penetration tests and glitchtip is cluttered with errors, I don’t think we need any logging for this it is pretty normal to expect number to convert to number and fall back to default.

I think it is worth putting limit and offset into metadata tho, because when you don’t provide it it might be useful to see the default value. But not in this PR.

<img width="720" alt="image" src="https://github.com/RHEnVision/provisioning-backend/assets/49752/7b8787b0-8a68-4260-8287-709b6da04d7e">
