### PR TITLE
fix(HMS-1847): Adding configmap to job

### DIFF
--- a/deploy/cloudwash_job.yaml
+++ b/deploy/cloudwash_job.yaml
@@ -31,6 +31,14 @@ objects:
                   - "-d"
                   - "azure"
                   - "--all"
+                volumeMounts:
+                  - name: config-volume
+                    mountPath: /opt/app-root/src/cloudwash/settings.yaml
+                    subPath: settings.yaml
+            volumes:
+              - name: config-volume
+                configMap:
+                  name: cloudwash-config
                 env:
                   - name: CLEANUP_PROVIDERS_AZURE_AUTH_CLIENT_ID
                     valueFrom:


### PR DESCRIPTION
For adding config maps into a job:
1. have already created config map yaml in app-interface
2. then referenced it to the namespace in app-interface itself.
**3. Now have added its mount point in this MR's job file** 
