### PR TITLE
fix: workaround for CVE-2023-44487

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -285,6 +285,9 @@ objects:
               successThreshold: 1
               timeoutSeconds: 120
             env:
+              # CVE-2023-44487
+              - name: GODEBUG
+                value: http2server=0
               - name: LOGGING_LEVEL
                 value: ${LOGGING_LEVEL}
               - name: REST_ENDPOINTS_TRACE_DATA


### PR DESCRIPTION
How to test this:

`curl --http2 .... stage_url`

Stage environment is accessible via the proxy and I just verified that HTTP2 works fine through curl, let’s merge this and see if it is disabled.