### PR TITLE
fix(HMS-3000): update log statement for kafka

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,4 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-json
+exclude: '(CHANGELOG.md|pull_request_template.md)'

--- a/internal/kafka/kafka.go
+++ b/internal/kafka/kafka.go
@@ -83,7 +83,7 @@ func NewKafkaBroker(ctx context.Context) (Broker, error) {
 	var saslMechanism sasl.Mechanism
 
 	logger := zerolog.Ctx(ctx)
-	logger.Info().Msgf("Setting up Kafka transport: %v Verify:%t CA:%t Auth:%s Proto:%sSASLMech:%s",
+	logger.Info().Msgf("Setting up Kafka transport: %v Verify:%t CA:%t Auth:%s Proto:%s SASLMech:%s",
 		config.Kafka.Brokers,
 		!config.Kafka.TlsSkipVerify,
 		config.Kafka.CACert != "",


### PR DESCRIPTION
Code-wise everything is okay and we already use multiple kafka brokers. It is just we haven’t deployed into stage for quite a bit and I do not see any of the messages, this small fix will trigger deployment so I can investigate the string on stage.