### PR TITLE
ci: Use the same postgres version in all environments

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: foobar

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -374,7 +374,7 @@ objects:
                 memory: ${MEMORY_REQUESTS}
       database:
         name: provisioning
-        version: 13
+        version: 15
       kafkaTopics:
         - topicName: platform.provisioning.internal.availability-check
           partitions: 1


### PR DESCRIPTION
Production database is already on v15, Integration tests were pulling latest v16 and ephemeral used v13. This changes all postgres versions to v15.
