### PR TITLE
fix(HMS-2640): Support missing values when using launch template

### DIFF
--- a/internal/clients/http/gcp/gcp_client.go
+++ b/internal/clients/http/gcp/gcp_client.go
@@ -191,17 +191,6 @@ func (c *gcpClient) InsertInstances(ctx context.Context, params *clients.GCPInst
 					"rh-uuid": params.UUID,
 					"rh-org":  identity.Identity(ctx).Identity.OrgID,
 				},
-				Disks: []*computepb.AttachedDisk{
-					{
-						InitializeParams: &computepb.AttachedDiskInitializeParams{
-							SourceImage: &params.ImageName,
-						},
-						AutoDelete: ptr.To(true),
-						Boot:       ptr.To(true),
-						Type:       ptr.To(computepb.AttachedDisk_PERSISTENT.String()),
-					},
-				},
-				MachineType: ptr.To(params.MachineType),
 				NetworkInterfaces: []*computepb.NetworkInterface{
 					{
 						AccessConfigs: []*computepb.AccessConfig{
@@ -223,6 +212,23 @@ func (c *gcpClient) InsertInstances(ctx context.Context, params *clients.GCPInst
 	if params.LaunchTemplateID != "" {
 		template := fmt.Sprintf("global/instanceTemplates/%s", params.LaunchTemplateID)
 		req.BulkInsertInstanceResourceResource.SourceInstanceTemplate = &template
+	}
+
+	if params.MachineType != "" {
+		req.BulkInsertInstanceResourceResource.InstanceProperties.MachineType = ptr.To(params.MachineType)
+	}
+
+	if params.ImageName != "" {
+		req.BulkInsertInstanceResourceResource.InstanceProperties.Disks = []*computepb.AttachedDisk{
+			{
+				InitializeParams: &computepb.AttachedDiskInitializeParams{
+					SourceImage: &params.ImageName,
+				},
+				AutoDelete: ptr.To(true),
+				Boot:       ptr.To(true),
+				Type:       ptr.To(computepb.AttachedDisk_PERSISTENT.String()),
+			},
+		}
 	}
 
 	op, err := client.BulkInsert(ctx, req)


### PR DESCRIPTION
There's an issue concerning GCP launch templates that involves different behaviors between the UI and API.
In the API, we  allow empty values for machine type and image ID so that users can launch instances with the properties they've defined in their templates, a feature not available in the UI.

This small fix aims to support both behaviors. On one hand, if a user provides a machine type or image ID, the instance will launch with those specified values. On the other hand, if a user selects a launch template and leaves the machine type and image ID blank, the instance will launch using the information provided in the template.

This adjustment might serves as a temporary solution for utilizing templates in GCP. I also believe it's essential to include a test for this behavior. It think it should ideally be part of the launch templates tests in IQE, but please correct me if I am wrong.