### PR TITLE
feat: config as second arg

### DIFF
--- a/cmd/pbackend/api.go
+++ b/cmd/pbackend/api.go
@@ -31,7 +31,13 @@ import (
 
 func api() {
 	ctx := context.Background()
-	config.Initialize("config/api.env")
+	cfgs := []string {
+		"config/api.env",
+	}
+	if len(os.Args) == 3 {
+		cfgs = append(cfgs, os.Args[2])
+	}
+	config.Initialize(cfgs...)
 
 	// initialize cloudwatch using the AWS clients
 	logger, closeFunc := logging.InitializeLogger()

--- a/cmd/pbackend/main.go
+++ b/cmd/pbackend/main.go
@@ -52,7 +52,7 @@ func main() {
 }
 
 func usage() {
-	fmt.Println("Usage: pbackend [migrate|api|worker|statuser|stats|update|version]")
+	fmt.Println("Usage: pbackend [migrate|api|worker|statuser|stats|update|version] [alternate_env_file]")
 	os.Exit(1)
 }
 

--- a/cmd/pbackend/migrate.go
+++ b/cmd/pbackend/migrate.go
@@ -13,7 +13,14 @@ import (
 
 func migrate() {
 	ctx := context.Background()
-	config.Initialize("config/api.env", "config/migrate.env")
+	cfgs := []string {
+		"config/api.env",
+		"config/migrate.env",
+	}
+	if len(os.Args) == 3 {
+		cfgs = append(cfgs, os.Args[2])
+	}
+	config.Initialize(cfgs...)
 
 	// initialize stdout logging and AWS clients first (cloudwatch is not available in init containers)
 	logging.InitializeStdout()

--- a/cmd/pbackend/stats.go
+++ b/cmd/pbackend/stats.go
@@ -23,7 +23,14 @@ import (
 
 func stats() {
 	ctx := context.Background()
-	config.Initialize("config/api.env", "config/stats.env")
+	cfgs := []string {
+		"config/api.env",
+		"config/stats.env",
+	}
+	if len(os.Args) == 3 {
+		cfgs = append(cfgs, os.Args[2])
+	}
+	config.Initialize(cfgs...)
 
 	// initialize cloudwatch using the AWS clients
 	logger, closeFunc := logging.InitializeLogger()

--- a/cmd/pbackend/statuser.go
+++ b/cmd/pbackend/statuser.go
@@ -342,7 +342,14 @@ func sendResults(cancelCtx context.Context, batchSize int, tickDuration time.Dur
 
 func statuser() {
 	ctx := context.Background()
-	config.Initialize("config/api.env", "config/statuser.env")
+	cfgs := []string {
+		"config/api.env",
+		"config/statuser.env",
+	}
+	if len(os.Args) == 3 {
+		cfgs = append(cfgs, os.Args[2])
+	}
+	config.Initialize(cfgs...)
 
 	// initialize cloudwatch using the AWS clients
 	logger, closeFunc := logging.InitializeLogger()

--- a/cmd/pbackend/worker.go
+++ b/cmd/pbackend/worker.go
@@ -26,7 +26,14 @@ import (
 
 func worker() {
 	ctx := context.Background()
-	config.Initialize("config/api.env", "config/worker.env")
+	cfgs := []string {
+		"config/api.env",
+		"config/worker.env",
+	}
+	if len(os.Args) == 3 {
+		cfgs = append(cfgs, os.Args[2])
+	}
+	config.Initialize(cfgs...)
 
 	// initialize stdout logging and AWS clients first
 	logging.InitializeStdout()


### PR DESCRIPTION
In my new setup, I am trying JetBrains Fleet. It always seem to start the app in a temporary directory, I need to be able to pass config explicitly. How about this?