### PR TITLE
refactor: rename errors

### DIFF
--- a/internal/clients/errors.go
+++ b/internal/clients/errors.go
@@ -5,11 +5,9 @@ import (
 )
 
 var (
-	ErrBadRequest     = usrerr.New(401, "backend service returned bad request", "")
-	ErrNotFound       = usrerr.New(404, "backend service returned not found or no data", "")
-	ErrUnauthorized   = usrerr.New(401, "backend service returned unauthorized", "")
-	ErrForbidden      = usrerr.New(403, "backend service returned forbidden", "")
-	ErrNon2xxResponse = usrerr.New(500, "backend service returned unexpedced response code", "")
+	ErrBadRequest   = usrerr.New(401, "backend service returned bad request", "")
+	ErrNotFound     = usrerr.New(404, "backend service returned not found or no data", "")
+	ErrUnauthorized = usrerr.New(401, "backend service returned unauthorized", "")
 
 	ErrUnknownAuthenticationType  = usrerr.New(500, "unknown authentication type", "sources backend error")
 	ErrUnknownProvider            = usrerr.New(500, "unknown provider type", "sources backend error")

--- a/internal/clients/http/ec2/iam_client.go
+++ b/internal/clients/http/ec2/iam_client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 )
 
-var AWSPermissionsMissing = errors.New("AWS permissions missing")
+var ErrAWSPermissionsMissing = errors.New("AWS permissions missing")
 
 // Statement is a main policy element.
 type Statement struct {
@@ -266,7 +266,7 @@ func (c *ec2Client) checkInlinePolicies(ctx context.Context, missingPermissions 
 	}
 	missing := listMissingPermissions(inlinePoliciesStatement, missingStatement)
 	if len(missingPermissions) != 0 {
-		return missing, fmt.Errorf("%w: %s", AWSPermissionsMissing, strings.Join(missing, ", "))
+		return missing, fmt.Errorf("%w: %s", ErrAWSPermissionsMissing, strings.Join(missing, ", "))
 	}
 	return nil, nil
 }

--- a/internal/clients/http/ec2/iam_client.go
+++ b/internal/clients/http/ec2/iam_client.go
@@ -71,14 +71,14 @@ var expectedStatement = Statement{
 func getRoleName(arn string) (string, error) {
 	arnParts := strings.Split(arn, ":")
 	if len(arnParts) == 0 {
-		return "", fmt.Errorf("%w: ARN has no colons: %s", http.ARNParsingError, arn)
+		return "", fmt.Errorf("%w: ARN has no colons: %s", http.ErrARNParsing, arn)
 	}
 	roleName := strings.Split(arnParts[len(arnParts)-1], "/")
 	if len(roleName) != 2 {
 		return "", fmt.Errorf("%w: ARN has incorrect syntax: %s rolename parsing result: %s",
-			http.ARNParsingError, arn, roleName)
+			http.ErrARNParsing, arn, roleName)
 	} else if roleName[0] != "role" {
-		return "", fmt.Errorf("%w: ARN does not have any role: %s", http.ARNParsingError, arn)
+		return "", fmt.Errorf("%w: ARN does not have any role: %s", http.ErrARNParsing, arn)
 	}
 	return roleName[1], nil
 }

--- a/internal/clients/http/errors.go
+++ b/internal/clients/http/errors.go
@@ -1,8 +1,6 @@
 package http
 
 import (
-	"errors"
-
 	"github.com/RHEnVision/provisioning-backend/internal/usrerr"
 )
 
@@ -15,7 +13,6 @@ var (
 	ErrAuthenticationForSourcesNotFound = usrerr.New(404, "authentications for source weren't found in sources", "")
 	ErrApplicationRead                  = usrerr.New(500, "application read returned no application type in sources", "")
 	ErrSourceTypeNameNotFound           = usrerr.New(404, "source type name not found", "")
-	ErrNotEven                          = errors.New("number of keys and values is not even when building a query")
 	ErrSourcesInvalidAuthentication     = usrerr.New(400, "insufficient data for authentication", "")
 )
 

--- a/internal/clients/http/errors.go
+++ b/internal/clients/http/errors.go
@@ -35,5 +35,5 @@ var (
 	ErrPubkeyNotFound              = usrerr.New(404, "pubkey not found in AWS account", "")
 	ErrServiceAccountUnsupportedOp = usrerr.New(500, "unsupported operation on service account", "")
 	ErrARNParsing                  = usrerr.New(500, "ARN parsing error", "")
-	ErrNoReservation               = usrerr.New(404, "no reservation has found in AWS response", "")
+	ErrNoReservation               = usrerr.New(404, "no reservation was found in AWS response", "")
 )

