### PR TITLE
pr_check: use insights-stage as ref-env

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -3,15 +3,16 @@
 # --------------------------------------------
 # Options that must be configured by app owner
 # --------------------------------------------
-APP_NAME="provisioning"  # name of app-sre "application" folder this component lives in
-COMPONENT_NAME="provisioning-backend"  # name of resourceTemplate component for deploy
-IMAGE="quay.io/cloudservices/provisioning-backend"  # image location on quay
+APP_NAME="provisioning"                            # name of app-sre "application" folder this component lives in
+COMPONENT_NAME="provisioning-backend"              # name of resourceTemplate component for deploy
+IMAGE="quay.io/cloudservices/provisioning-backend" # image location on quay
 DOCKERFILE="build/Dockerfile"
 
-IQE_PLUGINS="provisioning"  # name of the IQE plugin for this app.
-IQE_MARKER_EXPRESSION="api and smoke"  # This is the value passed to pytest -m
-IQE_FILTER_EXPRESSION=""  # This is the value passed to pytest -k
-IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or fail
+IQE_PLUGINS="provisioning"            # name of the IQE plugin for this app.
+IQE_MARKER_EXPRESSION="api and smoke" # This is the value passed to pytest -m
+IQE_FILTER_EXPRESSION=""              # This is the value passed to pytest -k
+IQE_CJI_TIMEOUT="30m"                 # This is the time to wait for smoke test to complete or fail
+REF_ENV="insights-stage"
 
 #EXTRA_DEPLOY_ARGS=
 
@@ -19,7 +20,7 @@ IQE_CJI_TIMEOUT="30m"  # This is the time to wait for smoke test to complete or 
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/bootstrap.sh
 # This script automates the install / config of bonfire
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/cicd-tools/main
-curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+curl -s $CICD_URL/bootstrap.sh >.cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 # This script is used to build the image that is used in the PR Check
 source $CICD_ROOT/build.sh
@@ -28,7 +29,6 @@ source $CICD_ROOT/build.sh
 # The manual steps for this can be found in:
 # https://internal.cloud.redhat.com/docs/devprod/ephemeral/02-deploying/
 source $CICD_ROOT/deploy_ephemeral_env.sh
-
 
 # ADD the image stubs
 oc project $NAMESPACE


### PR DESCRIPTION
This will deploy the apps using whatever is in stage which is where PRs are deployed after being merged.

Thanks for the contribution, make sure your commit message follows this subject style:

        type: brief summary up to 70 characters or
        type(scope): brief summary up to 70 characters

Type is required, scope is optional. Prefer lower-case and avoid dot at the end.

Find more info about types and scopes at:

https://github.com/RHEnVision/provisioning-backend#contributing

Take a moment to read our contributing and security guidelines:

https://github.com/RedHatInsights/secure-coding-checklist

**Checklist**

- [ ] all commit messages follows the policy above
- [ ] the change follows our security guidelines
