### PR TITLE
chore: revert workaround for CVE-2023-44487

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -285,9 +285,6 @@ objects:
               successThreshold: 1
               timeoutSeconds: 120
             env:
-              # CVE-2023-44487
-              - name: GODEBUG
-                value: http2server=0
               - name: LOGGING_LEVEL
                 value: ${LOGGING_LEVEL}
               - name: REST_ENDPOINTS_TRACE_DATA


### PR DESCRIPTION
Do not merge yet.

This is a PR to remind us we need to revert this workaround in the future.