### PR TITLE
fix: better sources non-200 logging

### DIFF
--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -114,15 +114,15 @@ func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, p
 	}
 
 	if resp == nil {
-		return nil, 0, fmt.Errorf("list application types empty response: %w", clients.ErrUnexpectedBackendResponse)
+		return nil, 0, fmt.Errorf("failed to get ApplicationTypes: empty response: %w", clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200 == nil {
-		return nil, 0, fmt.Errorf("list application types returned %d: %w", resp.StatusCode(), clients.ErrUnexpectedBackendResponse)
+		return nil, 0, fmt.Errorf("failed to get ApplicationTypes: %w", clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200.Data == nil {
-		return nil, 0, fmt.Errorf("list application types: %w", clients.ErrNoResponseData)
+		return nil, 0, fmt.Errorf("list provisioning sources call: %w", clients.ErrNoResponseData)
 	}
 
 	result := make([]*clients.Source, 0, len(*resp.JSON200.Data))
@@ -167,15 +167,15 @@ func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clie
 		return nil, 0, fmt.Errorf("failed to get ApplicationTypes: %w", err)
 	}
 	if resp == nil {
-		return nil, 0, fmt.Errorf("list provisioning sources empty response: %w", clients.ErrUnexpectedBackendResponse)
+		return nil, 0, fmt.Errorf("list provisioning sources call: empty response: %w", clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200 == nil {
-		return nil, 0, fmt.Errorf("list provisioning sources returned %d: %w", resp.StatusCode(), clients.ErrUnexpectedBackendResponse)
+		return nil, 0, fmt.Errorf("list provisioning sources call: %w", clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200.Data == nil {
-		return nil, 0, fmt.Errorf("list provisioning sources: %w", clients.ErrNoResponseData)
+		return nil, 0, fmt.Errorf("list provisioning sources call: %w", clients.ErrNoResponseData)
 	}
 
 	result := make([]*clients.Source, len(*resp.JSON200.Data))
@@ -214,14 +214,15 @@ func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId string) 
 	// Sources API currently does not provide a good server-side filtering.
 
 	if resp == nil {
-		return nil, fmt.Errorf("get source authentication empty response: %w", clients.ErrUnexpectedBackendResponse)
+		return nil, fmt.Errorf("get source authentication call: empty response: %w", clients.ErrUnexpectedBackendResponse)
 	}
 	if resp.JSON200 == nil {
+		logger.Warn().Str("source_id", sourceId).RawJSON("response", resp.Body).Msg("Sources returned non-200 response")
 		return nil, fmt.Errorf("get source authentication returned %d: %w", resp.StatusCode(), clients.ErrUnexpectedBackendResponse)
 	}
 
 	if resp.JSON200.Data == nil {
-		return nil, fmt.Errorf("get source authentication: %w", clients.ErrNoResponseData)
+		return nil, fmt.Errorf("get source authentication call: %w", clients.ErrNoResponseData)
 	}
 	auth, err := filterSourceAuthentications(*resp.JSON200.Data)
 	if err != nil {


### PR DESCRIPTION
We see random IQE errors when sources return 500 for some reason, there is nothing interesting in (sources) logs, so let’s try to send whole body as a warning to logs to find out more:

![image](https://github.com/RHEnVision/provisioning-backend/assets/49752/7dff0557-3f8b-43eb-aeca-d54687bd58f2)
