### PR TITLE
chore: shorten message field for unhandled panics

### DIFF
--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -55,7 +55,8 @@ func LoggerMiddleware(rootLogger *zerolog.Logger) func(next http.Handler) http.H
 					log.Error().
 						Bool("panic", true).
 						Int("status", panicStatus).
-						Msgf("Unhandled panic: %s\n%s", rec, debug.Stack())
+						Bytes("stacktrace", debug.Stack()).
+						Msgf("Unhandled panic in API: %s", rec)
 					http.Error(ww, http.StatusText(panicStatus), panicStatus)
 				}
 

--- a/pkg/worker/redis.go
+++ b/pkg/worker/redis.go
@@ -165,13 +165,10 @@ func (w *RedisWorker) dequeueLoop(ctx context.Context, i, total int) {
 
 func recoverAndLog(ctx context.Context) {
 	if rec := recover(); rec != nil {
-		logger := zerolog.Ctx(ctx).Error()
-
-		if err, ok := rec.(error); ok {
-			logger.Err(err).Stack().Msg("Job queue panic")
-		} else {
-			logger.Msgf("Error during job handling: %v, stacktrace: %s", rec, debug.Stack())
-		}
+		zerolog.Ctx(ctx).Error().
+			Bool("panic", true).
+			Bytes("stacktrace", debug.Stack()).
+			Msgf("Unhandled panic in worker: %s", rec)
 	}
 }
 


### PR DESCRIPTION
Looks like we are getting way too many glitchtip events in case of many of panics:

<img width="876" alt="image" src="https://github.com/RHEnVision/provisioning-backend/assets/49752/b929228b-b5ee-4beb-9a93-c4cfbf03e468">

I am moving the stacktrace into a different field so we keep only the error message. This should hopefully solve this.