### PR TITLE
chore: further increase AVL batch size

### DIFF
--- a/internal/background/initialize.go
+++ b/internal/background/initialize.go
@@ -12,7 +12,7 @@ import (
 
 // Maximum batch size for each batch send, also an incoming buffered channel size to prevent
 // incoming requests to overload the sender.
-const availabilityStatusBatchSize = 32
+const availabilityStatusBatchSize = 64
 
 // InitializeApi starts background goroutines for REST API processes.
 // Use context cancellation to stop them.


### PR DESCRIPTION
It looks like on stage the largest cumulated checks is around 175, this gets sent in 7 batches. This should be similar on prod as well as there are also two goroutines sending the requests from sources. Increasing to 64 will half number of goroutines spawned.