### PR TITLE
docs: Add descriptions to all tags

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -1397,7 +1397,7 @@
           }
         },
         "tags": [
-          "AvailabilityStatus"
+          "Source"
         ]
       }
     },
@@ -2156,6 +2156,14 @@
     {
       "description": "A pubkey represents the SSH public portion of a key pair with a name and body. Public key types and fingerprints are detected during their creation process. Two types are supported: RSA and ssh-ed25519. Fingerprints are calculated in two ways: using the standard SHA method and the legacy MD5 method, which is available under the fingerprint_legacy field. Each public key has a unique name and body and helps in verifying the uniqueness of the keys. Using this API, you can perform the following operations.\n",
       "name": "Pubkey"
+    },
+    {
+      "description": "A reservation represents a request for launching one or more instances from a single image. This reservation triggers a background job, that will Launch set amount of instances with the same configuration. The configuration decides target provider, instance size and ssh pubkey to use for the default user.\n",
+      "name": "Reservation"
+    },
+    {
+      "description": "A Source represents a connection with public cloud account. These endpoints serve as convenient way to read information about available Sources to deploy instances into. The source of through is different application called Sources.\n",
+      "name": "Source"
     }
   ]
 }

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -958,7 +958,7 @@ paths:
     /availability_status/sources:
         post:
             tags:
-                - AvailabilityStatus
+                - Source
             description: |
                 Schedules a background operation of Sources availability check. These checks are are performed in separate process at it's own pace. Results are sent via Kafka to Sources. There is no output from this REST operation available, no tracking of jobs is possible.
             operationId: availabilityStatus
@@ -1465,3 +1465,9 @@ tags:
     - name: Pubkey
       description: |
         A pubkey represents the SSH public portion of a key pair with a name and body. Public key types and fingerprints are detected during their creation process. Two types are supported: RSA and ssh-ed25519. Fingerprints are calculated in two ways: using the standard SHA method and the legacy MD5 method, which is available under the fingerprint_legacy field. Each public key has a unique name and body and helps in verifying the uniqueness of the keys. Using this API, you can perform the following operations.
+    - name: Reservation
+      description: |
+        A reservation represents a request for launching one or more instances from a single image. This reservation triggers a background job, that will Launch set amount of instances with the same configuration. The configuration decides target provider, instance size and ssh pubkey to use for the default user.
+    - name: Source
+      description: |
+        A Source represents a connection with public cloud account. These endpoints serve as convenient way to read information about available Sources to deploy instances into. The source of through is different application called Sources.

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -15,6 +15,16 @@ tags:
       Fingerprints are calculated in two ways: using the standard SHA method and the legacy MD5 method, which is available under the fingerprint_legacy field.
       Each public key has a unique name and body and helps in verifying the uniqueness of the keys.
       Using this API, you can perform the following operations.
+  - name: Reservation
+    description: >
+      A reservation represents a request for launching one or more instances from a single image.
+      This reservation triggers a background job, that will Launch set amount of instances with the same configuration.
+      The configuration decides target provider, instance size and ssh pubkey to use for the default user.
+  - name: Source
+    description: >
+      A Source represents a connection with public cloud account.
+      These endpoints serve as convenient way to read information about available Sources to deploy instances into.
+      The source of through is different application called Sources.
 paths:
   /pubkeys/{ID}:
     get:
@@ -546,7 +556,7 @@ paths:
     post:
       operationId: availabilityStatus
       tags:
-        - AvailabilityStatus
+        - Source
       description: >
         Schedules a background operation of Sources availability check. These checks are
         are performed in separate process at it's own pace. Results are sent via Kafka


### PR DESCRIPTION
Add descriptions to tags, as some libraries read the tags from tag list only.

Also moves the availability endpoint to Source tag, as it felt kinda lonely in the tag by itself and Source felt like a good home for it :)

For example RH api-catalog:

![image](https://github.com/RHEnVision/provisioning-backend/assets/2884324/4cc5f557-8cd0-4dc6-ad6e-6ac82c025774)
