### PR TITLE
fix(HMS-2757): improve unexpected row error

### DIFF
--- a/internal/dao/pgx/pubkey_pgx.go
+++ b/internal/dao/pgx/pubkey_pgx.go
@@ -88,7 +88,7 @@ func (x *pubkeyDao) Update(ctx context.Context, pubkey *models.Pubkey) error {
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }
@@ -132,7 +132,7 @@ func (x *pubkeyDao) Delete(ctx context.Context, id int64) error {
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }
@@ -191,7 +191,7 @@ func (x *pubkeyDao) UnscopedDeleteResource(ctx context.Context, id int64) error 
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }

--- a/internal/dao/pgx/reservation_pgx.go
+++ b/internal/dao/pgx/reservation_pgx.go
@@ -53,7 +53,7 @@ func (x *reservationDao) CreateAWS(ctx context.Context, reservation *models.AWSR
 			return fmt.Errorf("pgx error: %w", err)
 		}
 		if tag.RowsAffected() != 1 {
-			return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+			return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 		}
 
 		return nil
@@ -84,7 +84,7 @@ func (x *reservationDao) CreateAzure(ctx context.Context, reservation *models.Az
 			return fmt.Errorf("pgx error: %w", err)
 		}
 		if tag.RowsAffected() != 1 {
-			return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+			return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 		}
 
 		return nil
@@ -115,7 +115,7 @@ func (x *reservationDao) CreateGCP(ctx context.Context, reservation *models.GCPR
 			return fmt.Errorf("pgx error: %w", err)
 		}
 		if tag.RowsAffected() != 1 {
-			return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+			return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 		}
 
 		return nil
@@ -160,7 +160,7 @@ func (x *reservationDao) CreateInstance(ctx context.Context, instance *models.Re
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 
 	return nil
@@ -179,7 +179,7 @@ func (x *reservationDao) UpdateReservationInstance(ctx context.Context, reservat
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 
 	return nil
@@ -300,7 +300,7 @@ func (x *reservationDao) UpdateStatus(ctx context.Context, id int64, status stri
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }
@@ -313,7 +313,7 @@ func (x *reservationDao) UnscopedUpdateAWSDetail(ctx context.Context, id int64, 
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }
@@ -326,7 +326,7 @@ func (x *reservationDao) UpdateReservationIDForAWS(ctx context.Context, id int64
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }
@@ -339,7 +339,7 @@ func (x *reservationDao) UpdateOperationNameForGCP(ctx context.Context, id int64
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }
@@ -352,7 +352,7 @@ func (x *reservationDao) FinishWithSuccess(ctx context.Context, id int64) error 
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }
@@ -365,7 +365,7 @@ func (x *reservationDao) FinishWithError(ctx context.Context, id int64, errorStr
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }
@@ -378,7 +378,7 @@ func (x *reservationDao) Delete(ctx context.Context, id int64) error {
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }

--- a/internal/dao/pgx/service_pgx.go
+++ b/internal/dao/pgx/service_pgx.go
@@ -36,7 +36,7 @@ func UnscopedUpdatePubkey(ctx context.Context, pubkey *models.Pubkey) error {
 		return fmt.Errorf("pgx error: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("expected 1 row: %w", dao.ErrAffectedMismatch)
+		return fmt.Errorf("expected 1 row, got %d: %w", tag.RowsAffected(), dao.ErrAffectedMismatch)
 	}
 	return nil
 }

--- a/internal/jobs/launch_instance_aws.go
+++ b/internal/jobs/launch_instance_aws.go
@@ -181,6 +181,7 @@ func DoEnsurePubkeyOnAWS(ctx context.Context, args *LaunchInstanceAWSTaskArgs) e
 
 	// update the AWS key name in reservation details
 	awsReservation.Detail.PubkeyName = ec2Name
+	logger.Debug().Msgf("Updating AWS reservation detail %d", awsReservation.Reservation.ID)
 	err = resDao.UnscopedUpdateAWSDetail(ctx, awsReservation.Reservation.ID, awsReservation.Detail)
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to save AWS pubkey name to DB")


### PR DESCRIPTION
An error striked me this morning: "failed to save AWS pubkey name to DB: expected 1 row: unexpected affected rows" which means detail reservation could not be updated after AWS key was updated. It looks like we fetch AWS reservation detail from the database but we do not load `reservation_id` field which is okay unless we need to update such record. This field is used in the WHERE query to locate the correct record.

I am adding few more log statements to see little bit more and adding the missing field.

During this, I noticed that our reservation - detail association is set up in a way that one reservation can have multiple details for different providers. But we have never done that, our current implementation is 1:1, we might drop this in the future. But it is okay for now.