--- a/internal/clients/http/errors.go
+++ b/internal/clients/http/errors.go
@@ -6,20 +6,15 @@ import (
 
 // Sources
 var (
-	ErrApplicationNotFound              = usrerr.New(404, "application not found is sources", "")
 	ErrApplicationTypeNotFound          = usrerr.New(404, "application type 'provisioning' not found in sources", "")
-	ErrSourceNotFound                   = usrerr.New(404, "source not found", "")
-	ErrAuthenticationSourceAssociation  = usrerr.New(404, "authentication associated to source id not found", "")
 	ErrAuthenticationForSourcesNotFound = usrerr.New(404, "authentications for source weren't found in sources", "")
 	ErrApplicationRead                  = usrerr.New(500, "application read returned no application type in sources", "")
-	ErrSourceTypeNameNotFound           = usrerr.New(404, "source type name not found", "")
 	ErrSourcesInvalidAuthentication     = usrerr.New(400, "insufficient data for authentication", "")
 )
 
 // Image Builder
 var (
 	ErrCloneNotFound        = usrerr.New(404, "image clone not found", "")
-	ErrComposeNotFound      = usrerr.New(404, "image compose not found", "")
 	ErrImageStatus          = usrerr.New(500, "build of requested image has not finished yet", "image still building")
 	ErrUnknownImageType     = usrerr.New(500, "unknown image type", "")
 	ErrUploadStatus         = usrerr.New(500, "cannot get image status", "")

--- a/internal/clients/http/errors.go
+++ b/internal/clients/http/errors.go
@@ -8,32 +8,32 @@ import (
 
 // Sources
 var (
-	ApplicationNotFoundErr              = usrerr.New(404, "application not found is sources", "")
-	ApplicationTypeNotFoundErr          = usrerr.New(404, "application type 'provisioning' not found in sources", "")
-	SourceNotFoundErr                   = usrerr.New(404, "source not found", "")
-	AuthenticationSourceAssociationErr  = usrerr.New(404, "authentication associated to source id not found", "")
-	AuthenticationForSourcesNotFoundErr = usrerr.New(404, "authentications for source weren't found in sources", "")
-	ApplicationReadErr                  = usrerr.New(500, "application read returned no application type in sources", "")
-	SourceTypeNameNotFoundErr           = usrerr.New(404, "source type name not found", "")
-	NotEvenErr                          = errors.New("number of keys and values is not even when building a query")
-	SourcesInvalidAuthentication        = usrerr.New(400, "insufficient data for authentication", "")
+	ErrApplicationNotFound              = usrerr.New(404, "application not found is sources", "")
+	ErrApplicationTypeNotFound          = usrerr.New(404, "application type 'provisioning' not found in sources", "")
+	ErrSourceNotFound                   = usrerr.New(404, "source not found", "")
+	ErrAuthenticationSourceAssociation  = usrerr.New(404, "authentication associated to source id not found", "")
+	ErrAuthenticationForSourcesNotFound = usrerr.New(404, "authentications for source weren't found in sources", "")
+	ErrApplicationRead                  = usrerr.New(500, "application read returned no application type in sources", "")
+	ErrSourceTypeNameNotFound           = usrerr.New(404, "source type name not found", "")
+	ErrNotEven                          = errors.New("number of keys and values is not even when building a query")
+	ErrSourcesInvalidAuthentication     = usrerr.New(400, "insufficient data for authentication", "")
 )
 
 // Image Builder
 var (
-	CloneNotFoundErr        = usrerr.New(404, "image clone not found", "")
-	ComposeNotFoundErr      = usrerr.New(404, "image compose not found", "")
-	ImageStatusErr          = usrerr.New(500, "build of requested image has not finished yet", "image still building")
-	UnknownImageTypeErr     = usrerr.New(500, "unknown image type", "")
-	UploadStatusErr         = usrerr.New(500, "cannot get image status", "")
-	ImageRequestNotFoundErr = usrerr.New(500, "image compose request not found", "")
+	ErrCloneNotFound        = usrerr.New(404, "image clone not found", "")
+	ErrComposeNotFound      = usrerr.New(404, "image compose not found", "")
+	ErrImageStatus          = usrerr.New(500, "build of requested image has not finished yet", "image still building")
+	ErrUnknownImageType     = usrerr.New(500, "unknown image type", "")
+	ErrUploadStatus         = usrerr.New(500, "cannot get image status", "")
+	ErrImageRequestNotFound = usrerr.New(500, "image compose request not found", "")
 )
 
 // EC2
 var (
-	DuplicatePubkeyErr             = usrerr.New(406, "public key already exists in target cloud provider account and region", "")
-	PubkeyNotFoundErr              = usrerr.New(404, "pubkey not found in AWS account", "")
-	ServiceAccountUnsupportedOpErr = usrerr.New(500, "unsupported operation on service account", "")
-	ARNParsingError                = usrerr.New(500, "ARN parsing error", "")
-	NoReservationErr               = usrerr.New(404, "no reservation has found in AWS response", "")
+	ErrDuplicatePubkey             = usrerr.New(406, "public key already exists in target cloud provider account and region", "")
+	ErrPubkeyNotFound              = usrerr.New(404, "pubkey not found in AWS account", "")
+	ErrServiceAccountUnsupportedOp = usrerr.New(500, "unsupported operation on service account", "")
+	ErrARNParsing                  = usrerr.New(500, "ARN parsing error", "")
+	ErrNoReservation               = usrerr.New(404, "no reservation has found in AWS response", "")
 )

--- a/internal/clients/http/image_builder/image_client.go
+++ b/internal/clients/http/image_builder/image_client.go
@@ -73,15 +73,15 @@ func (c *ibClient) GetAWSAmi(ctx context.Context, composeID string) (string, err
 		return "", err
 	}
 	if imageStatus == nil {
-		return "", fmt.Errorf("%w: no image status", http.ImageStatusErr)
+		return "", fmt.Errorf("%w: no image status", http.ErrImageStatus)
 	}
 
 	if imageStatus.Type != UploadTypesAws {
-		return "", fmt.Errorf("%w: expected image type AWS", http.UnknownImageTypeErr)
+		return "", fmt.Errorf("%w: expected image type AWS", http.ErrUnknownImageType)
 	}
 	uploadStatus, err := imageStatus.Options.AsAWSUploadStatus()
 	if err != nil {
-		return "", fmt.Errorf("%w: not an AWS status", http.UploadStatusErr)
+		return "", fmt.Errorf("%w: not an AWS status", http.ErrUploadStatus)
 	}
 
 	logger.Info().Str("compose_id", composeID).Str("ami", uploadStatus.Ami).
@@ -100,24 +100,24 @@ func (c *ibClient) GetAzureImageID(ctx context.Context, composeID string) (strin
 	}
 	if composeStatus == nil {
 		logger.Warn().Msg("Compose status is not ready")
-		return "", fmt.Errorf("getting azure id: %w", http.ImageStatusErr)
+		return "", fmt.Errorf("getting azure id: %w", http.ErrImageStatus)
 	}
 
 	logger.Trace().Msgf("Verifying Azure type")
 	if composeStatus.ImageStatus.UploadStatus == nil {
-		return "", fmt.Errorf("%w: upload status is nil", http.UploadStatusErr)
+		return "", fmt.Errorf("%w: upload status is nil", http.ErrUploadStatus)
 	}
 	if composeStatus.ImageStatus.UploadStatus.Type != UploadTypesAzure {
-		return "", fmt.Errorf("%w: expected image type Azure, got %s", http.UnknownImageTypeErr, composeStatus.ImageStatus.UploadStatus.Type)
+		return "", fmt.Errorf("%w: expected image type Azure, got %s", http.ErrUnknownImageType, composeStatus.ImageStatus.UploadStatus.Type)
 	}
 	if len(composeStatus.Request.ImageRequests) < 1 {
-		logger.Error().Msg(http.ImageRequestNotFoundErr.Error())
-		return "", http.ImageRequestNotFoundErr
+		logger.Error().Msg(http.ErrImageRequestNotFound.Error())
+		return "", http.ErrImageRequestNotFound
 	}
 
 	uploadOptions, err := composeStatus.ImageStatus.UploadStatus.Options.AsAzureUploadStatus()
 	if err != nil {
-		return "", fmt.Errorf("%w: not an Azure status", http.UploadStatusErr)
+		return "", fmt.Errorf("%w: not an Azure status", http.ErrUploadStatus)
 	}
 
 	azureUploadRequest, err := composeStatus.Request.ImageRequests[0].UploadRequest.Options.AsAzureUploadRequestOptions()
@@ -137,15 +137,15 @@ func (c *ibClient) GetGCPImageName(ctx context.Context, composeID string) (strin
 	}
 
 	if imageStatus == nil {
-		return "", fmt.Errorf("%w: no image status", http.ImageStatusErr)
+		return "", fmt.Errorf("%w: no image status", http.ErrImageStatus)
 	}
 
 	if imageStatus.Type != UploadTypesGcp {
-		return "", fmt.Errorf("%w: expected image type GCP", http.UnknownImageTypeErr)
+		return "", fmt.Errorf("%w: expected image type GCP", http.ErrUnknownImageType)
 	}
 	uploadStatus, err := imageStatus.Options.AsGCPUploadStatus()
 	if err != nil {
-		return "", fmt.Errorf("%w: not a GCP status", http.UploadStatusErr)
+		return "", fmt.Errorf("%w: not a GCP status", http.ErrUploadStatus)
 	}
 
 	result := fmt.Sprintf("projects/%s/global/images/%s", uploadStatus.ProjectId, uploadStatus.ImageName)
@@ -208,7 +208,7 @@ func (c *ibClient) checkCompose(ctx context.Context, composeID string) (*UploadS
 
 	if composeStatus == nil || composeStatus.ImageStatus.Status != ImageStatusStatusSuccess {
 		logger.Warn().Msg("Compose status is not ready")
-		return nil, http.ImageStatusErr
+		return nil, http.ErrImageStatus
 	}
 
 	return composeStatus.ImageStatus.UploadStatus, nil
@@ -239,7 +239,7 @@ func (c *ibClient) checkClone(ctx context.Context, composeID string) (*UploadSta
 
 	if ImageStatusStatus(resp.JSON200.Status) != ImageStatusStatusSuccess {
 		logger.Warn().Msg("Clone status is not ready")
-		return nil, http.ImageStatusErr
+		return nil, http.ErrImageStatus
 	}
 
 	return resp.JSON200, nil

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -304,7 +304,7 @@ func (c *sourcesClient) loadAppId(ctx context.Context) (string, error) {
 func BuildQuery(keysAndValues ...string) func(ctx context.Context, req *stdhttp.Request) error {
 	return func(ctx context.Context, req *stdhttp.Request) error {
 		if len(keysAndValues)%2 != 0 {
-			return http.ErrNotEven
+			panic("cannot build sources query: invalid input")
 		}
 		queryParams := make([]string, 0)
 		for i := 0; i < len(keysAndValues); i += 2 {

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -114,15 +114,15 @@ func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, p
 	}
 
 	if resp == nil {
-		return nil, 0, fmt.Errorf("failed to get ApplicationTypes: empty response: %w", clients.ErrUnexpectedBackendResponse)
+		return nil, 0, fmt.Errorf("list application types empty response: %w", clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200 == nil {
-		return nil, 0, fmt.Errorf("failed to get ApplicationTypes: %w", clients.ErrUnexpectedBackendResponse)
+		return nil, 0, fmt.Errorf("list application types returned %d: %w", resp.StatusCode(), clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200.Data == nil {
-		return nil, 0, fmt.Errorf("list provisioning sources call: %w", clients.ErrNoResponseData)
+		return nil, 0, fmt.Errorf("list application types: %w", clients.ErrNoResponseData)
 	}
 
 	result := make([]*clients.Source, 0, len(*resp.JSON200.Data))
@@ -167,15 +167,15 @@ func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clie
 		return nil, 0, fmt.Errorf("failed to get ApplicationTypes: %w", err)
 	}
 	if resp == nil {
-		return nil, 0, fmt.Errorf("list provisioning sources call: empty response: %w", clients.ErrUnexpectedBackendResponse)
+		return nil, 0, fmt.Errorf("list provisioning sources empty response: %w", clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200 == nil {
-		return nil, 0, fmt.Errorf("list provisioning sources call: %w", clients.ErrUnexpectedBackendResponse)
+		return nil, 0, fmt.Errorf("list provisioning sources returned %d: %w", resp.StatusCode(), clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200.Data == nil {
-		return nil, 0, fmt.Errorf("list provisioning sources call: %w", clients.ErrNoResponseData)
+		return nil, 0, fmt.Errorf("list provisioning sources: %w", clients.ErrNoResponseData)
 	}
 
 	result := make([]*clients.Source, len(*resp.JSON200.Data))
@@ -214,14 +214,14 @@ func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId string) 
 	// Sources API currently does not provide a good server-side filtering.
 
 	if resp == nil {
-		return nil, fmt.Errorf("get source authentication call: empty response: %w", clients.ErrUnexpectedBackendResponse)
+		return nil, fmt.Errorf("get source authentication empty response: %w", clients.ErrUnexpectedBackendResponse)
 	}
 	if resp.JSON200 == nil {
-		return nil, fmt.Errorf("get source authentication call: %w", clients.ErrUnexpectedBackendResponse)
+		return nil, fmt.Errorf("get source authentication returned %d: %w", resp.StatusCode(), clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200.Data == nil {
-		return nil, fmt.Errorf("get source authentication call: %w", clients.ErrNoResponseData)
+		return nil, fmt.Errorf("get source authentication: %w", clients.ErrNoResponseData)
 	}
 	auth, err := filterSourceAuthentications(*resp.JSON200.Data)
 	if err != nil {

--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -237,7 +237,7 @@ func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId string) 
 	}
 
 	if auth.Username == nil || auth.Authtype == nil || auth.ResourceId == nil {
-		return nil, fmt.Errorf("cannot create source from source authentication type: %w", http.SourcesInvalidAuthentication)
+		return nil, fmt.Errorf("cannot create source from source authentication type: %w", http.ErrSourcesInvalidAuthentication)
 	}
 	authentication, err := clients.NewAuthenticationFromSourceAuthType(ctx, *auth.Username, *auth.Authtype, *auth.ResourceId)
 	if err != nil {
@@ -298,13 +298,13 @@ func (c *sourcesClient) loadAppId(ctx context.Context) (string, error) {
 			return t.Id, nil
 		}
 	}
-	return "", http.ApplicationTypeNotFoundErr
+	return "", http.ErrApplicationTypeNotFound
 }
 
 func BuildQuery(keysAndValues ...string) func(ctx context.Context, req *stdhttp.Request) error {
 	return func(ctx context.Context, req *stdhttp.Request) error {
 		if len(keysAndValues)%2 != 0 {
-			return http.NotEvenErr
+			return http.ErrNotEven
 		}
 		queryParams := make([]string, 0)
 		for i := 0; i < len(keysAndValues); i += 2 {
@@ -333,5 +333,5 @@ func filterSourceAuthentications(authentications []AuthenticationRead) (Authenti
 			}
 		}
 	}
-	return AuthenticationRead{}, http.ApplicationReadErr
+	return AuthenticationRead{}, http.ErrApplicationRead
 }

--- a/internal/clients/http/sources/sources_client_test.go
+++ b/internal/clients/http/sources/sources_client_test.go
@@ -133,6 +133,7 @@ func TestSourcesClient_BuildQuery(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "filter%5Bsource_type%5D%5Bname%5D=amazon", req.URL.RawQuery)
 	})
+
 	t.Run("Build Query with even and multiple number of keys and values", func(t *testing.T) {
 		fn := sources.BuildQuery("filter[resource_type]", "Application", "filter[authtype][starts_with]", "provisioning")
 		err := fn(context.Background(), req)
@@ -141,8 +142,8 @@ func TestSourcesClient_BuildQuery(t *testing.T) {
 	})
 
 	t.Run("Build Query with odd number of keys and values", func(t *testing.T) {
-		fn := sources.BuildQuery("filter[resource_type]")
-		err := fn(context.Background(), req)
-		assert.Error(t, err, "number of keys and values is not even when building a query")
+		assert.Panics(t, func() {
+			_ = sources.BuildQuery("keyWithNoValue")(context.Background(), req)
+		})
 	})
 }

--- a/internal/clients/regional_availability.go
+++ b/internal/clients/regional_availability.go
@@ -40,7 +40,7 @@ func NewRegionalInstanceTypes() *RegionalTypeAvailability {
 	}
 }
 
-var UnknownRegionZoneCombinationErr error = errors.New("unknown region and zone combination")
+var ErrUnknownRegionZoneCombination error = errors.New("unknown region and zone combination")
 
 func key(region, zone string) string {
 	if zone == "" {
@@ -52,7 +52,7 @@ func key(region, zone string) string {
 func (rit *RegionalTypeAvailability) NamesForZone(region, zone string) ([]InstanceTypeName, error) {
 	result, ok := rit.types[key(region, zone)]
 	if !ok {
-		return nil, UnknownRegionZoneCombinationErr
+		return nil, ErrUnknownRegionZoneCombination
 	}
 	return result, nil
 }
@@ -111,7 +111,7 @@ func (rit *RegionalTypeAvailability) Load(fsTypes embed.FS, path string) error {
 	return nil
 }
 
-var RegionAndZoneSplitErr = errors.New("unable to split region and zone for")
+var ErrRegionAndZoneSplit = errors.New("unable to split region and zone for")
 
 func splitRegionZone(str string) (string, string, error) {
 	result := strings.Split(str, regionSeparator)
@@ -121,7 +121,7 @@ func splitRegionZone(str string) (string, string, error) {
 	} else if len(result) == 1 {
 		return result[0], "", nil
 	} else {
-		return "", "", fmt.Errorf("%w: %s", RegionAndZoneSplitErr, str)
+		return "", "", fmt.Errorf("%w: %s", ErrRegionAndZoneSplit, str)
 	}
 }
 

--- a/internal/clients/stubs/context_getters.go
+++ b/internal/clients/stubs/context_getters.go
@@ -27,7 +27,7 @@ func getAzureClientStub(ctx context.Context) (*AzureClientStub, error) {
 	var si *AzureClientStub
 	var ok bool
 	if si, ok = ctx.Value(azureCtxKey).(*AzureClientStub); !ok {
-		return nil, ContextReadError
+		return nil, ErrContextRead
 	}
 	return si, nil
 }

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -51,7 +51,7 @@ func getEC2StubFromContext(ctx context.Context) (*EC2ClientStub, error) {
 	var err error
 	var ok bool
 	if si, ok = ctx.Value(ec2CtxKey).(*EC2ClientStub); !ok {
-		err = ContextReadError
+		err = ErrContextRead
 	}
 	return si, err
 }

--- a/internal/clients/stubs/ec2_stub.go
+++ b/internal/clients/stubs/ec2_stub.go
@@ -85,7 +85,7 @@ func (mock *EC2ClientStub) GetPubkeyName(ctx context.Context, fingerprint string
 			return *key.KeyName, nil
 		}
 	}
-	return "", http.PubkeyNotFoundErr
+	return "", http.ErrPubkeyNotFound
 }
 
 func (mock *EC2ClientStub) DeleteSSHKey(ctx context.Context, handle string) error {

--- a/internal/clients/stubs/errors.go
+++ b/internal/clients/stubs/errors.go
@@ -5,8 +5,8 @@ import (
 )
 
 var (
-	NotImplementedErr            = errors.New("stub not yet implemented")
-	MissingInstanceIDErr         = errors.New("instance id is not present")
-	SourceAuthenticationNotFound = errors.New("stubbed authentication for source not found")
-	ContextReadError             = errors.New("failed to find or convert dao stored in testing context")
+	ErrNotImplemented               = errors.New("stub not yet implemented")
+	ErrMissingInstanceID            = errors.New("instance id is not present")
+	ErrSourceAuthenticationNotFound = errors.New("stubbed authentication for source not found")
+	ErrContextRead                  = errors.New("failed to find or convert dao stored in testing context")
 )

--- a/internal/clients/stubs/gcp_stub.go
+++ b/internal/clients/stubs/gcp_stub.go
@@ -51,7 +51,7 @@ func getCustomerGCPClientStub(ctx context.Context, auth *clients.Authentication)
 	var err error
 	var ok bool
 	if si, ok = ctx.Value(gcpCtxKey).(*GCPClientStub); !ok {
-		err = ContextReadError
+		err = ErrContextRead
 	}
 	return si, err
 }
@@ -59,7 +59,7 @@ func getCustomerGCPClientStub(ctx context.Context, auth *clients.Authentication)
 func getServiceGCPClientStub(ctx context.Context) (si clients.ServiceGCP, err error) {
 	var ok bool
 	if si, ok = ctx.Value(serviceGCPCtxKey).(*GCPServiceClientStub); !ok {
-		err = ContextReadError
+		err = ErrContextRead
 	}
 	return si, err
 }
@@ -88,7 +88,7 @@ func (mock *GCPClientStub) GetInstanceDescriptionByID(ctx context.Context, id, z
 			return instanceDesc, nil
 		}
 	}
-	return nil, MissingInstanceIDErr
+	return nil, ErrMissingInstanceID
 }
 
 func (mock *GCPClientStub) ListLaunchTemplates(ctx context.Context) ([]*clients.LaunchTemplate, string, error) {

--- a/internal/clients/stubs/image_builder_stub.go
+++ b/internal/clients/stubs/image_builder_stub.go
@@ -24,7 +24,7 @@ func WithImageBuilderClient(parent context.Context) context.Context {
 func getImageBuilderClientStub(ctx context.Context) (si clients.ImageBuilder, err error) {
 	var ok bool
 	if si, ok = ctx.Value(imageBuilderCtxKey).(*ImageBuilderClientStub); !ok {
-		err = ContextReadError
+		err = ErrContextRead
 	}
 	return si, err
 }

--- a/internal/clients/stubs/sources_stub.go
+++ b/internal/clients/stubs/sources_stub.go
@@ -49,7 +49,7 @@ func getSourcesClient(ctx context.Context) (clients.Sources, error) {
 func getSourcesClientStub(ctx context.Context) (si *SourcesClientStub, err error) {
 	var ok bool
 	if si, ok = ctx.Value(sourcesCtxKey).(*SourcesClientStub); !ok {
-		err = ContextReadError
+		err = ErrContextRead
 	}
 	return si, err
 }
@@ -69,7 +69,7 @@ func (stub *SourcesClientStub) addSource(ctx context.Context, provider models.Pr
 		stub.auths[id] = clients.NewAuthentication("test@org.com", provider)
 	case models.ProviderTypeUnknown, models.ProviderTypeNoop:
 		// not implemented
-		return nil, NotImplementedErr
+		return nil, ErrNotImplemented
 	}
 
 	stub.sources = append(stub.sources, source)
@@ -89,7 +89,7 @@ func (stub *SourcesClientStub) GetAuthentication(ctx context.Context, sourceId s
 
 	auth, ok := stub.auths[sourceId]
 	if !ok {
-		return nil, SourceAuthenticationNotFound
+		return nil, ErrSourceAuthenticationNotFound
 	}
 	return auth, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,8 +193,8 @@ var (
 
 // Errors
 var (
-	validateMissingSecretError = errors.New("config error: Cloudwatch enabled but Region or Key or Secret are blank")
-	validateGroupStreamError   = errors.New("config error: Cloudwatch enabled but Group or Stream is blank")
+	ErrValidateMissingSecret = errors.New("config error: Cloudwatch enabled but Region or Key or Secret are blank")
+	ErrValidateGroupStream   = errors.New("config error: Cloudwatch enabled but Group or Stream is blank")
 )
 
 var hostname string

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -19,10 +19,10 @@ func present(args ...string) bool {
 func validate() error {
 	if Cloudwatch.Enabled {
 		if Cloudwatch.Region == "" || Cloudwatch.Key == "" || Cloudwatch.Secret == "" {
-			return validateMissingSecretError
+			return ErrValidateMissingSecret
 		}
 		if Cloudwatch.Group == "" || Cloudwatch.Stream == "" {
-			return validateGroupStreamError
+			return ErrValidateGroupStream
 		}
 	}
 

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -147,12 +147,12 @@ func DoEnsurePubkeyOnAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) e
 		span.SetStatus(codes.Error, "key error")
 
 		// if not found on AWS, import
-		if errors.Is(err, http.PubkeyNotFoundErr) {
+		if errors.Is(err, http.ErrPubkeyNotFound) {
 			pkr.Tag = ""
 			pkr.RandomizeTag()
 			pkr.Handle, err = ec2Client.ImportPubkey(ctx, pubkey, pkr.FormattedTag())
 
-			if errors.Is(err, http.DuplicatePubkeyErr) {
+			if errors.Is(err, http.ErrDuplicatePubkey) {
 				// key not found by fingerprint but importing failed for duplicate err so fingerprints do not match
 				return fmt.Errorf("key with fingerprint %s not found on AWS, but importing the key failed: %w", pubkey.Fingerprint, err)
 			} else if err != nil {

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -154,7 +154,8 @@ func DoEnsurePubkeyOnAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) e
 
 			if errors.Is(err, http.ErrDuplicatePubkey) {
 				// key not found by fingerprint but importing failed for duplicate err so fingerprints do not match
-				return fmt.Errorf("key with fingerprint %s not found on AWS, but importing the key failed: %w", pubkey.Fingerprint, err)
+				logger.Warn().Msgf("Pubkey with fingerprint %s not found on AWS, but importing the key failed: %s", pubkey.Fingerprint, err.Error())
+				return fmt.Errorf("cannot upload aws pubkey because of duplicate: %w", err)
 			} else if err != nil {
 				return fmt.Errorf("cannot upload aws pubkey: %w", err)
 			}

--- a/internal/jobs/noop_job.go
+++ b/internal/jobs/noop_job.go
@@ -17,7 +17,7 @@ type NoopJobArgs struct {
 	Sleep         time.Duration // Sleep (delay) duration (used in tests)
 }
 
-var NoOperationFailure = errors.New("job failed on request")
+var ErrNoOperationFailure = errors.New("job failed on request")
 
 // HandleNoop unmarshalls arguments and handle error
 func HandleNoop(ctx context.Context, job *worker.Job) {
@@ -60,7 +60,7 @@ func DoNoop(ctx context.Context, args *NoopJobArgs) error {
 	logger.Info().Msg("No operation finished")
 
 	if args.Fail {
-		return NoOperationFailure
+		return ErrNoOperationFailure
 	}
 
 	return nilUnlessTimeout(ctx)

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -33,8 +33,8 @@ type kafkaBroker struct {
 var _ Broker = &kafkaBroker{}
 
 var (
-	DifferentTopicErr       = errors.New("messages in batch have different topics")
-	UnknownSaslMechanismErr = errors.New("unknown SASL mechanism")
+	ErrDifferentTopic       = errors.New("messages in batch have different topics")
+	ErrUnknownSASLMechanism = errors.New("unknown SASL mechanism")
 )
 
 func createSASLMechanism(saslMechanismName string, username string, password string) (sasl.Mechanism, error) {
@@ -59,7 +59,7 @@ func createSASLMechanism(saslMechanismName string, username string, password str
 
 		return mechanism, nil
 	default:
-		return nil, fmt.Errorf("%w: %s", UnknownSaslMechanismErr, saslMechanismName)
+		return nil, fmt.Errorf("%w: %s", ErrUnknownSASLMechanism, saslMechanismName)
 	}
 }
 
@@ -247,7 +247,7 @@ func header(name string, headers []protocol.Header) string {
 }
 
 // Send one or more generic messages with the same topic. If there is a message with
-// different topic than the first one, DifferentTopicErr is returned.
+// different topic than the first one, ErrDifferentTopic is returned.
 func (b *kafkaBroker) Send(ctx context.Context, messages ...*GenericMessage) error {
 	logger := zerolog.Ctx(ctx)
 
@@ -268,7 +268,7 @@ func (b *kafkaBroker) Send(ctx context.Context, messages ...*GenericMessage) err
 	kMessages := make([]kafka.Message, len(messages))
 	for i, m := range messages {
 		if m.Topic != commonTopic {
-			return DifferentTopicErr
+			return ErrDifferentTopic
 		}
 		kMessages[i] = m.KafkaMessage()
 		if logger.Trace().Enabled() {

--- a/internal/payloads/error_payload_test.go
+++ b/internal/payloads/error_payload_test.go
@@ -23,7 +23,7 @@ func TestFindUserPayload(t *testing.T) {
 			&userPayload{400, "bad request"},
 		},
 		{
-			httpClients.CloneNotFoundErr,
+			httpClients.ErrCloneNotFound,
 			&userPayload{404, "image clone not found"},
 		},
 		{

--- a/internal/queue/stub/stub.go
+++ b/internal/queue/stub/stub.go
@@ -15,8 +15,8 @@ import (
 type enqueueCtxKeyType string
 
 var (
-	ContextReadError = errors.New("failed to find or convert dao stored in testing context")
-	JobNotFoundError = errors.New("no job found")
+	ErrContextRead = errors.New("failed to find or convert dao stored in testing context")
+	ErrJobNotFound = errors.New("no job found")
 )
 
 var enqueueCtxKey enqueueCtxKeyType = "enqueuer-stub"
@@ -63,7 +63,7 @@ func (h hollowEnqueuer) Enqueue(_ context.Context, _ *worker.Job) error {
 
 func (s *stubEnqueuer) Enqueue(ctx context.Context, job *worker.Job) error {
 	if job == nil {
-		return fmt.Errorf("failed to enqueue: %w", JobNotFoundError)
+		return fmt.Errorf("failed to enqueue: %w", ErrJobNotFound)
 	}
 	s.enqueued = append(s.enqueued, job)
 	return nil

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -40,13 +40,13 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 		payload.Region = "us-east-1"
 	}
 	if !preload.EC2InstanceType.ValidateRegion(payload.Region) {
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Unsupported region", UnsupportedRegionError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Unsupported region", ErrUnsupportedRegion))
 		return
 	}
 
 	// Either Launch Template or Instance Type must be set. Both can be set too, in that case, instance type overrides the launch template.
 	if payload.InstanceType == "" && payload.LaunchTemplateID == "" {
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Both instance type and launch template are missing", BothTypeAndTemplateMissingError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Both instance type and launch template are missing", ErrBothTypeAndTemplateMissing))
 		return
 	}
 
@@ -56,11 +56,11 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 		supportedArch := "x86_64"
 		it := preload.EC2InstanceType.FindInstanceType(clients.InstanceTypeName(payload.InstanceType))
 		if it == nil {
-			renderError(w, r, payloads.NewInvalidRequestError(r.Context(), fmt.Sprintf("unknown type: %s", payload.InstanceType), UnknownInstanceTypeNameError))
+			renderError(w, r, payloads.NewInvalidRequestError(r.Context(), fmt.Sprintf("unknown type: %s", payload.InstanceType), ErrUnknownInstanceTypeName))
 			return
 		}
 		if it.Architecture.String() != supportedArch {
-			renderError(w, r, payloads.NewWrongArchitectureUserError(r.Context(), ArchitectureMismatch))
+			renderError(w, r, payloads.NewWrongArchitectureUserError(r.Context(), ErrArchitectureMismatch))
 			return
 		}
 	}

--- a/internal/services/azure_reservation_service.go
+++ b/internal/services/azure_reservation_service.go
@@ -37,7 +37,7 @@ func CreateAzureReservation(w http.ResponseWriter, r *http.Request) {
 		payload.Location = "eastus_1"
 	}
 	if !preload.AzureInstanceType.ValidateRegion(payload.Location) {
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Unsupported location", UnsupportedRegionError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Unsupported location", ErrUnsupportedRegion))
 		return
 	}
 
@@ -101,11 +101,11 @@ func CreateAzureReservation(w http.ResponseWriter, r *http.Request) {
 	supportedArch := "x86_64"
 	it := preload.AzureInstanceType.FindInstanceType(clients.InstanceTypeName(payload.InstanceSize))
 	if it == nil {
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), fmt.Sprintf("unknown instance size: %s", payload.InstanceSize), UnknownInstanceTypeNameError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), fmt.Sprintf("unknown instance size: %s", payload.InstanceSize), ErrUnknownInstanceTypeName))
 		return
 	}
 	if it.Architecture.String() != supportedArch {
-		renderError(w, r, payloads.NewWrongArchitectureUserError(r.Context(), ArchitectureMismatch))
+		renderError(w, r, payloads.NewWrongArchitectureUserError(r.Context(), ErrArchitectureMismatch))
 		return
 	}
 

--- a/internal/services/gcp_reservation_service.go
+++ b/internal/services/gcp_reservation_service.go
@@ -36,7 +36,7 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 
 	// Check for preloaded region
 	if !preload.GCPInstanceType.ValidateRegion(payload.Zone) {
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Unsupported zone", UnsupportedRegionError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Unsupported zone", ErrUnsupportedRegion))
 		return
 	}
 

--- a/internal/services/launch_templates_service.go
+++ b/internal/services/launch_templates_service.go
@@ -31,11 +31,11 @@ func ListLaunchTemplates(w http.ResponseWriter, r *http.Request) {
 	case models.ProviderTypeAWS:
 		ListLaunchTemplateAWS(w, r)
 	case models.ProviderTypeAzure:
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "azure reservation is not implemented", ProviderTypeNotImplementedError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "azure reservation is not implemented", ErrProviderTypeNotImplemented))
 	case models.ProviderTypeGCP:
 		ListLaunchTemplateGCP(w, r)
 	default:
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", UnknownProviderTypeError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", ErrUnknownProviderType))
 	}
 }
 

--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -150,7 +150,7 @@ func DeletePubkey(w http.ResponseWriter, r *http.Request) {
 				logger.Warn().Msgf("Skipping pubkey resource %d with empty handle", res.ID)
 			}
 		} else {
-			renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "delete not implemented for this provider", ProviderTypeNotImplementedError))
+			renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "delete not implemented for this provider", ErrProviderTypeNotImplemented))
 		}
 	}
 

--- a/internal/services/pubkey_service.go
+++ b/internal/services/pubkey_service.go
@@ -141,7 +141,7 @@ func DeletePubkey(w http.ResponseWriter, r *http.Request) {
 						renderError(w, r, payloads.NewAWSError(r.Context(), "unable to delete AWS public key", errDelete))
 						return
 					}
-				} else if errors.Is(errAuth, httpClients.AuthenticationForSourcesNotFoundErr) {
+				} else if errors.Is(errAuth, httpClients.ErrAuthenticationForSourcesNotFound) {
 					logger.Warn().Msgf("Skipping source %s authorization which is no longer available", res.SourceID)
 				} else {
 					logger.Warn().Err(errAuth).Msg("Skipping source authorization because sources returned an error")

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -15,13 +15,13 @@ import (
 )
 
 var (
-	UnknownProviderTypeError        = errors.New("unknown provider type parameter")
-	ProviderTypeMismatchError       = errors.New("reservation type does not match requested provider type")
-	ProviderTypeNotImplementedError = errors.New("provider type not yet implemented")
-	UnknownInstanceTypeNameError    = errors.New("unknown instance type")
-	ArchitectureMismatch            = errors.New("instance type and image architecture mismatch")
-	BothTypeAndTemplateMissingError = errors.New("instance type or launch template not set")
-	UnsupportedRegionError          = errors.New("unknown region/location/zone")
+	ErrUnknownProviderType        = errors.New("unknown provider type parameter")
+	ErrProviderTypeMismatch       = errors.New("reservation type does not match requested provider type")
+	ErrProviderTypeNotImplemented = errors.New("provider type not yet implemented")
+	ErrUnknownInstanceTypeName    = errors.New("unknown instance type")
+	ErrArchitectureMismatch       = errors.New("instance type and image architecture mismatch")
+	ErrBothTypeAndTemplateMissing = errors.New("instance type or launch template not set")
+	ErrUnsupportedRegion          = errors.New("unknown region/location/zone")
 )
 
 // CreateReservation dispatches requests to type provider specific handlers
@@ -46,14 +46,14 @@ func CreateReservation(w http.ResponseWriter, r *http.Request) {
 		if config.FeatureEnabled(r.Context(), "azure") {
 			CreateAzureReservation(w, r)
 		} else {
-			renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "azure reservation is not implemented", ProviderTypeNotImplementedError))
+			renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "azure reservation is not implemented", ErrProviderTypeNotImplemented))
 		}
 	case models.ProviderTypeGCP:
 		CreateGCPReservation(w, r)
 	case models.ProviderTypeUnknown:
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", UnknownProviderTypeError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", ErrUnknownProviderType))
 	default:
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", UnknownProviderTypeError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", ErrUnknownProviderType))
 	}
 }
 
