### PR TITLE
fix(HMS-3185): fail with 403 on failed assume role

### DIFF
--- a/internal/clients/http/ec2/ec2_client.go
+++ b/internal/clients/http/ec2/ec2_client.go
@@ -140,7 +140,7 @@ func getStsAssumedCredentials(ctx context.Context, arn string, region string) (*
 	})
 	if err != nil {
 		logger.Warn().Err(err).Msg("Cannot assume role")
-		return nil, fmt.Errorf("cannot assume role %w", err)
+		return nil, fmt.Errorf("cannot assume role: %w", err)
 	}
 
 	return output.Credentials, nil


### PR DESCRIPTION
AssumeRole is supposed to assume the role that client is giving us. This fixes the error code when this operation fails.

It could have also been 401 as the role might be considered an input. Given this is a permissions operation, I went with 403.

Let me know if you think 401 (or any other code) would be more fitting.

I've went bit overboard to mimic the error that AWS returns in our stub.
But now it should test the real thing pretty closely.