### PR TITLE
feat: Allow Azure resource group customization

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -64,10 +64,11 @@
           "amount": 1,
           "image_id": "composer-api-081fc867-838f-44a5-af03-8b8def808431",
           "instance_size": "Basic_A0",
-          "location": "useast",
+          "location": "useast_1",
           "name": "my-instance",
           "poweroff": false,
           "pubkey_id": 42,
+          "resource_group": "redhat-hcc",
           "source_id": "654321"
         }
       },
@@ -676,6 +677,10 @@
           "pubkey_id": {
             "format": "int64",
             "type": "integer"
+          },
+          "resource_group": {
+            "description": "Azure resource group name to deploy the VM resources into. Optional, defaults to 'redhat-deployed'.",
+            "type": "string"
           },
           "source_id": {
             "type": "string"

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -98,6 +98,9 @@ components:
                 pubkey_id:
                     type: integer
                     format: int64
+                resource_group:
+                    type: string
+                    description: Azure resource group name to deploy the VM resources into. Optional, defaults to 'redhat-deployed'.
                 source_id:
                     type: string
         v1.AzureReservationResponse:
@@ -645,10 +648,11 @@ components:
                 amount: 1
                 image_id: composer-api-081fc867-838f-44a5-af03-8b8def808431
                 instance_size: Basic_A0
-                location: useast
+                location: useast_1
                 name: my-instance
                 poweroff: false
                 pubkey_id: 42
+                resource_group: redhat-hcc
                 source_id: "654321"
         v1.AzureReservationResponsePayloadDoneExample:
             value:

--- a/cmd/spec/example_reservation.go
+++ b/cmd/spec/example_reservation.go
@@ -118,14 +118,15 @@ var AwsReservationResponsePayloadDoneExample = payloads.AWSReservationResponse{
 }
 
 var AzureReservationRequestPayloadExample = payloads.AzureReservationRequest{
-	PubkeyID:     42,
-	SourceID:     "654321",
-	Location:     "useast",
-	InstanceSize: "Basic_A0",
-	Amount:       1,
-	ImageID:      "composer-api-081fc867-838f-44a5-af03-8b8def808431",
-	Name:         "my-instance",
-	PowerOff:     false,
+	PubkeyID:      42,
+	SourceID:      "654321",
+	Location:      "useast_1",
+	ResourceGroup: "redhat-hcc",
+	InstanceSize:  "Basic_A0",
+	Amount:        1,
+	ImageID:       "composer-api-081fc867-838f-44a5-af03-8b8def808431",
+	Name:          "my-instance",
+	PowerOff:      false,
 }
 
 var AzureReservationResponsePayloadPendingExample = payloads.AzureReservationResponse{

--- a/internal/jobs/launch_instance_azure_test.go
+++ b/internal/jobs/launch_instance_azure_test.go
@@ -64,18 +64,19 @@ func TestDoEnsureAzureResourceGroup(t *testing.T) {
 	require.NoError(t, err, "failed to add stubbed reservation")
 
 	args := &jobs.LaunchInstanceAzureTaskArgs{
-		AzureImageID:  "/subscriptions/subUUID/rgName/images/uuid2",
-		Location:      "useast",
-		PubkeyID:      pk.ID,
-		ReservationID: res.ID,
-		SourceID:      "2",
-		Subscription:  clients.NewAuthentication("subUUID", models.ProviderTypeAzure),
+		AzureImageID:      "/subscriptions/subUUID/rgName/images/uuid2",
+		Location:          "useast",
+		PubkeyID:          pk.ID,
+		ReservationID:     res.ID,
+		SourceID:          "2",
+		Subscription:      clients.NewAuthentication("subUUID", models.ProviderTypeAzure),
+		ResourceGroupName: "testGroup",
 	}
 
 	err = jobs.DoEnsureAzureResourceGroup(ctx, args)
 	require.NoError(t, err, "the ensure resource group failed to run")
 
-	assert.True(t, clientStubs.DidCreateAzureResourceGroup(ctx, "redhat-deployed"))
+	assert.True(t, clientStubs.DidCreateAzureResourceGroup(ctx, "testGroup"))
 }
 
 func TestDoLaunchInstanceAzure(t *testing.T) {

--- a/internal/models/reservation_model.go
+++ b/internal/models/reservation_model.go
@@ -149,6 +149,9 @@ type AzureDetail struct {
 
 	// Immediately power off the system after initialization
 	PowerOff bool `json:"poweroff"`
+
+	// ResourceGroup is name of Resource Group to put the created resources into
+	ResourceGroup string `json:"resource_group"`
 }
 
 type AzureReservation struct {

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -195,6 +195,9 @@ type AzureReservationRequest struct {
 	// Image Builder UUID of the image that should be launched. This can be directly Azure image ID.
 	ImageID string `json:"image_id" yaml:"image_id"`
 
+	// ResourceGroup to use to deploy the resources into
+	ResourceGroup string `json:"resource_group" yaml:"resource_group" description:"Azure resource group name to deploy the VM resources into. Optional, defaults to 'redhat-deployed'."`
+
 	// Azure Location to deploy into.
 	Location string `json:"location" yaml:"location"`
 

--- a/internal/services/azure_reservation_service_test.go
+++ b/internal/services/azure_reservation_service_test.go
@@ -23,27 +23,29 @@ import (
 
 func TestCreateAzureReservationHandler(t *testing.T) {
 	var json_data []byte
-	ctx := stubs.WithAccountDaoOne(context.Background())
-	ctx = identity.WithTenant(t, ctx)
-	ctx = Clientstubs.WithSourcesClient(ctx)
-	ctx = Clientstubs.WithImageBuilderClient(ctx)
-	ctx = stubs.WithReservationDao(ctx)
-	ctx = stubs.WithPubkeyDao(ctx)
-	ctx = stub.WithEnqueuer(ctx)
+	sharedCtx := stubs.WithAccountDaoOne(context.Background())
+	sharedCtx = identity.WithTenant(t, sharedCtx)
+	sharedCtx = Clientstubs.WithSourcesClient(sharedCtx)
+	sharedCtx = Clientstubs.WithImageBuilderClient(sharedCtx)
+	sharedCtx = stubs.WithPubkeyDao(sharedCtx)
 	pk := factories.NewPubkeyRSA()
-	err := stubs.AddPubkey(ctx, pk)
+	err := stubs.AddPubkey(sharedCtx, pk)
 	require.NoError(t, err, "failed to generate pubkey")
-	source, err := Clientstubs.AddSource(ctx, models.ProviderTypeAzure)
+	source, err := Clientstubs.AddSource(sharedCtx, models.ProviderTypeAzure)
 	require.NoError(t, err, "failed to generate Azure source")
 
 	t.Run("successful reservation with compose ID", func(t *testing.T) {
+		ctx := stubs.WithReservationDao(sharedCtx)
+		ctx = stub.WithEnqueuer(ctx)
+
 		var err error
 		values := map[string]interface{}{
-			"source_id":     source.ID,
-			"image_id":      "92ea98f8-7697-472e-80b1-7454fa0e7fa7",
-			"amount":        1,
-			"instance_size": "Basic_A0",
-			"pubkey_id":     pk.ID,
+			"source_id":      source.ID,
+			"image_id":       "92ea98f8-7697-472e-80b1-7454fa0e7fa7",
+			"resource_group": "testGroup",
+			"amount":         1,
+			"instance_size":  "Basic_A0",
+			"pubkey_id":      pk.ID,
 		}
 		if json_data, err = json.Marshal(values); err != nil {
 			t.Fatalf("unable to marshal values to json: %v", err)
@@ -65,18 +67,60 @@ func TestCreateAzureReservationHandler(t *testing.T) {
 		assert.Equal(t, 1, len(stub.EnqueuedJobs(ctx)), "Expected exactly one job to be planned")
 		assert.IsType(t, jobs.LaunchInstanceAzureTaskArgs{}, stub.EnqueuedJobs(ctx)[0].Args, "Unexpected type of arguments for the planned job")
 		jobArgs := stub.EnqueuedJobs(ctx)[0].Args.(jobs.LaunchInstanceAzureTaskArgs)
+		assert.Equal(t, "testGroup", jobArgs.ResourceGroupName)
 		assert.Equal(t, "/subscriptions/4b9d213f-712f-4d17-a483-8a10bbe9df3a/resourceGroups/redhat-deployed/providers/Microsoft.Compute/images/composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7", jobArgs.AzureImageID, "Expected translated image to real name - one from IB client stub")
 	})
 
-	t.Run("failed reservation with invalid location", func(t *testing.T) {
+	t.Run("successful reservation with azure image name translated to full azure ID", func(t *testing.T) {
+		ctx := stubs.WithReservationDao(sharedCtx)
+		ctx = stub.WithEnqueuer(ctx)
+
 		var err error
 		values := map[string]interface{}{
-			"source_id":     source.ID,
-			"location":      "blank",
-			"image_id":      "92ea98f8-7697-472e-80b1-7454fa0e7fa7",
-			"amount":        1,
-			"instance_size": "Basic_A0",
-			"pubkey_id":     pk.ID,
+			"source_id":      source.ID,
+			"image_id":       "composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7",
+			"resource_group": "testGroup",
+			"amount":         1,
+			"instance_size":  "Basic_A0",
+			"pubkey_id":      pk.ID,
+		}
+		if json_data, err = json.Marshal(values); err != nil {
+			t.Fatalf("unable to marshal values to json: %v", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", "/api/provisioning/reservations/azure", bytes.NewBuffer(json_data))
+		require.NoError(t, err, "failed to create request")
+		req.Header.Add("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(services.CreateAzureReservation)
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code, "Handler returned wrong status code")
+
+		stubCount := stubs.AzureReservationStubCount(ctx)
+		assert.Equal(t, 1, stubCount, "Reservation has not been Created through DAO")
+
+		assert.Equal(t, 1, len(stub.EnqueuedJobs(ctx)), "Expected exactly one job to be planned")
+		assert.IsType(t, jobs.LaunchInstanceAzureTaskArgs{}, stub.EnqueuedJobs(ctx)[0].Args, "Unexpected type of arguments for the planned job")
+		jobArgs := stub.EnqueuedJobs(ctx)[0].Args.(jobs.LaunchInstanceAzureTaskArgs)
+		assert.Equal(t, "testGroup", jobArgs.ResourceGroupName)
+		assert.Equal(t, "/subscriptions/4b9d213f-712f-4d17-a483-8a10bbe9df3a/resourceGroups/testGroup/providers/Microsoft.Compute/images/composer-api-92ea98f8-7697-472e-80b1-7454fa0e7fa7", jobArgs.AzureImageID, "Expected translated image to real name - one from IB client stub")
+	})
+
+	t.Run("failed reservation with invalid location", func(t *testing.T) {
+		ctx := stubs.WithReservationDao(sharedCtx)
+		ctx = stub.WithEnqueuer(ctx)
+
+		var err error
+		values := map[string]interface{}{
+			"source_id":      source.ID,
+			"location":       "blank",
+			"image_id":       "92ea98f8-7697-472e-80b1-7454fa0e7fa7",
+			"resource_group": "testGroup",
+			"amount":         1,
+			"instance_size":  "Basic_A0",
+			"pubkey_id":      pk.ID,
 		}
 		if json_data, err = json.Marshal(values); err != nil {
 			t.Fatalf("unable to marshal values to json: %v", err)

--- a/scripts/rest_examples/http-client.env.json
+++ b/scripts/rest_examples/http-client.env.json
@@ -10,6 +10,7 @@
     "region": "us-east-1",
     "launch_template_id": "",
     "reservation-get-id": "1",
-    "azure-source-id": "2"
+    "azure-source-id": "2",
+    "azure-resource-group": "redhat-deployed"
   }
 }

--- a/scripts/rest_examples/reservation-create-azure.http
+++ b/scripts/rest_examples/reservation-create-azure.http
@@ -7,9 +7,10 @@ X-Rh-Identity: {{identity}}
   "name": "azure-linux-us-east",
   "location": "eastus_1",
   "source_id": "{{azure-source-id}}",
-  "image_id": "composer-api-081fc867-838f-44a5-af03-8b8def808431",
+  "image_id": "composer-api-e7e1c242-4ce8-4d5e-a5d0-75720e91afca",
   "amount": 1,
   "instance_size": "Standard_B1ls",
   "pubkey_id": 2,
-  "poweroff": true
+  "poweroff": true,
+  "resource_group": "{{azure-resource-group}}"
 }


### PR DESCRIPTION
This makes the Azure resource group work as expected. The static image is expected in the same group.
Composer image is still looked up.

Fixes HMS-1772


You  won't believe it, but I've even  tested it properly and it works! xD