@@ -106,7 +106,7 @@ func GetReservationDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if providerType != models.ProviderTypeUnknown && reservation.Provider != providerType {
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider type", ProviderTypeMismatchError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider type", ErrProviderTypeMismatch))
 		return
 	}
 
@@ -171,6 +171,6 @@ func GetReservationDetail(w http.ResponseWriter, r *http.Request) {
 			renderError(w, r, payloads.NewRenderError(r.Context(), "unable to render reservation", err))
 		}
 	default:
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", ProviderTypeNotImplementedError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", ErrProviderTypeNotImplemented))
 	}
 }

--- a/internal/services/sources_service.go
+++ b/internal/services/sources_service.go
@@ -112,7 +112,7 @@ func GetSourceUploadInfo(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case models.ProviderTypeNoop, models.ProviderTypeUnknown:
-		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", ProviderTypeNotImplementedError))
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "provider is not supported", ErrProviderTypeNotImplemented))
 		return
 	}
 

--- a/internal/services/sources_status_service.go
+++ b/internal/services/sources_status_service.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-var UnknownProviderFromSourcesErr = errors.New("unknown provider returned from sources")
+var ErrUnknownProviderFromSources = errors.New("unknown provider returned from sources")
 
 // SourcesStatus fetches information from sources and then performs a smallest possible
 // request on the cloud provider (list keys or similar). Reports an error if sources configuration
