### PR TITLE
refactor: extract common funcionality of listing sources

### DIFF
--- a/scripts/rest_examples/sources-list.http
+++ b/scripts/rest_examples/sources-list.http
@@ -1,4 +1,4 @@
 // @no-log
-GET http://{{hostname}}:{{port}}/{{prefix}}/sources?limit=&offset= HTTP/1.1
+GET http://{{hostname}}:{{port}}/{{prefix}}/sources?limit=2&offset= HTTP/1.1
 Content-Type: application/json
 X-Rh-Identity: {{identity}}


### PR DESCRIPTION
Extracts funcionality that was duplicated between ListSources and ListSourcesByProvider. Keeps the unique bits and thus both functions.
This way it will be easy to merge the functions once sources support the filtering through OpenAPI client.
