### PR TITLE
Fix aws args

### DIFF
--- a/deploy/cloudwash_job.yaml
+++ b/deploy/cloudwash_job.yaml
@@ -66,7 +66,7 @@ objects:
                 args:
                   - "-d"
                   - "aws"
-                  - "--vm"
+                  - "--vms"
                 volumeMounts:
                   - name: config-volume
                     mountPath: /opt/app-root/src/cloudwash/settings.yaml


### PR DESCRIPTION
Cloudwash pod args have a small fix.

The cmd should be 
`aws -d --vms` instead of `aws -d --vm`