@@ -54,7 +54,7 @@ func SourcesStatus(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 	case models.ProviderTypeNoop:
 	case models.ProviderTypeUnknown:
 	default:
-		renderError(w, r, payloads.NewStatusError(r.Context(), "unknown sources provider", UnknownProviderFromSourcesErr))
+		renderError(w, r, payloads.NewStatusError(r.Context(), "unknown sources provider", ErrUnknownProviderFromSources))
 		return
 	}
 

--- a/internal/services/status_service.go
+++ b/internal/services/status_service.go
@@ -18,7 +18,7 @@ func ReadyService(w http.ResponseWriter, r *http.Request) {
 	writeOk(w, r)
 }
 
-var UnknownReadinessServiceErr = errors.New("unknown service for readiness test")
+var ErrUnknownReadinessService = errors.New("unknown service for readiness test")
 
 func ReadyBackendService(w http.ResponseWriter, r *http.Request) {
 	service := chi.URLParam(r, "SRV")
@@ -53,7 +53,7 @@ func ReadyBackendService(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	default:
-		renderError(w, r, payloads.NewURLParsingError(r.Context(), "unable to parse SRV parameter", UnknownReadinessServiceErr))
+		renderError(w, r, payloads.NewURLParsingError(r.Context(), "unable to parse SRV parameter", ErrUnknownReadinessService))
 		return
 	}
 

--- a/pkg/worker/errors.go
+++ b/pkg/worker/errors.go
@@ -4,4 +4,4 @@ import (
 	"errors"
 )
 
-var JobNotFound = errors.New("job not found")
+var ErrJobNotFound = errors.New("job not found")

--- a/pkg/worker/job.go
+++ b/pkg/worker/job.go
@@ -35,7 +35,7 @@ type Job struct {
 	Args any
 }
 
-var HandlerNotFoundErr = errors.New("handler not registered")
+var ErrHandlerNotFound = errors.New("handler not registered")
 
 // JobEnqueuer sends Job messages into worker queue.
 type JobEnqueuer interface {
@@ -73,7 +73,7 @@ type Stats struct {
 
 func contextLogger(ctx context.Context, job *Job) context.Context {
 	if job == nil {
-		zerolog.Ctx(ctx).Error().Err(JobNotFound).Msg("No job, context not changed")
+		zerolog.Ctx(ctx).Error().Err(ErrJobNotFound).Msg("No job, context not changed")
 		return ctx
 	}
 

--- a/pkg/worker/memory.go
+++ b/pkg/worker/memory.go
@@ -28,7 +28,7 @@ func (w *MemoryWorker) RegisterHandler(jtype JobType, handler JobHandler, _ any)
 func (w *MemoryWorker) Enqueue(ctx context.Context, job *Job) error {
 	var err error
 	if job == nil {
-		return fmt.Errorf("unable to enqueue job: %w", JobNotFound)
+		return fmt.Errorf("unable to enqueue job: %w", ErrJobNotFound)
 	}
 
 	if job.ID == uuid.Nil {
@@ -59,7 +59,7 @@ func (w *MemoryWorker) dequeueLoop(ctx context.Context) {
 
 func (w *MemoryWorker) processJob(ctx context.Context, job *Job) {
 	if job == nil {
-		zerolog.Ctx(ctx).Error().Err(JobNotFound).Msg("No job to process")
+		zerolog.Ctx(ctx).Error().Err(ErrJobNotFound).Msg("No job to process")
 		return
 	}
 

--- a/pkg/worker/redis.go
+++ b/pkg/worker/redis.go
@@ -86,7 +86,7 @@ func loggerWithJob(ctx context.Context, job *Job) *zerolog.Logger {
 func (w *RedisWorker) Enqueue(ctx context.Context, job *Job) error {
 	var err error
 	if job == nil {
-		return fmt.Errorf("unable to enqueue job: %w", JobNotFound)
+		return fmt.Errorf("unable to enqueue job: %w", ErrJobNotFound)
 	}
 
 	if job.ID == uuid.Nil {


### PR DESCRIPTION
It is a good practice to prefix error values with `Err` and suffix error types:

```
// error type
type MyErr error

// error value
var ErrMy = errors.New("error")
```

This PR is pure refactoring, no changes introduced.