### PR TITLE
chore: prevent possible leaks

### DIFF
--- a/build/RedHat.dockerfile
+++ b/build/RedHat.dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as build
 USER 0
 RUN mkdir /build
 WORKDIR /build
-COPY . .
+COPY Makefile cmd/ internal/ pkg/ mk/ .
 RUN make prep build strip GO=go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
This should prevent possible credentials leak into build container. Although it is not being uploaded anywhere, it is better to be on the safe side.