### PR TITLE
fix(HMS-2703): allow to configure TLS without CA cert

### DIFF
--- a/config/api.env.example
+++ b/config/api.env.example
@@ -111,7 +111,7 @@
 #   KAFKA_BROKERS slice
 #     	kafka hostname:port list of brokers (default "localhost:9092")
 #   KAFKA_CA_CERT string
-#     	kafka TLS CA certificate path (default "")
+#     	kafka TLS CA certificate path (use the OS cert store when blank) (default "")
 #   KAFKA_ENABLED bool
 #     	kafka service enabled (default "false")
 #   KAFKA_SASL_MECHANISM string
@@ -122,6 +122,10 @@
 #     	kafka SASL security protocol (default "")
 #   KAFKA_SASL_USERNAME string
 #     	kafka SASL username (default "")
+#   KAFKA_TLS_ENABLED bool
+#     	enable TLS or use plaintext when false (default "false")
+#   KAFKA_TLS_SKIP_VERIFY bool
+#     	do not verify TLS server certificate (default "false")
 #   LOGGING_LEVEL string
 #     	logger level (trace, debug, info, warn, error, fatal, panic) (default "info")
 #   LOGGING_MAX_FIELD int

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -103,6 +103,8 @@ objects:
                 value: ${APP_CACHE_TYPE}
               - name: WORKER_QUEUE
                 value: ${WORKER_QUEUE}
+              - name: KAFKA_TLS_ENABLED
+                value: ${KAFKA_TLS_ENABLED}
             resources:
               limits:
                 cpu: ${{CPU_LIMIT}}
@@ -190,6 +192,8 @@ objects:
                 value: ${APP_INSTANCE_PREFIX}
               - name: APP_CACHE_TYPE
                 value: ${APP_CACHE_TYPE}
+              - name: KAFKA_TLS_ENABLED
+                value: ${KAFKA_TLS_ENABLED}
             resources:
               limits:
                 cpu: ${{CPU_LIMIT}}
@@ -239,6 +243,8 @@ objects:
                 value: ${APP_INSTANCE_PREFIX}
               - name: APP_CACHE_TYPE
                 value: ${APP_CACHE_TYPE}
+              - name: KAFKA_TLS_ENABLED
+                value: ${KAFKA_TLS_ENABLED}
             resources:
               limits:
                 cpu: ${{CPU_LIMIT}}
@@ -365,6 +371,8 @@ objects:
                 value: ${APP_CACHE_TYPE}
               - name: WORKER_QUEUE
                 value: ${WORKER_QUEUE}
+              - name: KAFKA_TLS_ENABLED
+                value: ${KAFKA_TLS_ENABLED}
             resources:
               limits:
                 cpu: ${{CPU_LIMIT}}
@@ -572,3 +580,6 @@ parameters:
   - description: Notification service enabled
     name: APP_NOTIFICATIONS_ENABLED
     value: "true"
+  - description: Kafka TLS connection
+    name: KAFKA_TLS_ENABLED
+    value: "false"

--- a/docs/make.md
+++ b/docs/make.md
@@ -4,10 +4,10 @@
 Usage:
   make <target>
 
-Database migrations
-  migrate               Run database migration
-  purgedb               Delete database (dangerous!)
-  generate-migration    Generate new migration file, use MIGRATION_NAME=name
+HTTP Clients
+  update-clients        Update OpenAPI specs from upstream
+  generate-clients      Generate HTTP client stubs
+  validate-clients      Compare generated client code with git
 
 Code quality
   format                Format Go source code using `go fmt`
@@ -26,16 +26,17 @@ Building
   run                   Build and run backend API
   clean                 Clean build artifacts and cache
 
-Help
-  help                  Print out the help content
-  generate-help-doc     Generate 'make help' markdown in docs/
-  validate-help-doc     Compare example configuration
-  generate-example-config  Generate example configuration
-  validate-example-config  Compare example configuration
+Image building
+  build-podman          Build container image using Podman
 
 Dashboard
   generate-dashboard    Generate dashboard
   validate-dashboard    Compare dashboard configmaps with git
+
+Database migrations
+  migrate               Run database migration
+  purgedb               Delete database (dangerous!)
+  generate-migration    Generate new migration file, use MIGRATION_NAME=name
 
 Go modules
   tidy-deps             Cleanup Go modules
