### PR TITLE
chore: correlation for worker logger

### DIFF
--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -13,7 +13,11 @@ type Principal = identity.XRHID
 
 // Identity returns identity header struct or nil when not set.
 func Identity(ctx context.Context) Principal {
-	return identity.Get(ctx)
+	val := ctx.Value(identity.Key)
+	if val == nil {
+		return Principal{}
+	}
+	return val.(Principal)
 }
 
 // IdentityHeader returns identity header (base64-encoded JSON)

--- a/internal/jobs/ctx.go
+++ b/internal/jobs/ctx.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/RHEnVision/provisioning-backend/internal/identity"
 	"github.com/RHEnVision/provisioning-backend/internal/logging"
+	"github.com/RHEnVision/provisioning-backend/internal/ptr"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -17,4 +19,15 @@ func copyContext(ctx context.Context) context.Context {
 	nCtx = logging.WithEdgeRequestId(nCtx, logging.EdgeRequestId(ctx))
 	nCtx = identity.WithAccountId(nCtx, identity.AccountId(ctx))
 	return nCtx
+}
+
+func reservationContextLogger(origCtx context.Context, reservationID int64) (context.Context, *zerolog.Logger) {
+	ctx := logging.WithReservationId(origCtx, reservationID)
+
+	logger := zerolog.Ctx(ctx)
+	logger = ptr.To(logger.With().
+		Int64("reservation_id", reservationID).
+		Logger())
+	ctx = logger.WithContext(ctx)
+	return ctx, logger
 }

