### PR TITLE
fix(HMS-2545): add rh labels to all providers

### DIFF
--- a/internal/clients/http/azure/create_vms.go
+++ b/internal/clients/http/azure/create_vms.go
@@ -26,11 +26,11 @@ func (c *client) CreateVMs(ctx context.Context, vmParams clients.AzureInstancePa
 	resumeTokens := make([]string, amount)
 	var i int64
 	for i = 0; i < amount; i++ {
-		uuid, err := uuid.NewUUID()
+		uid, err := uuid.NewUUID()
 		if err != nil {
 			return vmDescriptions, fmt.Errorf("could not generate a new UUID: %w", err)
 		}
-		vmName := fmt.Sprintf("%s-%s", vmNamePrefix, uuid.String())
+		vmName := fmt.Sprintf("%s-%s", vmNamePrefix, uid.String())
 
 		networkInterface, publicIP, err := c.prepareVMNetworking(ctx, subnet, nsg, vmParams, vmName)
 		if err != nil {

--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/RHEnVision/provisioning-backend/internal/identity"
+
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/clients/http"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
@@ -407,6 +409,10 @@ func (c *ec2Client) RunInstances(ctx context.Context, params *clients.AWSInstanc
 				{
 					Key:   ptr.To("rh-rid"),
 					Value: ptr.To(config.EnvironmentPrefix("r", strconv.FormatInt(reservation.ID, 10))),
+				},
+				{
+					Key:   ptr.To("rh-org"),
+					Value: ptr.To(identity.Identity(ctx).Identity.OrgID),
 				},
 			},
 		},

--- a/internal/clients/http/gcp/gcp_client.go
+++ b/internal/clients/http/gcp/gcp_client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/RHEnVision/provisioning-backend/internal/identity"
+
 	"github.com/RHEnVision/provisioning-backend/internal/logging"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/page"
@@ -187,6 +189,7 @@ func (c *gcpClient) InsertInstances(ctx context.Context, params *clients.GCPInst
 				Labels: map[string]string{
 					"rh-rid":  config.EnvironmentPrefix("r", strconv.FormatInt(params.ReservationID, 10)),
 					"rh-uuid": params.UUID,
+					"rh-org":  identity.Identity(ctx).Identity.OrgID,
 				},
 				Disks: []*computepb.AttachedDisk{
 					{

--- a/internal/clients/instance_params.go
+++ b/internal/clients/instance_params.go
@@ -74,4 +74,7 @@ type AzureInstanceParams struct {
 
 	// UserData for the instance launch
 	UserData []byte
+
+	// Tags carries list of key-value tags
+	Tags map[string]*string
 }

--- a/internal/jobs/launch_instance_azure.go
+++ b/internal/jobs/launch_instance_azure.go
@@ -3,6 +3,10 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"strconv"
+
+	"github.com/RHEnVision/provisioning-backend/internal/config"
+	"github.com/RHEnVision/provisioning-backend/internal/identity"
 
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
@@ -154,6 +158,10 @@ func DoLaunchInstanceAzure(ctx context.Context, args *LaunchInstanceAzureTaskArg
 		Pubkey:            pubkey,
 		InstanceType:      clients.InstanceTypeName(reservation.Detail.InstanceSize),
 		UserData:          userData,
+		Tags: map[string]*string{
+			"rh-rid": ptr.To(config.EnvironmentPrefix("r", strconv.FormatInt(reservation.ID, 10))),
+			"rh-org": ptr.To(identity.Identity(ctx).Identity.OrgID),
+		},
 	}
 
 	instanceDescriptions, err := azureClient.CreateVMs(ctx, vmParams, reservation.Detail.Amount, vmNamePrefix)


### PR DESCRIPTION
We already have "rh-rid" for EC2 and GCP, this patch adds the same for Azure.

On top of that, this patch also adds "rh-org" with organization number. This was requested by Mike and I hope it will help to solve the problem.