### PR TITLE
fix(HMS-2933): Improve some HTTP error codes

### DIFF
--- a/cmd/pbackend/statuser.go
+++ b/cmd/pbackend/statuser.go
@@ -92,6 +92,10 @@ func processMessage(msgCtx context.Context, message *kafka.GenericMessage) {
 			logger.Warn().Err(err).Msg("Not found error from sources")
 			return
 		}
+		if errors.Is(err, clients.ErrBadRequest) {
+			logger.Warn().Err(err).Msg("Bad request error from sources")
+			return
+		}
 		logger.Warn().Err(err).Msg("Could not get authentication")
 		return
 	}

--- a/internal/payloads/validation/id.go
+++ b/internal/payloads/validation/id.go
@@ -1,0 +1,19 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+var ErrInvalidId = errors.New("invalid id")
+
+func DigitsOnly(id string) error {
+	// Checking for out of range error
+	_, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidId, err.Error())
+	}
+
+	return nil
+}

--- a/internal/payloads/validation/id_test.go
+++ b/internal/payloads/validation/id_test.go
@@ -1,0 +1,93 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDigitsOnlySucceeds(t *testing.T) {
+	id1 := "1111"
+	err := DigitsOnly(id1)
+	require.NoError(t, err)
+
+	id2 := "1"
+	err = DigitsOnly(id2)
+	require.NoError(t, err)
+
+	id3 := "0"
+	err = DigitsOnly(id3)
+	require.NoError(t, err)
+
+	id4 := "-1111"
+	err = DigitsOnly(id4)
+	require.NoError(t, err)
+}
+
+func TestDigitsOnlyWithSymbolsFails(t *testing.T) {
+	id1 := "۹"
+	err := DigitsOnly(id1)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id1)
+	}
+
+	id2 := "aa"
+	err = DigitsOnly(id2)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id2)
+	}
+
+	id3 := "7a"
+	err = DigitsOnly(id3)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id3)
+	}
+
+	id4 := "a7"
+	err = DigitsOnly(id4)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id4)
+	}
+
+	id5 := "7a7"
+	err = DigitsOnly(id5)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id5)
+	}
+
+	id6 := "zj{{=9243*9806}}zj"
+	err = DigitsOnly(id6)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id6)
+	}
+
+	id7 := "123.456"
+	err = DigitsOnly(id7)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id7)
+	}
+
+	id8 := "123⁰456"
+	err = DigitsOnly(id8)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id8)
+	}
+
+	id9 := "10^10"
+	err = DigitsOnly(id9)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id9)
+	}
+
+	id10 := "1_1"
+	err = DigitsOnly(id10)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id10)
+	}
+
+	id11 := "170141183460469231731687303715884105727"
+	err = DigitsOnly(id11)
+	if err == nil {
+		t.Errorf("no error for invalid input: %s", id11)
+	}
+}

--- a/internal/services/launch_templates_service.go
+++ b/internal/services/launch_templates_service.go
@@ -3,6 +3,8 @@ package services
 import (
 	"net/http"
 
+	"github.com/RHEnVision/provisioning-backend/internal/payloads/validation"
+
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
 	"github.com/RHEnVision/provisioning-backend/internal/page"
@@ -14,6 +16,9 @@ import (
 //nolint:exhaustive
 func ListLaunchTemplates(w http.ResponseWriter, r *http.Request) {
 	sourceId := chi.URLParam(r, "ID")
+	if err := validation.DigitsOnly(sourceId); err != nil {
+		renderError(w, r, payloads.NewURLParsingError(r.Context(), "id parameter invalid", err))
+	}
 
 	sourcesClient, err := clients.GetSourcesClient(r.Context())
 	if err != nil {
@@ -41,6 +46,10 @@ func ListLaunchTemplates(w http.ResponseWriter, r *http.Request) {
 
 func ListLaunchTemplateAWS(w http.ResponseWriter, r *http.Request) {
 	sourceId := chi.URLParam(r, "ID")
+	if err := validation.DigitsOnly(sourceId); err != nil {
+		renderError(w, r, payloads.NewURLParsingError(r.Context(), "id parameter invalid", err))
+	}
+
 	region := r.URL.Query().Get("region")
 	if region == "" {
 		renderError(w, r, payloads.NewMissingRequestParameterError(r.Context(), "region parameter is missing"))
@@ -80,6 +89,10 @@ func ListLaunchTemplateAWS(w http.ResponseWriter, r *http.Request) {
 
 func ListLaunchTemplateGCP(w http.ResponseWriter, r *http.Request) {
 	sourceId := chi.URLParam(r, "ID")
+	if err := validation.DigitsOnly(sourceId); err != nil {
+		renderError(w, r, payloads.NewURLParsingError(r.Context(), "id parameter invalid", err))
+	}
+
 	sourcesClient, err := clients.GetSourcesClient(r.Context())
 	if err != nil {
 		renderError(w, r, payloads.NewClientError(r.Context(), err))

--- a/internal/services/sources_service.go
+++ b/internal/services/sources_service.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/RHEnVision/provisioning-backend/internal/payloads/validation"
+
 	"github.com/RHEnVision/provisioning-backend/internal/cache"
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
@@ -81,6 +83,9 @@ func ListProvisioningSourcesByProvider(w http.ResponseWriter, r *http.Request, a
 
 func GetSourceUploadInfo(w http.ResponseWriter, r *http.Request) {
 	sourceId := chi.URLParam(r, "ID")
+	if err := validation.DigitsOnly(sourceId); err != nil {
+		renderError(w, r, payloads.NewURLParsingError(r.Context(), "id parameter invalid", err))
+	}
 
 	sourcesClient, err := clients.GetSourcesClient(r.Context())
 	if err != nil {

--- a/internal/services/sources_status_service.go
+++ b/internal/services/sources_status_service.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	stdhttp "net/http"
 
+	"github.com/RHEnVision/provisioning-backend/internal/payloads/validation"
+
 	"github.com/RHEnVision/provisioning-backend/internal/clients"
 	"github.com/RHEnVision/provisioning-backend/internal/config"
 	"github.com/RHEnVision/provisioning-backend/internal/models"
@@ -18,6 +20,9 @@ var ErrUnknownProviderFromSources = errors.New("unknown provider returned from s
 // is no longer valid.
 func SourcesStatus(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 	sourceId := chi.URLParam(r, "ID")
+	if err := validation.DigitsOnly(sourceId); err != nil {
+		renderError(w, r, payloads.NewURLParsingError(r.Context(), "id parameter invalid", err))
+	}
 
 	sourcesClient, err := clients.GetSourcesClient(r.Context())
 	if err != nil {


### PR DESCRIPTION
Hopefully this should be okay.
I am not entirely sure, if ParseUint would prevent out of range error. Maybe sources use ParseInt, and I just added a bigger range for them.
Also, I think, that they validate with different regex: https://github.com/RedHatInsights/sources-api-go/blob/4a3475e59b8f515dbda70c423826b2a3e4d07cb6/middleware/id_validation.go#L14, and I do not think that this is correct tbh, so I did this my way.
This is still WIP, but I wanted you to be able to comment on this in advance.