### PR TITLE
chore: Sanitize job logging 

### DIFF
--- a/pkg/worker/job.go
+++ b/pkg/worker/job.go
@@ -105,8 +105,7 @@ func initJobContext(origCtx context.Context, job *Job) (context.Context, *zerolo
 		Str("account_number", job.Identity.Identity.AccountNumber).
 		Str("request_id", job.EdgeID).
 		Str("job_id", job.ID.String()).
-		Str("job_type", job.Type.String()).
-		Interface("job_args", job.Args)
+		Str("job_type", job.Type.String())
 
 	if config.Telemetry.Enabled {
 		ctx = otel.GetTextMapPropagator().Extract(ctx, job.TraceContext)

--- a/pkg/worker/memory.go
+++ b/pkg/worker/memory.go
@@ -33,9 +33,16 @@ func (w *MemoryWorker) Enqueue(ctx context.Context, job *Job) error {
 		return fmt.Errorf("unable to enqueue job: %w", ErrJobNotFound)
 	}
 
+	logger := zerolog.Ctx(ctx).With().
+		Str("job_id", job.ID.String()).
+		Str("job_type", job.Type.String()).
+		Logger()
+	logger.Info().Interface("job_args", job.Args).Msg("Enqueuing job via memory")
+
 	if job.ID == uuid.Nil {
 		job.ID, err = uuid.NewRandom()
 		if err != nil {
+			logger.Error().Err(err).Msg("Unable to generate a job id")
 			return fmt.Errorf("unable to generate UUID: %w", err)
 		}
 	}
@@ -72,6 +79,7 @@ func (w *MemoryWorker) processJob(origCtx context.Context, job *Job) {
 
 	ctx, logger, span := initJobContext(origCtx, job)
 	defer span.End()
+	logger.Info().Interface("job_args", job.Args).Msgf("Dequeued job from memory")
 
 	if h, ok := w.handlers[job.Type]; ok {
 		cCtx, cFunc := context.WithTimeout(ctx, config.Worker.Timeout)


### PR DESCRIPTION
:tipping_hand_person:  depends on #711 and thus contains those changes as well

Cleans up job logs.
Removes job_args from most of the job logs except Enqueue and Dequeue.
Removes double logging of job id and type.

I was touching this code quite heavily in #711 so I wanted to follow-up with what I feel might improve the logging a bit.
:warning: These are my opinions and maybe some of the logs were there on purpose, happy to discuss it! :)
