### PR TITLE
chore: Add GCP provider to floorist

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -461,8 +461,7 @@ objects:
             from reservations r
             join aws_reservation_details d on r.id = d.reservation_id
             join accounts a on r.account_id = a.id
-            where provider = provider_type_aws()
-            order by r.created_at)
+            where provider = provider_type_aws())
 
             union all
 
@@ -483,8 +482,27 @@ objects:
             from reservations r
             join azure_reservation_details d on r.id = d.reservation_id
             join accounts a on r.account_id = a.id
-            where provider = provider_type_azure()
-            order by r.created_at);
+            where provider = provider_type_azure())
+            
+            union all
+            
+            (select 'gcp'                     as provider,
+            r.id,
+            r.created_at,
+            r.finished_at,
+            r.success,
+            r.status || ' (' || r.step || '/' || r.steps || ')' as status,
+            a.account_number,
+            a.org_id,
+            d.source_id,
+            d.image_id,
+            d.detail -> 'machine_type' as type,
+            d.detail -> 'amount'        as amount,
+            d.detail -> 'launch_template_id' is not null as template
+            from reservations r
+            join gcp_reservation_details d on r.id = d.reservation_id
+            join accounts a on r.account_id = a.id
+            where provider = provider_type_gcp());
 
 
 # possible application ENV variables are in config/api.env.example


### PR DESCRIPTION
I noticed we do not make statistics of gcp provider. :eyes: I understand that the floorplan is old, but I hope we can do this now.
Please, do not merge yet, I am thinking if I would add something else. But could you please check if this would not break the process?

note: We only track whether or not the users use any template, but we do not track what is in the template. We could add the template to the floorplan in the future, but we'd most likely have to export the template for each reservation detail. I remember @lzap wanted to track this, so I am just saying it is possible. But it seems it would complicate the data, so I would postpone it a bit.