### PR TITLE
chore: requery account for transaction isolation

### DIFF
--- a/internal/middleware/account.go
+++ b/internal/middleware/account.go
@@ -44,10 +44,9 @@ func AccountMiddleware(next http.Handler) http.Handler {
 			logger.Error().Err(err).Msg("Cache returned error")
 			http.Error(w, err.Error(), 500)
 			return
+		} else {
+			logger.Trace().Int64("account", cachedAccount.ID).Msg("Account cache hit")
 		}
-
-		// account found in cache
-		logger.Trace().Int64("account", cachedAccount.ID).Msg("Account cache hit")
 
 		// set contexts - account id
 		ctx := identity.WithAccountId(r.Context(), cachedAccount.ID)


### PR DESCRIPTION
So I came up with this nice trick on how to quickly create accounts without explicit transactions. Works great, except it does not :-) When there are actually two requests with the same account at the same time, the query is executed in an implicit transactions which cannot be turned off and I totally forgot about it.

What happens is that one request will fail with `pgx error: scanning one: no rows in result set` (https://glitchtip.devshift.net/insights/issues/973561) because although the conflict will trigger, the default isolation level in postgres will not allow to see the inserted record.

The solution is to execute the same query one more time, this only happens rarely, I saw 20 events in production in one week. But it is worth fixing this.

This is hard to test or reproduce, so review carefully. Maybe with some arbitrary sleep via `pg_sleep()` function but I find this difficult to figure out. I think the code is good (TM). 