### PR TITLE
fix(HMS-1847): Removing location and resource group

### DIFF
--- a/deploy/cloudwash_job.yaml
+++ b/deploy/cloudwash_job.yaml
@@ -56,16 +56,6 @@ objects:
                       secretKeyRef:
                         key: subscription_id
                         name: provisioning-azure-auth-secret
-                  - name: CLEANUP_AZURE__AUTH__RESOURCE_GROUPS
-                    valueFrom:
-                      secretKeyRef:
-                        key: resource_group
-                        name: provisioning-azure-auth-secret
-                  - name: CLEANUP_AZURE__AUTH__REGIONS
-                    valueFrom:
-                      secretKeyRef:
-                        key: location
-                        name: provisioning-azure-auth-secret
             volumes:
               - name: config-volume
                 configMap:


### PR DESCRIPTION
Have added a new vault path for only secrets.
https://vault.devshift.net/ui/vault/secrets/insights/show/secrets/qe/global/hms/azure

and removed the location and resource group field of auth from the previous path.

now pod spec will fetch the location and resource group value from the configmap file instead of overriding it from the secrets file.