### PR TITLE
fix: Double the availability request channel size

### DIFF
--- a/internal/background/availability_queue.go
+++ b/internal/background/availability_queue.go
@@ -6,24 +6,30 @@ import (
 	"time"
 
 	"github.com/RHEnVision/provisioning-backend/internal/kafka"
+	"github.com/RHEnVision/provisioning-backend/internal/telemetry"
 	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/codes"
 )
 
 // buffered channel for incoming requests
-var kafkaAvailabilityRequest = make(chan *kafka.GenericMessage, availabilityStatusBatchSize)
+// the length is twice the batch size to have room for additional messages when first batch is processed.
+var kafkaAvailabilityRequest = make(chan *kafka.GenericMessage, 2*availabilityStatusBatchSize)
 
 // EnqueueAvailabilityStatusRequest prepares a status request check to be sent in the next
 // batch to the platform kafka. Messages can be delayed up to several seconds until sent.
 // The function can block if the enqueueing channel is full.
 func EnqueueAvailabilityStatusRequest(ctx context.Context, asm *kafka.AvailabilityStatusMessage) error {
-	zerolog.Ctx(ctx).Trace().Str("source_id", asm.SourceID).Msgf("Enqueued source id %s availability check", asm.SourceID)
+	ctx, span := telemetry.StartSpan(ctx, "EnqueueAvailabilityStatusRequest")
+	defer span.End()
 
 	msg, err := asm.GenericMessage(ctx)
 	if err != nil {
+		span.SetStatus(codes.Error, "Failed to generate Kafka message")
 		return fmt.Errorf("cannot create message: %w", err)
 	}
 
 	kafkaAvailabilityRequest <- &msg
+	zerolog.Ctx(ctx).Trace().Str("source_id", asm.SourceID).Msgf("Enqueued source id %s availability check", asm.SourceID)
 	return nil
 }
 


### PR DESCRIPTION
We are seeing major slow down in queing up the availability status checks after certain amount of checks are queued up.

This doubles the channel size in hope the requests can be queued up in channel in the meantime when the previous batch is being send to kafka. This is just a guess for the cause, thus this also adds telemetry, so we have bit more info.

Refs HMS-3415
