### PR TITLE
Fix: SQL Union on different datatypes

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -457,7 +457,7 @@ objects:
             d.detail -> 'instance_type'                  as type,
             d.detail -> 'region'                         as region,
             d.detail -> 'amount'                         as amount,
-            d.detail -> 'launch_template_id' as template
+            d.detail -> 'launch_template_id'             as template
             from reservations r
             join aws_reservation_details d on r.id = d.reservation_id
             join accounts a on r.account_id = a.id
@@ -478,7 +478,7 @@ objects:
             d.detail -> 'instance_size' as type,
             d.detail -> 'location'      as region,
             d.detail -> 'amount'        as amount,
-            false                       as template
+            ''                          as template
             from reservations r
             join azure_reservation_details d on r.id = d.reservation_id
             join accounts a on r.account_id = a.id


### PR DESCRIPTION
I do not wish to make a nightmare commit history. But I guess we are not able to test this until we find out that we broke the process. And it seems to be broken right now, we are not getting the latest data, unfortunately. I think I have found the reason, after incorporating the gcp, we still could have fetched the data, so I hope that it is only this.
I think that since I have recreated the field into a string field, it was wrong to leave the boolean for Azure.