### PR TITLE
fix(HMS-1847): Updating env_var variables location

### DIFF
--- a/deploy/cloudwash_job.yaml
+++ b/deploy/cloudwash_job.yaml
@@ -28,17 +28,13 @@ objects:
                 command:
                   - swach
                 args:
-                  - "-d"
+                  - "-d" # remove this after merging everything
                   - "azure"
                   - "--all"
                 volumeMounts:
                   - name: config-volume
                     mountPath: /opt/app-root/src/cloudwash/settings.yaml
                     subPath: settings.yaml
-            volumes:
-              - name: config-volume
-                configMap:
-                  name: cloudwash-config
                 env:
                   - name: CLEANUP_PROVIDERS_AZURE_AUTH_CLIENT_ID
                     valueFrom:
@@ -76,6 +72,10 @@ objects:
                         key: location
                         name: provisioning-azure-auth-secret
                         optional: true
+            volumes:
+              - name: config-volume
+                configMap:
+                  name: cloudwash-config
 parameters:
 - name: IMAGE_TAG
   value: ''


### PR DESCRIPTION
The env_vars which is being used by config map is defined under cronjob yaml.

which needs to be defined under the container block instead of the volum_mounts block.