### PR TITLE
chore: add otel pgx parameters to log

### DIFF
--- a/internal/telemetry/zerolog_exporter.go
+++ b/internal/telemetry/zerolog_exporter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
@@ -44,6 +45,9 @@ func (e *loggerExporter) ExportSpans(ctx context.Context, spans []trace.ReadOnly
 
 		for _, kv := range span.Attributes() {
 			key := string(kv.Key)
+			if kv.Value.Type() == attribute.STRINGSLICE {
+				t = t.Strs(key, kv.Value.AsStringSlice())
+			}
 			val := kv.Value.AsString()
 
 			if val == "" {


### PR DESCRIPTION
We do not include slices in our telemetry2zerolog implementation, the otelpgx library does use string slice for params. This was the reason why it was missing. This fixes it.