@@ -44,31 +45,30 @@ Go modules
   list-deps             List dependencies and their versions
   update-deps           Update Go modules to latest versions
 
+Help
+  help                  Print out the help content
+  generate-help-doc     Generate 'make help' markdown in docs/
+  validate-help-doc     Compare example configuration
+  generate-example-config  Generate example configuration
+  validate-example-config  Compare example configuration
+
+OpenAPI
+  generate-spec         Generate OpenAPI spec
+  validate-spec         Compare OpenAPI spec with git
+
+Testing
+  test                  Run unit tests
+  integration-test      Run integration tests (require database)
+
 Go commands
   install-go            Install required Go version
   install-tools         Install required Go commands into ./bin
   update-tools          Update required Go commands
   generate-changelog    Generate CHANGELOG.md from git history
 
-Testing
-  test                  Run unit tests
-  integration-test      Run integration tests (require database)
-
-OpenAPI
-  generate-spec         Generate OpenAPI spec
-  validate-spec         Compare OpenAPI spec with git
-
 Instance types
   generate-azure-types  Generate instance types for Azure
   generate-ec2-types    Generate instance types for EC2
   generate-gcp-types    Generate instance types for GCP
   generate-types        Generate instance types for all providers
-
-HTTP Clients
-  update-clients        Update OpenAPI specs from upstream
-  generate-clients      Generate HTTP client stubs
-  validate-clients      Compare generated client code with git
-
-Image building
-  build-podman          Build container image using Podman
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,11 +155,13 @@ var config struct {
 		Dsn string `env:"DSN" env-default:"" env-description:"data source name (empty value disables Sentry)"`
 	} `env-prefix:"SENTRY_"`
 	Kafka struct {
-		Enabled  bool     `env:"ENABLED" env-default:"false" env-description:"kafka service enabled"`
-		Brokers  []string `env:"BROKERS" env-default:"localhost:9092" env-description:"kafka hostname:port list of brokers"`
-		AuthType string   `env:"AUTH_TYPE" env-default:"" env-description:"kafka authentication type (mtls, sasl or empty)"`
-		CACert   string   `env:"CA_CERT" env-default:"" env-description:"kafka TLS CA certificate path"`
-		SASL     struct {
+		Enabled       bool     `env:"ENABLED" env-default:"false" env-description:"kafka service enabled"`
+		TlsEnabled    bool     `env:"TLS_ENABLED" env-default:"false" env-description:"enable TLS or use plaintext when false"`
+		TlsSkipVerify bool     `env:"TLS_SKIP_VERIFY" env-default:"false" env-description:"do not verify TLS server certificate"`
+		Brokers       []string `env:"BROKERS" env-default:"localhost:9092" env-description:"kafka hostname:port list of brokers"`
+		AuthType      string   `env:"AUTH_TYPE" env-default:"" env-description:"kafka authentication type (mtls, sasl or empty)"`
+		CACert        string   `env:"CA_CERT" env-default:"" env-description:"kafka TLS CA certificate path (use the OS cert store when blank)"`
+		SASL          struct {
 			Username         string `env:"USERNAME" env-default:"" env-description:"kafka SASL username"`
 			Password         string `env:"PASSWORD" env-default:"" env-description:"kafka SASL password"`
 			SaslMechanism    string `env:"MECHANISM" env-default:"" env-description:"kafka SASL mechanism (scram-sha-512, scram-sha-256 or plain)"`


### PR DESCRIPTION
Our app expects CA cert to be present to configure TLS, in case it is blank it will not configure TLS and will attempt to connect via plain text.

The recent stage migration changed the configuration, CA cert is no longer provided. All our pods currently fail with errors "TLS is required".

This patch changes the app behavior, it is not possible to enable TLS separately via flag (enabled by default) and also skip TLS server cert validation (false at the moment, can be useful for dev setup). When CA is blank, it will pass `nil` to the Kafka client library which has documented behavior to "use host OS cert store" which is what we want.

When we merge this, it should fix the problem on stage as long as Amazon Managed Kafka CA is in the host OS cert store. If not, the workaround will be to disable cert validation and ask the devprod team to pass Amazon CA via Clowder or we could do the same in `clowdapp.yaml`.