### PR TITLE
feat: async avl check kafka send

### DIFF
--- a/internal/background/initialize.go
+++ b/internal/background/initialize.go
@@ -12,7 +12,7 @@ import (
 
 // Maximum batch size for each batch send, also an incoming buffered channel size to prevent
 // incoming requests to overload the sender.
-const availabilityStatusBatchSize = 16
+const availabilityStatusBatchSize = 32
 
 // InitializeApi starts background goroutines for REST API processes.
 // Use context cancellation to stop them.
@@ -21,7 +21,7 @@ func InitializeApi(ctx context.Context) {
 	ctx = logger.WithContext(ctx)
 
 	// start availability request batch sender
-	go sendAvailabilityRequestMessages(ctx, availabilityStatusBatchSize, 5*time.Second)
+	go sendAvailabilityRequestMessages(ctx, availabilityStatusBatchSize, 2*time.Second)
 }
 
 // InitializeWorker starts background goroutines for worker processes.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -90,6 +90,15 @@ var DbStatsDuration = prometheus.NewHistogram(
 	},
 )
 
+var AvailabilityBatchSendDuration = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Name:        "availability_batch_send_duration",
+		Help:        "availability kafka batch send duration (in ms)",
+		ConstLabels: prometheus.Labels{"service": version.PrometheusLabelName, "component": "api"},
+		Buckets:     []float64{5, 10, 25, 50, 100, 250, 500, 2000},
+	},
+)
+
 var Reservations24hCount = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name:        "provisioning_reservations_24h_count",
@@ -162,6 +171,15 @@ func ObserveDbStatsDuration(observedFunc func()) {
 	start := time.Now()
 	defer func() {
 		DbStatsDuration.Observe(time.Since(start).Seconds())
+	}()
+
+	observedFunc()
+}
+
+func ObserveAvailabilitySendDuration(observedFunc func()) {
+	start := time.Now()
+	defer func() {
+		AvailabilityBatchSendDuration.Observe(time.Since(start).Seconds())
 	}()
 
 	observedFunc()

--- a/internal/metrics/registration.go
+++ b/internal/metrics/registration.go
@@ -26,6 +26,7 @@ func RegisterApiMetrics() {
 	prometheus.MustRegister(
 		RbacAclFetchDuration,
 		CacheHits,
+		AvailabilityBatchSendDuration,
 	)
 }
 


### PR DESCRIPTION
I believe these delays are caused by slow Kafka batch send. This patch makes the sending async, this requires full copy of the buffer to prevent random misbehaviour and a wait group to ensure all messages are flushed on restart. Additionally, I have added new duration metric to actually see how slow this is. Also I slightly increase the buffer size and incoming queue, although I think it will be only the background processing what will help to solve the situation as the problem is really in pace of incoming request being much faster than sending.