### PR TITLE
fix(HMS-3760): Remove Bearer from Unleash auth header

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,7 +271,7 @@ func Initialize(configFiles ...string) {
 		url := fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
 		config.Unleash.URL = url
 		if cfg.FeatureFlags.ClientAccessToken != nil {
-			config.Unleash.Token = fmt.Sprintf("Bearer %s", *cfg.FeatureFlags.ClientAccessToken)
+			config.Unleash.Token = *cfg.FeatureFlags.ClientAccessToken
 		}
 
 		// kafka


### PR DESCRIPTION
Thanks for the contribution, make sure your commit message follows this subject style:

        type: brief summary up to 70 characters or
        type(scope): brief summary up to 70 characters

Type is required, scope is optional. Prefer lower-case and avoid dot at the end.

Find more info about types and scopes at:

https://github.com/RHEnVision/provisioning-backend#contributing

Take a moment to read our contributing and security guidelines:

https://github.com/RedHatInsights/secure-coding-checklist

**Checklist**

- [ ] all commit messages follows the policy above
- [ ] the change follows our security guidelines
