### PR TITLE
chore: add more otel params

### DIFF
--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -79,6 +79,10 @@ func Initialize(ctx context.Context, schema string) error {
 					if jobId != "" {
 						zx = zx.Str("job_id", jobId)
 					}
+					jobType := logging.JobType(ctx)
+					if jobType != "" {
+						zx = zx.Str("job_type", jobType)
+					}
 					reservationId := logging.ReservationId(ctx)
 					if reservationId != 0 {
 						zx = zx.Int64("reservation_id", reservationId)
@@ -91,7 +95,7 @@ func Initialize(ctx context.Context, schema string) error {
 					if requestId != "" {
 						zx = zx.Str("request_id", requestId)
 					}
-					accountId := identity.AccountIdOrNil(ctx)
+					accountId := identity.AccountIdOrZero(ctx)
 					if accountId != 0 {
 						zx = zx.Int64("account_id", accountId)
 					}

--- a/internal/identity/account.go
+++ b/internal/identity/account.go
@@ -22,8 +22,8 @@ func AccountId(ctx context.Context) int64 {
 	return value.(int64)
 }
 
-// AccountIdOrNil returns current account model or 0 when not set.
-func AccountIdOrNil(ctx context.Context) int64 {
+// AccountIdOrZero returns current account model or 0 when not set.
+func AccountIdOrZero(ctx context.Context) int64 {
 	value := ctx.Value(accountIdCtxKey)
 	if value == nil {
 		return 0

--- a/internal/jobs/ctx.go
+++ b/internal/jobs/ctx.go
@@ -18,6 +18,7 @@ func copyContext(ctx context.Context) context.Context {
 	nCtx = logging.WithTraceId(nCtx, logging.TraceId(ctx))
 	nCtx = logging.WithEdgeRequestId(nCtx, logging.EdgeRequestId(ctx))
 	nCtx = identity.WithAccountId(nCtx, identity.AccountId(ctx))
+	nCtx = logging.WithReservationId(nCtx, logging.ReservationId(ctx))
 	return nCtx
 }
 

--- a/internal/logging/ctx.go
+++ b/internal/logging/ctx.go
@@ -12,6 +12,7 @@ const (
 	correlationCtxKey   commonKeyId = iota
 	jobIdCtxKey         commonKeyId = iota
 	reservationIdCtxKey commonKeyId = iota
+	jobTypeCtxKey       commonKeyId = iota
 )
 
 // CorrelationId returns UI correlation id or an empty string when not set.
@@ -82,4 +83,18 @@ func ReservationId(ctx context.Context) int64 {
 // WithReservationId returns context copy with trace id value.
 func WithReservationId(ctx context.Context, id int64) context.Context {
 	return context.WithValue(ctx, reservationIdCtxKey, id)
+}
+
+// JobType returns relevant context data or empty string when not set.
+func JobType(ctx context.Context) string {
+	value := ctx.Value(jobTypeCtxKey)
+	if value == nil {
+		return ""
+	}
+	return value.(string)
+}
+
+// WithJobType returns context copy with relevant value.
+func WithJobType(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, jobTypeCtxKey, id)
 }

--- a/pkg/worker/job.go
+++ b/pkg/worker/job.go
@@ -90,6 +90,8 @@ func contextLogger(origCtx context.Context, job *Job) (context.Context, *zerolog
 	ctx = logging.WithTraceId(ctx, job.TraceID)
 	ctx = logging.WithEdgeRequestId(ctx, job.EdgeID)
 	ctx = identity.WithAccountId(ctx, job.AccountID)
+	ctx = logging.WithJobId(ctx, job.ID.String())
+	ctx = logging.WithJobType(ctx, job.Type.String())
 
 	logger := zerolog.Ctx(ctx)
 	logger = ptr.To(logger.With().


### PR DESCRIPTION
Add few more important correlation params into otel logger, also store job id and type in context for later use. Finally, rename one context function to better reflect what it returns.