### PR TITLE
fix(HMS-2674): Error when name pattern is invalid

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -1796,7 +1796,7 @@
     },
     "/reservations/gcp": {
       "post": {
-        "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. A GCP reservation is a reservation created for a GCP job. Image Builder UUID image is required and needs to be shared with the service account. Furthermore, by specifying the name pattern for example as \"instance\", instances names will be created in the format: \"instance-#####\". A single account can create maximum of 2 reservations per second.\n",
+        "description": "A reservation is a way to activate a job, keeps all data needed for a job to start. A GCP reservation is a reservation created for a GCP job. Image Builder UUID image is required and needs to be shared with the service account. Furthermore, by specifying the RFC-1035 compatible name pattern for example as \"instance\", instances names will be created in the format: \"instance-#####\". A single account can create maximum of 2 reservations per second.\n",
         "operationId": "createGCPReservation",
         "requestBody": {
           "content": {

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -1262,7 +1262,7 @@ paths:
             tags:
                 - Reservation
             description: |
-                A reservation is a way to activate a job, keeps all data needed for a job to start. A GCP reservation is a reservation created for a GCP job. Image Builder UUID image is required and needs to be shared with the service account. Furthermore, by specifying the name pattern for example as "instance", instances names will be created in the format: "instance-#####". A single account can create maximum of 2 reservations per second.
+                A reservation is a way to activate a job, keeps all data needed for a job to start. A GCP reservation is a reservation created for a GCP job. Image Builder UUID image is required and needs to be shared with the service account. Furthermore, by specifying the RFC-1035 compatible name pattern for example as "instance", instances names will be created in the format: "instance-#####". A single account can create maximum of 2 reservations per second.
             operationId: createGCPReservation
             requestBody:
                 description: gcp request body

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -417,7 +417,7 @@ paths:
         A reservation is a way to activate a job, keeps all data needed for a job to start.
         A GCP reservation is a reservation created for a GCP job. Image Builder UUID image
         is required and needs to be shared with the service account.
-        Furthermore, by specifying the name pattern for example as "instance",
+        Furthermore, by specifying the RFC-1035 compatible name pattern for example as "instance",
         instances names will be created in the format: "instance-#####".
         A single account can create maximum of 2 reservations per second.
       requestBody:

--- a/internal/jobs/launch_instance_gcp.go
+++ b/internal/jobs/launch_instance_gcp.go
@@ -93,7 +93,6 @@ func DoLaunchInstanceGCP(ctx context.Context, args *LaunchInstanceGCPTaskArgs) e
 	// status updates before and after the code logic
 	updateStatusBefore(ctx, args.ReservationID, "Launching instance(s)")
 	defer updateStatusAfter(ctx, args.ReservationID, "Launched instance(s)", 1)
-	name := "inst-####"
 	pkD := dao.GetPubkeyDao(ctx)
 
 	pk, err := pkD.GetById(ctx, args.PubkeyID)
@@ -120,11 +119,8 @@ func DoLaunchInstanceGCP(ctx context.Context, args *LaunchInstanceGCPTaskArgs) e
 		return fmt.Errorf("cannot generate user data: %w", err)
 	}
 
-	if args.Detail.NamePattern != nil {
-		name = fmt.Sprintf("%s-#####", *args.Detail.NamePattern)
-	}
 	params := &clients.GCPInstanceParams{
-		NamePattern:      ptr.To(name),
+		NamePattern:      args.Detail.NamePattern,
 		ImageName:        args.ImageName,
 		MachineType:      args.Detail.MachineType,
 		Zone:             args.Zone,

--- a/internal/jobs/launch_instance_gcp_test.go
+++ b/internal/jobs/launch_instance_gcp_test.go
@@ -33,7 +33,7 @@ func prepareGCPReservation(t *testing.T, ctx context.Context, pk *models.Pubkey)
 	detail := &models.GCPDetail{
 		Zone:        "europe-west8-c",
 		MachineType: "e2-micro",
-		NamePattern: ptr.To("instance"),
+		NamePattern: ptr.To("instance-#####"),
 		Amount:      1,
 		PowerOff:    false,
 	}

--- a/internal/services/gcp_reservation_service_test.go
+++ b/internal/services/gcp_reservation_service_test.go
@@ -85,4 +85,30 @@ func TestCreateGCPReservationHandler(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), "Unsupported zone")
 		require.Equal(t, http.StatusBadRequest, rr.Code, "Handler returned wrong status code")
 	})
+
+	t.Run("failed reservation with invalid name pattern", func(t *testing.T) {
+		var err error
+		values := map[string]interface{}{
+			"name_pattern": "Envision",
+			"source_id":    source.ID,
+			"image_id":     "80967e7f-efef-4eee-85b0-bd4cef4c455d",
+			"amount":       1,
+			"zone":         "us-central1-a",
+			"machine_type": "n1-standard-1",
+			"pubkey_id":    pk.ID,
+		}
+		if json_data, err = json.Marshal(values); err != nil {
+			t.Fatalf("unable to marshal values to json: %v", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/reservations/gcp", bytes.NewBuffer(json_data))
+		require.NoError(t, err, "failed to create request")
+		req.Header.Add("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(services.CreateGCPReservation)
+		handler.ServeHTTP(rr, req)
+		assert.Contains(t, rr.Body.String(), "Invalid name pattern")
+		require.Equal(t, http.StatusBadRequest, rr.Code, "Handler returned wrong status code")
+	})
 }

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -22,6 +22,7 @@ var (
 	ErrArchitectureMismatch       = errors.New("instance type and image architecture mismatch")
 	ErrBothTypeAndTemplateMissing = errors.New("instance type or launch template not set")
 	ErrUnsupportedRegion          = errors.New("unknown region/location/zone")
+	ErrInvalidNamePattern         = errors.New("name pattern is not RFC-1035 compatible")
 )
 
 // CreateReservation dispatches requests to type provider specific handlers


### PR DESCRIPTION
Google API does not allow upper case name pattern, this PR fixes the issue and verifies the name pattern is lower cased, if not we error out. 