### PR TITLE
chore: add extra sources body logging

### DIFF
--- a/internal/clients/http/sources/sources_client.go
+++ b/internal/clients/http/sources/sources_client.go
@@ -77,6 +77,9 @@ func (c *sourcesClient) Ready(ctx context.Context) error {
 	if resp == nil {
 		return fmt.Errorf("ready call: empty response: %w", clients.ErrUnexpectedBackendResponse)
 	}
+	if resp.JSON400 != nil {
+		logger.Warn().Bytes("body", resp.Body).Int("status", resp.StatusCode()).Msg("Get authentication from sources returned 4xx")
+	}
 
 	if resp.StatusCode() < 200 || resp.StatusCode() > 299 {
 		return fmt.Errorf("ready call: %w: %d", clients.ErrUnexpectedBackendResponse, resp.StatusCode())
@@ -115,6 +118,9 @@ func (c *sourcesClient) ListProvisioningSourcesByProvider(ctx context.Context, p
 
 	if resp == nil {
 		return nil, 0, fmt.Errorf("list application types empty response: %w", clients.ErrUnexpectedBackendResponse)
+	}
+	if resp.JSON404 != nil || resp.JSON400 != nil {
+		logger.Warn().Bytes("body", resp.Body).Int("status", resp.StatusCode()).Msg("Get authentication from sources returned 4xx")
 	}
 
 	if resp.JSON200 == nil {
@@ -169,6 +175,9 @@ func (c *sourcesClient) ListAllProvisioningSources(ctx context.Context) ([]*clie
 	if resp == nil {
 		return nil, 0, fmt.Errorf("list provisioning sources empty response: %w", clients.ErrUnexpectedBackendResponse)
 	}
+	if resp.JSON404 != nil || resp.JSON400 != nil {
+		logger.Warn().Bytes("body", resp.Body).Int("status", resp.StatusCode()).Msg("Get authentication from sources returned 4xx")
+	}
 
 	if resp.JSON200 == nil {
 		return nil, 0, fmt.Errorf("list provisioning sources returned %d: %w", resp.StatusCode(), clients.ErrUnexpectedBackendResponse)
@@ -215,6 +224,9 @@ func (c *sourcesClient) GetAuthentication(ctx context.Context, sourceId string) 
 
 	if resp == nil {
 		return nil, fmt.Errorf("get source authentication empty response: %w", clients.ErrUnexpectedBackendResponse)
+	}
+	if resp.JSON404 != nil || resp.JSON400 != nil {
+		logger.Warn().Bytes("body", resp.Body).Int("status", resp.StatusCode()).Msg("Get authentication from sources returned 4xx")
 	}
 	if resp.JSON200 == nil {
 		return nil, fmt.Errorf("get source authentication returned %d: %w", resp.StatusCode(), clients.ErrUnexpectedBackendResponse)


### PR DESCRIPTION
I am trying to understand why sources randomly returns 404, there should be something in the body it looks like:

https://github.com/RedHatInsights/sources-api-go/blob/main/middleware/error_handling.go#L22C25-L22C25

This will print a warning log statement with full body as a field. @akhil-jha then let’s reproduce once again.