### PR TITLE
fix(HMS-2640): machine type is required

### DIFF
--- a/internal/services/gcp_reservation_service.go
+++ b/internal/services/gcp_reservation_service.go
@@ -44,6 +44,12 @@ func CreateGCPReservation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check machine type for "This organization policy prevents creating instances with exotic machine types. Contact the IT Public Cloud team at help.redhat.com for an exception"
+	if payload.MachineType == "" {
+		renderError(w, r, payloads.NewInvalidRequestError(r.Context(), "Machine type must be present even when a template is in use", ErrBothTypeAndTemplateMissing))
+		return
+	}
+
 	namePattern := "inst-####"
 	// Verify name pattern is lower cased and add #####
 	if payload.NamePattern != "" {

--- a/internal/services/reservations_service.go
+++ b/internal/services/reservations_service.go
@@ -21,6 +21,7 @@ var (
 	ErrUnknownInstanceTypeName    = errors.New("unknown instance type")
 	ErrArchitectureMismatch       = errors.New("instance type and image architecture mismatch")
 	ErrBothTypeAndTemplateMissing = errors.New("instance type or launch template not set")
+	ErrMachineTypeMissing         = errors.New("machine type missing")
 	ErrUnsupportedRegion          = errors.New("unknown region/location/zone")
 	ErrInvalidNamePattern         = errors.New("name pattern is not RFC-1035 compatible")
 	ErrPubkeyNotFound             = errors.New("no pubkey found")

--- a/scripts/rest_examples/http-client.env.json
+++ b/scripts/rest_examples/http-client.env.json
@@ -11,7 +11,9 @@
     "source_id_gcp": "3",
     "pubkey_id": "1",
     "region": "us-east-1",
-    "launch_template_id": "",
+    "zone_gcp": "us-central1-a",
+    "launch_template_id_aws": "",
+    "launch_template_id_gcp": "",
     "reservation-get-id": "1",
     "azure-resource-group": "redhat-deployed"
   }

--- a/scripts/rest_examples/reservation-create-aws.http
+++ b/scripts/rest_examples/reservation-create-aws.http
@@ -8,7 +8,7 @@ X-Rh-Identity: {{identity}}
   "source_id": "{{source_id_aws}}",
   "image_id": "ami-05fa00d4c63e32376",
   "amount": 1,
-  "launch_template_id": "{{launch_template_id}}",
+  "launch_template_id_aws": "{{launch_template_id_aws}}",
   "instance_type": "t2.nano",
   "pubkey_id": {{pubkey_id}},
   "poweroff": true

--- a/scripts/rest_examples/reservation-create-gcp.http
+++ b/scripts/rest_examples/reservation-create-gcp.http
@@ -5,12 +5,12 @@ X-Rh-Identity: {{identity}}
 
 {
   "name_pattern": "gcp-linux-eu-west8-c",
-  "zone": "europe-west8-c",
+  "zone": "{{zone_gcp}}",
   "source_id": "{{source_id_gcp}}",
   "image_id": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-9-v20230411",
   "amount": 1,
   "machine_type": "e2-micro",
-  "launch_template_id": "{{launch_template_id}}",
+  "launch_template_id_gcp": "{{launch_template_id_gcp}}",
   "pubkey_id": {{pubkey_id}},
   "poweroff": true
 }


### PR DESCRIPTION
It looks like GCP errors out with "Operation denied by custom org policy: [customConstraints/custom.denyMachineTypes] : This organization policy prevents creating instances with exotic machine types. Contact the IT Public Cloud team at help.redhat.com for an exception" when nothing is passed into machine type. It is likely only on our account, but I am unable to test this with different account so making the field a required field.

Replaces: https://github.com/RHEnVision/provisioning-backend/pull/689