--- a/internal/jobs/launch_instance_gcp.go
+++ b/internal/jobs/launch_instance_gcp.go
@@ -11,7 +11,6 @@ import (
 	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/gcp"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
-	"github.com/RHEnVision/provisioning-backend/internal/ptr"
 	"github.com/RHEnVision/provisioning-backend/internal/userdata"
 	"github.com/RHEnVision/provisioning-backend/pkg/worker"
 	"github.com/rs/zerolog"
@@ -56,9 +55,11 @@ func HandleLaunchInstanceGCP(ctx context.Context, job *worker.Job) {
 		return
 	}
 
+	// context and logger
+	ctx, logger = reservationContextLogger(ctx, args.ReservationID)
+	logger.Info().Msg("Started launch instance GCP job")
+
 	// ensure panic finishes the job
-	logger = ptr.To(logger.With().Int64("reservation_id", args.ReservationID).Logger())
-	ctx = logger.WithContext(ctx)
 	defer func() {
 		if r := recover(); r != nil {
 			panicErr := fmt.Errorf("%w: %s", ErrPanicInJob, r)

--- a/internal/jobs/noop_job.go
+++ b/internal/jobs/noop_job.go
@@ -33,8 +33,9 @@ func HandleNoop(ctx context.Context, job *worker.Job) {
 		return
 	}
 
-	logger := zerolog.Ctx(ctx).With().Int64("reservation_id", args.ReservationID).Logger()
-	ctx = logger.WithContext(ctx)
+	// context and logger
+	ctx, _ = reservationContextLogger(ctx, args.ReservationID)
+
 	nc := notifications.GetNotificationClient(ctx)
 
 	jobErr := DoNoop(ctx, &args)

--- a/internal/logging/ctx.go
+++ b/internal/logging/ctx.go
@@ -10,6 +10,8 @@ const (
 	requestIdCtxKey     commonKeyId = iota
 	edgeRequestIdCtxKey commonKeyId = iota
 	correlationCtxKey   commonKeyId = iota
+	jobIdCtxKey         commonKeyId = iota
+	reservationIdCtxKey commonKeyId = iota
 )
 
 // CorrelationId returns UI correlation id or an empty string when not set.
@@ -52,4 +54,32 @@ func TraceId(ctx context.Context) string {
 // WithTraceId returns context copy with trace id value.
 func WithTraceId(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, requestIdCtxKey, id)
+}
+
+// JobId returns request id or an empty string when not set.
+func JobId(ctx context.Context) string {
+	value := ctx.Value(jobIdCtxKey)
+	if value == nil {
+		return ""
+	}
+	return value.(string)
+}
+
+// WithJobId returns context copy with trace id value.
+func WithJobId(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, jobIdCtxKey, id)
+}
+
+// ReservationId returns request id or an empty string when not set.
+func ReservationId(ctx context.Context) int64 {
+	value := ctx.Value(reservationIdCtxKey)
+	if value == nil {
+		return 0
+	}
+	return value.(int64)
+}
+
+// WithReservationId returns context copy with trace id value.
+func WithReservationId(ctx context.Context, id int64) context.Context {
+	return context.WithValue(ctx, reservationIdCtxKey, id)
 }

--- a/internal/services/aws_reservation_service.go
+++ b/internal/services/aws_reservation_service.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/RHEnVision/provisioning-backend/internal/logging"
+
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	_ "github.com/RHEnVision/provisioning-backend/internal/clients/http/image_builder"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
@@ -148,6 +150,8 @@ func CreateAWSReservation(w http.ResponseWriter, r *http.Request) {
 	launchJob := worker.Job{
 		Type:      jobs.TypeLaunchInstanceAws,
 		Identity:  id,
+		TraceID:   logging.TraceId(r.Context()),
+		EdgeID:    logging.EdgeRequestId(r.Context()),
 		AccountID: accountId,
 		Args: jobs.LaunchInstanceAWSTaskArgs{
 			ReservationID:    reservation.ID,

--- a/internal/services/azure_reservation_service.go
+++ b/internal/services/azure_reservation_service.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/RHEnVision/provisioning-backend/internal/logging"
+
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
@@ -142,6 +144,8 @@ func CreateAzureReservation(w http.ResponseWriter, r *http.Request) {
 	launchJob := worker.Job{
 		Type:      jobs.TypeLaunchInstanceAzure,
 		Identity:  identity.Identity(r.Context()),
+		TraceID:   logging.TraceId(r.Context()),
+		EdgeID:    logging.EdgeRequestId(r.Context()),
 		AccountID: identity.AccountId(r.Context()),
 		Args: jobs.LaunchInstanceAzureTaskArgs{
 			ReservationID:     reservation.ID,

--- a/internal/services/gcp_reservation_service.go
+++ b/internal/services/gcp_reservation_service.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/RHEnVision/provisioning-backend/internal/logging"
+
 	"github.com/RHEnVision/provisioning-backend/internal/preload"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
@@ -140,6 +142,8 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 	launchJob := worker.Job{
 		Type:      jobs.TypeLaunchInstanceGcp,
 		AccountID: accountId,
+		TraceID:   logging.TraceId(r.Context()),
+		EdgeID:    logging.EdgeRequestId(r.Context()),
 		Identity:  id,
 		Args: jobs.LaunchInstanceGCPTaskArgs{
 			ReservationID:    reservation.ID,

--- a/internal/services/noop_reservation_service.go
+++ b/internal/services/noop_reservation_service.go
@@ -3,6 +3,8 @@ package services
 import (
 	"net/http"
 
+	"github.com/RHEnVision/provisioning-backend/internal/logging"
+
 	"github.com/RHEnVision/provisioning-backend/internal/dao"
 	"github.com/RHEnVision/provisioning-backend/internal/identity"
 	"github.com/RHEnVision/provisioning-backend/internal/jobs"
@@ -44,6 +46,8 @@ func CreateNoopReservation(w http.ResponseWriter, r *http.Request) {
 		Type:      jobs.TypeNoop,
 		AccountID: accountId,
 		Identity:  identity,
+		TraceID:   logging.TraceId(r.Context()),
+		EdgeID:    logging.EdgeRequestId(r.Context()),
 		Args: jobs.NoopJobArgs{
 			ReservationID: reservation.ID,
 		},

--- a/pkg/worker/memory.go
+++ b/pkg/worker/memory.go
@@ -64,7 +64,7 @@ func (w *MemoryWorker) processJob(ctx context.Context, job *Job) {
 	}
 
 	if h, ok := w.handlers[job.Type]; ok {
-		ctx = contextLogger(ctx, job)
+		ctx, _ = contextLogger(ctx, job)
 		cCtx, cFunc := context.WithTimeout(ctx, config.Worker.Timeout)
 		defer cFunc()
 		h(cCtx, job)


### PR DESCRIPTION
During investigation of a problem, I noticed that worker is missing jobID from all pgx log messages therefore you will not see some records which are useful. This fixes it and unifies how context (and logger) is created across jobs. It also adds trace/edge IDs so logs can be correlated across api/worker to see the whole workflow of a reservation.

I cannot figure out why tests are failing, it is too late my brain does not work anymore. Will take a look tomorrow.