### PR TITLE
ci: Disable beta integration testing for backend repo

### DIFF
--- a/deploy/testing-integration.yaml
+++ b/deploy/testing-integration.yaml
@@ -131,7 +131,7 @@ parameters:
 - name: ENV_FOR_DYNACONF
   value: stage_proxy
 - name: USE_BETA
-  value: "true"
+  value: "false"
 - name: IQE_PLUGINS
   value: hms_integration
 - name: IQE_MARKER_EXPRESSION


### PR DESCRIPTION
Imagebuilder navigation in beta has lots of new elements due to blueprints. This breaks the existsing hms-integration test. 
The use_beta flag will be turned true when the navigation exists in the qe repo.