### PR TITLE
chore: log HTTP protocol in request start

### DIFF
--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -27,7 +27,8 @@ func LoggerMiddleware(rootLogger *zerolog.Logger) func(next http.Handler) http.H
 				Str("remote_ip", r.RemoteAddr).
 				Str("url", r.URL.Path).
 				Str("method", r.Method).
-				Int("bytes_in", bytesIn)
+				Int("bytes_in", bytesIn).
+				Str("proto", r.Proto)
 			if edgeId != "" {
 				lctx = lctx.Str("request_id", edgeId)
 			}


### PR DESCRIPTION
SSIA

Our 3scale API uses HTTP/2 for client communication but internally I believe it relies on HTTP 1.1. This should confirm this.