### PR TITLE
feat: Support naming Azure instances

### DIFF
--- a/api/openapi.gen.json
+++ b/api/openapi.gen.json
@@ -684,6 +684,7 @@
             "type": "string"
           },
           "name": {
+            "description": "Name of the instance, to keep names unique, it will be suffixed with UUID. Optional, defaults to 'redhat-vm''",
             "type": "string"
           },
           "poweroff": {

--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -98,6 +98,7 @@ components:
                     description: Location (also known as region) to deploy the VM into, be aware it needs to be the same as the image location. Defaults to the Resource Group location, or 'eastus' when also creating the resource group.
                 name:
                     type: string
+                    description: Name of the instance, to keep names unique, it will be suffixed with UUID. Optional, defaults to 'redhat-vm''
                 poweroff:
                     type: boolean
                 pubkey_id:

--- a/internal/payloads/reservation_payload.go
+++ b/internal/payloads/reservation_payload.go
@@ -97,8 +97,9 @@ type AzureReservationResponse struct {
 
 	ResourceGroup string `json:"resource_group" yaml:"resource_group"`
 
-	// Azure Location.
-	Location string `json:"location" yaml:"location"`
+	// Azure Location. Included only if it was explicitly passed by User.
+	// If it was induced from Resource Group, it will be empty and thus not included in response.
+	Location string `json:"location,omitempty" yaml:"location,omitempty"`
 
 	// Azure Instance size.
 	InstanceSize string `json:"instance_size" yaml:"instance_size"`
@@ -211,8 +212,8 @@ type AzureReservationRequest struct {
 	// Amount of instances to provision of size: InstanceSize.
 	Amount int64 `json:"amount" yaml:"amount"`
 
-	// Name of the instance(s).
-	Name string `json:"name" yaml:"name"`
+	// Name of the instance(s). Defaults to redhat-vm.
+	Name string `json:"name" yaml:"name" description:"Name of the instance, to keep names unique, it will be suffixed with UUID. Optional, defaults to 'redhat-vm''"`
 
 	// Immediately power off the system after initialization.
 	PowerOff bool `json:"poweroff" yaml:"poweroff"`

--- a/internal/services/azure_reservation_service.go
+++ b/internal/services/azure_reservation_service.go
@@ -167,6 +167,7 @@ func CreateAzureReservation(w http.ResponseWriter, r *http.Request) {
 			SourceID:          reservation.SourceID,
 			AzureImageID:      azureImageName,
 			Subscription:      authentication,
+			Name:              name,
 		},
 	}
 


### PR DESCRIPTION
This adds ability to pass the optional name of the instance. If the name is not passed, we use redhat-vm as default name.

This also removes location from the response, if location was not explicitly passed by user.

Refs HMS-2004 , HMS-2923